### PR TITLE
Remove duplicate admin menus

### DIFF
--- a/admin/main-page.php
+++ b/admin/main-page.php
@@ -111,7 +111,7 @@ foreach ($branding_results as $result) {
                 </div>
             </a>
             
-            <a href="<?php echo admin_url('admin.php?page=federwiegen-branding'); ?>" class="federwiegen-nav-card">
+            <a href="<?php echo admin_url('admin.php?page=federwiegen-settings&tab=branding'); ?>" class="federwiegen-nav-card">
                 <div class="federwiegen-nav-icon">🎨</div>
                 <div class="federwiegen-nav-content">
                     <h4>Branding</h4>

--- a/admin/tabs/categories-add-tab.php
+++ b/admin/tabs/categories-add-tab.php
@@ -61,10 +61,6 @@
                     <input type="text" name="product_title" required placeholder="Titel unter dem Produktbild">
                 </div>
                 <div class="federwiegen-form-group">
-                    <label>Versandkosten (€)</label>
-                    <input type="number" name="shipping_cost" step="0.01" min="0">
-                </div>
-                <div class="federwiegen-form-group">
                     <label>Versanddienstleister</label>
                     <div class="federwiegen-shipping-radios">
                         <?php $shipping_providers = [

--- a/admin/tabs/categories-edit-tab.php
+++ b/admin/tabs/categories-edit-tab.php
@@ -201,10 +201,6 @@
                 <h4>🚚 Versand</h4>
                 <div class="federwiegen-form-row">
                     <div class="federwiegen-form-group">
-                        <label>Versandkosten (€)</label>
-                        <input type="number" name="shipping_cost" value="<?php echo esc_attr($edit_item->shipping_cost); ?>" step="0.01" min="0">
-                    </div>
-                    <div class="federwiegen-form-group">
                         <label>Versanddienstleister</label>
                         <div class="federwiegen-shipping-radios">
                             <?php $shipping_providers = [

--- a/admin/tabs/categories-list-tab.php
+++ b/admin/tabs/categories-list-tab.php
@@ -53,13 +53,6 @@
                         <?php endif; ?>
                     </div>
                     
-                    <div class="federwiegen-category-shipping">
-                        <strong><?php echo number_format($category->shipping_cost ?? 0, 2, ',', '.'); ?>€</strong>
-                        <small>Versand</small>
-                        <?php if (!empty($category->shipping_provider)): ?>
-                            <img src="<?php echo esc_url(FEDERWIEGEN_PLUGIN_URL . 'assets/shipping-icons/' . $category->shipping_provider . '.svg'); ?>" alt="<?php echo esc_attr($category->shipping_provider); ?>">
-                        <?php endif; ?>
-                    </div>
                 </div>
                 
                 <div class="federwiegen-category-actions">

--- a/admin/tabs/variants-add-tab.php
+++ b/admin/tabs/variants-add-tab.php
@@ -21,12 +21,8 @@
                     <input type="text" name="name" required placeholder="z.B. Premium Federwiege">
                 </div>
                 <div class="federwiegen-form-group">
-                    <label>Grundpreis (€) *</label>
-                    <input type="number" name="base_price" step="0.01" min="0" required placeholder="29.99">
-                </div>
-                <div class="federwiegen-form-group">
-                    <label>Preis ab (€)</label>
-                    <input type="number" name="price_from" step="0.01" min="0" placeholder="">
+                    <label>Stripe Preis ID *</label>
+                    <input type="text" name="stripe_price_id" required placeholder="price_123...">
                 </div>
             </div>
             

--- a/admin/tabs/variants-edit-tab.php
+++ b/admin/tabs/variants-edit-tab.php
@@ -22,12 +22,8 @@
                     <input type="text" name="name" value="<?php echo esc_attr($edit_item->name); ?>" required>
                 </div>
                 <div class="federwiegen-form-group">
-                    <label>Grundpreis (€) *</label>
-                    <input type="number" name="base_price" value="<?php echo $edit_item->base_price; ?>" step="0.01" min="0" required>
-                </div>
-                <div class="federwiegen-form-group">
-                    <label>Preis ab (€)</label>
-                    <input type="number" name="price_from" value="<?php echo $edit_item->price_from; ?>" step="0.01" min="0">
+                    <label>Stripe Preis ID *</label>
+                    <input type="text" name="stripe_price_id" value="<?php echo esc_attr($edit_item->stripe_price_id); ?>" required>
                 </div>
             </div>
             

--- a/admin/tabs/variants-list-tab.php
+++ b/admin/tabs/variants-list-tab.php
@@ -65,8 +65,17 @@
                 <p class="federwiegen-variant-description"><?php echo esc_html($variant->description); ?></p>
                 
                 <div class="federwiegen-variant-meta">
+                    <?php
+                        $price = 0;
+                        if (!empty($variant->stripe_price_id)) {
+                            $p = \FederwiegenVerleih\StripeService::get_price_amount($variant->stripe_price_id);
+                            if (!is_wp_error($p)) {
+                                $price = $p;
+                            }
+                        }
+                    ?>
                     <div class="federwiegen-variant-price">
-                        <strong><?php echo number_format($variant->base_price, 2, ',', '.'); ?>€</strong>
+                        <strong><?php echo number_format($price, 2, ',', '.'); ?>€</strong>
                         <small>/Monat</small>
                     </div>
                     

--- a/admin/variants-page.php
+++ b/admin/variants-page.php
@@ -24,6 +24,12 @@ foreach ($image_columns as $column) {
     }
 }
 
+// Ensure stripe_price_id column exists
+$price_column_exists = $wpdb->get_results("SHOW COLUMNS FROM $table_name LIKE 'stripe_price_id'");
+if (empty($price_column_exists)) {
+    $wpdb->query("ALTER TABLE $table_name ADD COLUMN stripe_price_id VARCHAR(255) DEFAULT '' AFTER name");
+}
+
 // Ensure category_id column exists
 $category_column_exists = $wpdb->get_results("SHOW COLUMNS FROM $table_name LIKE 'category_id'");
 if (empty($category_column_exists)) {
@@ -49,8 +55,7 @@ if (isset($_POST['submit'])) {
     $category_id = intval($_POST['category_id']);
     $name = sanitize_text_field($_POST['name']);
     $description = sanitize_textarea_field($_POST['description']);
-    $base_price = floatval($_POST['base_price']);
-    $price_from = isset($_POST['price_from']) ? floatval($_POST['price_from']) : 0;
+    $stripe_price_id = sanitize_text_field($_POST['stripe_price_id']);
     $available = isset($_POST['available']) ? 1 : 0;
     $availability_note = sanitize_text_field($_POST['availability_note']);
     $delivery_time = sanitize_text_field($_POST['delivery_time']);
@@ -69,8 +74,7 @@ if (isset($_POST['submit'])) {
             'category_id' => $category_id,
             'name' => $name,
             'description' => $description,
-            'base_price' => $base_price,
-            'price_from' => $price_from,
+            'stripe_price_id' => $stripe_price_id,
             'available' => $available,
             'availability_note' => $availability_note,
             'delivery_time' => $delivery_time,
@@ -82,7 +86,7 @@ if (isset($_POST['submit'])) {
             $table_name,
             $update_data,
             array('id' => intval($_POST['id'])),
-            array_merge(array('%d', '%s', '%s', '%f', '%f', '%d', '%s', '%s', '%d', '%d'), array_fill(0, 5, '%s')),
+            array_merge(array('%d', '%s', '%s', '%s', '%d', '%s', '%s', '%d', '%d'), array_fill(0, 5, '%s')),
             array('%d')
         );
         
@@ -97,8 +101,7 @@ if (isset($_POST['submit'])) {
             'category_id' => $category_id,
             'name' => $name,
             'description' => $description,
-            'base_price' => $base_price,
-            'price_from' => $price_from,
+            'stripe_price_id' => $stripe_price_id,
             'available' => $available,
             'availability_note' => $availability_note,
             'delivery_time' => $delivery_time,
@@ -109,7 +112,7 @@ if (isset($_POST['submit'])) {
         $result = $wpdb->insert(
             $table_name,
             $insert_data,
-            array_merge(array('%d', '%s', '%s', '%f', '%f', '%d', '%s', '%s', '%d', '%d'), array_fill(0, 5, '%s'))
+            array_merge(array('%d', '%s', '%s', '%s', '%d', '%s', '%s', '%d', '%d'), array_fill(0, 5, '%s'))
         );
         
         if ($result !== false) {

--- a/assets/script.js
+++ b/assets/script.js
@@ -14,6 +14,7 @@ jQuery(document).ready(function($) {
     let touchStartX = 0;
     let touchEndX = 0;
     let currentPrice = 0;
+    let currentShippingCost = 0;
     let colorNotificationTimeout = null;
 
     // Get category ID from container
@@ -161,6 +162,7 @@ jQuery(document).ready(function($) {
         $('#federwiegen-field-zustand').val(conditionName);
         $('#federwiegen-field-farbe').val(colorName);
         $('#federwiegen-field-preis').val(Math.round(currentPrice * 100));
+        $('#federwiegen-field-shipping').val(Math.round(currentShippingCost * 100));
 
         $('#federwiegen-order-form').submit();
     });
@@ -585,6 +587,7 @@ jQuery(document).ready(function($) {
                     if (response.success) {
                         const data = response.data;
                         currentPrice = data.final_price;
+                        currentShippingCost = data.shipping_cost || 0;
                         
                         // Update price display
                         $('#federwiegen-final-price').text(formatPrice(data.final_price) + '€');

--- a/assets/style.css
+++ b/assets/style.css
@@ -1214,21 +1214,33 @@ body.federwiegen-popup-open {
 }
 
 /* Checkout styles */
-.federwiegen-checkout {
-    max-width: 600px;
+.federwiegen-checkout-wrapper {
+    max-width: 1100px;
     margin: 0 auto;
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    gap: 2rem;
+}
+
+.federwiegen-checkout-left,
+.federwiegen-checkout-right {
     background: #fff;
     padding: 2rem;
     border-radius: 1rem;
     box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1);
 }
 
-.federwiegen-checkout h2 {
-    font-size: 1.75rem;
-    font-weight: bold;
-    text-align: center;
+@media (max-width: 768px) {
+    .federwiegen-checkout-wrapper {
+        grid-template-columns: 1fr;
+    }
+}
+
+.federwiegen-checkout-left h3 {
+    font-size: 1.2rem;
+    font-weight: 600;
     color: #2a372a;
-    margin-bottom: 1rem;
+    margin-bottom: 0.5rem;
 }
 
 .federwiegen-checkout-summary {

--- a/federwiegen-verleih.php
+++ b/federwiegen-verleih.php
@@ -119,13 +119,27 @@ function federwiegen_stripe_elements_form() {
           $total_first_cents = $preis_cents + $shipping_cents;
         ?>
         <ul class="federwiegen-checkout-summary">
-          <li>Produkt: <?php echo esc_html($_GET['produkt'] ?? ''); ?></li>
-          <li>Extra: <?php echo esc_html($_GET['extra'] ?? ''); ?></li>
-          <li>Mietdauer: <?php echo esc_html($_GET['dauer_name'] ?? ($_GET['dauer'] ?? '')); ?></li>
-          <li>Zustand: <?php echo esc_html($_GET['zustand'] ?? ''); ?></li>
-          <li>Farbe: <?php echo esc_html($_GET['farbe'] ?? ''); ?></li>
-          <li>Preis: <?php echo $preis_cents ? number_format($preis_cents / 100, 2, ',', '.') . ' €' : ''; ?></li>
-          <li>Versand: <?php echo $shipping_cents ? number_format($shipping_cents / 100, 2, ',', '.') . ' €' : ''; ?></li>
+          <?php if (!empty($_GET['produkt'])): ?>
+          <li>Produkt: <?php echo esc_html($_GET['produkt']); ?></li>
+          <?php endif; ?>
+          <?php if (!empty($_GET['extra'])): ?>
+          <li>Extra: <?php echo esc_html($_GET['extra']); ?></li>
+          <?php endif; ?>
+          <?php if (!empty($_GET['dauer']) || !empty($_GET['dauer_name'])): ?>
+          <li>Mietdauer: <?php echo esc_html($_GET['dauer_name'] ?? $_GET['dauer']); ?></li>
+          <?php endif; ?>
+          <?php if (!empty($_GET['zustand'])): ?>
+          <li>Zustand: <?php echo esc_html($_GET['zustand']); ?></li>
+          <?php endif; ?>
+          <?php if (!empty($_GET['farbe'])): ?>
+          <li>Farbe: <?php echo esc_html($_GET['farbe']); ?></li>
+          <?php endif; ?>
+          <?php if ($preis_cents): ?>
+          <li>Preis: <?php echo number_format($preis_cents / 100, 2, ',', '.'); ?> €</li>
+          <?php endif; ?>
+          <?php if ($shipping_cents): ?>
+          <li>Versand: <?php echo number_format($shipping_cents / 100, 2, ',', '.'); ?> €</li>
+          <?php endif; ?>
           <li>Gesamt 1. Monat: <?php echo number_format($total_first_cents / 100, 2, ',', '.'); ?> €</li>
           <li>Jeder weitere Monat: <?php echo number_format($preis_cents / 100, 2, ',', '.'); ?> €</li>
         </ul>

--- a/federwiegen-verleih.php
+++ b/federwiegen-verleih.php
@@ -113,14 +113,21 @@ function federwiegen_stripe_elements_form() {
 
       <div class="federwiegen-checkout-right">
         <h3>Bestellübersicht</h3>
+        <?php
+          $preis_cents = isset($_GET['preis']) ? intval($_GET['preis']) : 0;
+          $shipping_cents = isset($_GET['shipping']) ? intval($_GET['shipping']) : 0;
+          $total_first_cents = $preis_cents + $shipping_cents;
+        ?>
         <ul class="federwiegen-checkout-summary">
           <li>Produkt: <?php echo esc_html($_GET['produkt'] ?? ''); ?></li>
           <li>Extra: <?php echo esc_html($_GET['extra'] ?? ''); ?></li>
           <li>Mietdauer: <?php echo esc_html($_GET['dauer_name'] ?? ($_GET['dauer'] ?? '')); ?></li>
           <li>Zustand: <?php echo esc_html($_GET['zustand'] ?? ''); ?></li>
           <li>Farbe: <?php echo esc_html($_GET['farbe'] ?? ''); ?></li>
-          <li>Preis: <?php echo isset($_GET['preis']) ? number_format($_GET['preis'] / 100, 2, ',', '.') . ' €' : ''; ?></li>
-          <li>Versand: <?php echo isset($_GET['shipping']) ? number_format($_GET['shipping'] / 100, 2, ',', '.') . ' €' : ''; ?></li>
+          <li>Preis: <?php echo $preis_cents ? number_format($preis_cents / 100, 2, ',', '.') . ' €' : ''; ?></li>
+          <li>Versand: <?php echo $shipping_cents ? number_format($shipping_cents / 100, 2, ',', '.') . ' €' : ''; ?></li>
+          <li>Gesamt 1. Monat: <?php echo number_format($total_first_cents / 100, 2, ',', '.'); ?> €</li>
+          <li>Jeder weitere Monat: <?php echo number_format($preis_cents / 100, 2, ',', '.'); ?> €</li>
         </ul>
       </div>
     </div>

--- a/federwiegen-verleih.php
+++ b/federwiegen-verleih.php
@@ -20,6 +20,7 @@ define('FEDERWIEGEN_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('FEDERWIEGEN_PLUGIN_PATH', FEDERWIEGEN_PLUGIN_DIR);
 define('FEDERWIEGEN_VERSION', FEDERWIEGEN_PLUGIN_VERSION);
 define('FEDERWIEGEN_PLUGIN_FILE', __FILE__);
+define('FEDERWIEGEN_SHIPPING_PRICE_ID', 'price_versand_once');
 
 // Control whether default demo data is inserted on activation
 if (!defined('FEDERWIEGEN_LOAD_DEFAULT_DATA')) {
@@ -119,6 +120,7 @@ function federwiegen_stripe_elements_form() {
           <li>Zustand: <?php echo esc_html($_GET['zustand'] ?? ''); ?></li>
           <li>Farbe: <?php echo esc_html($_GET['farbe'] ?? ''); ?></li>
           <li>Preis: <?php echo isset($_GET['preis']) ? number_format($_GET['preis'] / 100, 2, ',', '.') . ' €' : ''; ?></li>
+          <li>Versand: <?php echo isset($_GET['shipping']) ? number_format($_GET['shipping'] / 100, 2, ',', '.') . ' €' : ''; ?></li>
         </ul>
       </div>
     </div>
@@ -154,8 +156,11 @@ function federwiegen_stripe_elements_form() {
         dauer_name: getUrlParameter('dauer_name'),
         zustand: getUrlParameter('zustand'),
         farbe: getUrlParameter('farbe'),
-        preis: getUrlParameter('preis')
+        preis: getUrlParameter('preis'),
+        shipping: getUrlParameter('shipping')
       };
+
+      const SHIPPING_PRICE_ID = '<?php echo esc_js(FEDERWIEGEN_SHIPPING_PRICE_ID); ?>';
 
       const stripe = Stripe('<?php echo esc_js(\FederwiegenVerleih\StripeService::get_publishable_key()); ?>');
       const elements = stripe.elements();
@@ -197,7 +202,9 @@ function federwiegen_stripe_elements_form() {
           zustand: baseData.zustand,
           farbe: baseData.farbe,
           preis: baseData.preis,
-          price_id: getPriceId(baseData.dauer)
+          shipping: baseData.shipping,
+          price_id: getPriceId(baseData.dauer),
+          shipping_price_id: SHIPPING_PRICE_ID
         };
 
         const messageEl = document.getElementById('payment-message');

--- a/federwiegen-verleih.php
+++ b/federwiegen-verleih.php
@@ -42,52 +42,86 @@ add_shortcode('stripe_elements_form', 'federwiegen_stripe_elements_form');
 function federwiegen_stripe_elements_form() {
     ob_start(); ?>
 
-    <div class="federwiegen-checkout">
-    <h2>Deine Bestellung</h2>
-    <ul class="federwiegen-checkout-summary">
-      <li>Produkt: <?php echo esc_html($_GET['produkt'] ?? ''); ?></li>
-      <li>Extra: <?php echo esc_html($_GET['extra'] ?? ''); ?></li>
-      <li>Abo: <?php echo esc_html($_GET['dauer_name'] ?? ($_GET['dauer'] ?? '')); ?></li>
-      <li>Zustand: <?php echo esc_html($_GET['zustand'] ?? ''); ?></li>
-      <li>Farbe: <?php echo esc_html($_GET['farbe'] ?? ''); ?></li>
-      <li>Preis: <?php echo isset($_GET['preis']) ? number_format($_GET['preis'] / 100, 2, ',', '.') . ' €' : ''; ?></li>
-    </ul>
+    <div class="federwiegen-checkout-wrapper">
+      <div class="federwiegen-checkout-left">
+        <form id="checkout-form" class="federwiegen-checkout-form">
+          <div class="checkout-section">
+            <h3>1. Kontaktinformationen</h3>
+            <p>Wir werden diese E-Mail verwenden, um Ihnen Details und Aktualisierungen zu Ihrer Bestellung zu senden.</p>
+            <label for="email">E-Mail-Adresse*</label>
+            <input type="email" id="email" name="email" required>
+          </div>
 
-    <form id="checkout-form" class="federwiegen-checkout-form">
-      <h3>Lieferadresse</h3>
+          <div class="checkout-section">
+            <h3>2. Versandadresse</h3>
+            <p>Geben Sie die Adresse ein, an die Ihre Bestellung geliefert werden soll.</p>
+            <label for="country">Land*</label>
+            <input type="text" id="country" name="country" value="DE" required>
 
-      <label for="fullname">Vollständiger Name*</label>
-      <input type="text" id="fullname" name="fullname" required>
+            <label for="fullname">Vollständiger Name*</label>
+            <input type="text" id="fullname" name="fullname" required>
 
-      <label for="email">E-Mail-Adresse*</label>
-      <input type="email" id="email" name="email" required>
+            <label for="street">Adresse*</label>
+            <input type="text" id="street" name="street" required>
 
-      <label for="phone">Telefonnummer*</label>
-      <input type="tel" id="phone" name="phone" required>
+            <label for="city">Stadt*</label>
+            <input type="text" id="city" name="city" required>
 
-      <label for="street">Straße &amp; Hausnummer*</label>
-      <input type="text" id="street" name="street" required>
+            <label for="postal">PLZ*</label>
+            <input type="text" id="postal" name="postal" required>
 
-      <label for="postal">PLZ*</label>
-      <input type="text" id="postal" name="postal" required>
+            <label for="phone">Telefon*</label>
+            <input type="tel" id="phone" name="phone" required>
 
-      <label for="city">Ort*</label>
-      <input type="text" id="city" name="city" required>
+            <label class="checkbox">
+              <input type="checkbox" id="same-address" checked>
+              Dieselbe Adresse für die Rechnungsstellung verwenden
+            </label>
 
-      <label for="country">Land*</label>
-      <input type="text" id="country" name="country" value="DE" required>
+            <div id="billing-fields" style="display: none;">
+              <h4>Rechnungsadresse</h4>
+              <label for="bill_country">Land*</label>
+              <input type="text" id="bill_country" name="bill_country" value="DE">
 
-      <label class="checkbox">
-        <input type="checkbox" id="agb" required>
-        Ich akzeptiere die <a href="/agb" target="_blank">Allgemeinen Geschäftsbedingungen</a>*
-      </label>
+              <label for="bill_fullname">Vollständiger Name*</label>
+              <input type="text" id="bill_fullname" name="bill_fullname">
 
-      <h3>Zahlung</h3>
-      <div id="card-element"></div>
+              <label for="bill_street">Adresse*</label>
+              <input type="text" id="bill_street" name="bill_street">
 
-      <button id="submit">Jetzt bezahlen</button>
-      <div id="payment-message"></div>
-    </form>
+              <label for="bill_city">Stadt*</label>
+              <input type="text" id="bill_city" name="bill_city">
+
+              <label for="bill_postal">PLZ*</label>
+              <input type="text" id="bill_postal" name="bill_postal">
+            </div>
+          </div>
+
+          <div class="checkout-section">
+            <h3>3. Zahlungsoptionen</h3>
+            <div id="card-element"></div>
+            <label class="checkbox">
+              <input type="checkbox" id="agb" required>
+              Ich akzeptiere die <a href="/agb" target="_blank">Allgemeinen Geschäftsbedingungen</a>*
+            </label>
+            <button id="submit">Jetzt bezahlen</button>
+            <div id="payment-message"></div>
+          </div>
+        </form>
+      </div>
+
+      <div class="federwiegen-checkout-right">
+        <h3>Bestellübersicht</h3>
+        <ul class="federwiegen-checkout-summary">
+          <li>Produkt: <?php echo esc_html($_GET['produkt'] ?? ''); ?></li>
+          <li>Extra: <?php echo esc_html($_GET['extra'] ?? ''); ?></li>
+          <li>Mietdauer: <?php echo esc_html($_GET['dauer_name'] ?? ($_GET['dauer'] ?? '')); ?></li>
+          <li>Zustand: <?php echo esc_html($_GET['zustand'] ?? ''); ?></li>
+          <li>Farbe: <?php echo esc_html($_GET['farbe'] ?? ''); ?></li>
+          <li>Preis: <?php echo isset($_GET['preis']) ? number_format($_GET['preis'] / 100, 2, ',', '.') . ' €' : ''; ?></li>
+        </ul>
+      </div>
+    </div>
 
     <script src="https://js.stripe.com/v3/"></script>
     <script>
@@ -124,9 +158,15 @@ function federwiegen_stripe_elements_form() {
       };
 
       const stripe = Stripe('<?php echo esc_js(\FederwiegenVerleih\StripeService::get_publishable_key()); ?>');
-      let elements = stripe.elements();
-      let card = elements.create('card');
+      const elements = stripe.elements();
+      const card = elements.create('card');
       card.mount('#card-element');
+
+      const sameAddressCheckbox = document.getElementById('same-address');
+      const billingFields = document.getElementById('billing-fields');
+      sameAddressCheckbox.addEventListener('change', () => {
+        billingFields.style.display = sameAddressCheckbox.checked ? 'none' : 'block';
+      });
 
       const form = document.getElementById('checkout-form');
       form.addEventListener('submit', async (event) => {
@@ -145,6 +185,11 @@ function federwiegen_stripe_elements_form() {
           postal: document.getElementById('postal').value,
           city: document.getElementById('city').value,
           country: document.getElementById('country').value,
+          bill_fullname: document.getElementById('bill_fullname').value,
+          bill_street: document.getElementById('bill_street').value,
+          bill_postal: document.getElementById('bill_postal').value,
+          bill_city: document.getElementById('bill_city').value,
+          bill_country: document.getElementById('bill_country').value,
           produkt: baseData.produkt,
           extra: baseData.extra,
           dauer: baseData.dauer,
@@ -168,8 +213,31 @@ function federwiegen_stripe_elements_form() {
             throw new Error('Serverfehler');
           }
           const responseData = await res.json();
+          const shipping = {
+            name: document.getElementById('fullname').value,
+            phone: document.getElementById('phone').value,
+            address: {
+              line1: document.getElementById('street').value,
+              postal_code: document.getElementById('postal').value,
+              city: document.getElementById('city').value,
+              country: document.getElementById('country').value,
+            }
+          };
+
+          const billing = {
+            name: document.getElementById('bill_fullname').value || shipping.name,
+            email: document.getElementById('email').value,
+            address: {
+              line1: document.getElementById('bill_street').value || shipping.address.line1,
+              postal_code: document.getElementById('bill_postal').value || shipping.address.postal_code,
+              city: document.getElementById('bill_city').value || shipping.address.city,
+              country: document.getElementById('bill_country').value || shipping.address.country,
+            }
+          };
+
           const { error, paymentIntent } = await stripe.confirmCardPayment(responseData.client_secret, {
-            payment_method: { card: card }
+            payment_method: { card: card, billing_details: billing },
+            shipping: shipping
           });
           if (error) {
             messageEl.textContent = error.message;

--- a/federwiegen-verleih.php
+++ b/federwiegen-verleih.php
@@ -20,7 +20,10 @@ define('FEDERWIEGEN_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('FEDERWIEGEN_PLUGIN_PATH', FEDERWIEGEN_PLUGIN_DIR);
 define('FEDERWIEGEN_VERSION', FEDERWIEGEN_PLUGIN_VERSION);
 define('FEDERWIEGEN_PLUGIN_FILE', __FILE__);
-define('FEDERWIEGEN_SHIPPING_PRICE_ID', 'price_versand_once');
+// Stripe price ID for the one-time shipping charge
+define('FEDERWIEGEN_SHIPPING_PRICE_ID', 'price_1QKQDzRxDui5dUOqdlAFIJcr');
+// Display amount for shipping in Euros
+define('FEDERWIEGEN_SHIPPING_COST', 9.99);
 
 // Control whether default demo data is inserted on activation
 if (!defined('FEDERWIEGEN_LOAD_DEFAULT_DATA')) {

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -109,31 +109,14 @@ class Admin {
             array($this, 'analytics_page')
         );
 
+        // New settings menu with Stripe integration tab
         add_submenu_page(
             'federwiegen-verleih',
-            'Popup',
-            'Popup',
+            'Einstellungen',
+            'Einstellungen',
             'manage_options',
-            'federwiegen-popup',
-            array($this, 'popup_page')
-        );
-        
-        add_submenu_page(
-            'federwiegen-verleih',
-            'Branding',
-            'Branding',
-            'manage_options',
-            'federwiegen-branding',
-            array($this, 'branding_page')
-        );
-        
-        add_submenu_page(
-            'federwiegen-verleih',
-            'Debug',
-            'Debug',
-            'manage_options',
-            'federwiegen-debug',
-            array($this, 'debug_page')
+            'federwiegen-settings',
+            array($this, 'settings_page')
         );
     }
     
@@ -577,15 +560,8 @@ class Admin {
         include FEDERWIEGEN_PLUGIN_PATH . 'admin/analytics-page.php';
     }
     
-    public function branding_page() {
-        include FEDERWIEGEN_PLUGIN_PATH . 'admin/branding-page.php';
+    public function settings_page() {
+        include FEDERWIEGEN_PLUGIN_PATH . 'admin/settings-page.php';
     }
 
-    public function debug_page() {
-        include FEDERWIEGEN_PLUGIN_PATH . 'admin/debug-page.php';
-    }
-
-    public function popup_page() {
-        include FEDERWIEGEN_PLUGIN_PATH . 'admin/popup-page.php';
-    }
 }

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -292,7 +292,6 @@ class Admin {
             $button_icon = esc_url_raw($_POST['button_icon']);
             $payment_icons = isset($_POST['payment_icons']) ? array_map('sanitize_text_field', (array) $_POST['payment_icons']) : array();
             $payment_icons = implode(',', $payment_icons);
-            $shipping_cost = floatval($_POST['shipping_cost']);
             $shipping_provider = sanitize_text_field($_POST['shipping_provider'] ?? '');
             $shipping_label = sanitize_text_field($_POST['shipping_label']);
             $price_label = sanitize_text_field($_POST['price_label']);
@@ -334,7 +333,6 @@ class Admin {
                         'button_text' => $button_text,
                         'button_icon' => $button_icon,
                         'payment_icons' => $payment_icons,
-                        'shipping_cost' => $shipping_cost,
                         'shipping_provider' => $shipping_provider,
                         'price_label' => $price_label,
                         'shipping_label' => $shipping_label,
@@ -350,7 +348,7 @@ class Admin {
                         'sort_order' => $sort_order,
                     ],
                     ['id' => intval($_POST['id'])],
-                    array('%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%f','%s','%s','%s','%s','%d','%s','%s','%s','%d','%d','%f','%s','%d'),
+                    array('%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%d','%s','%s','%s','%d','%d','%f','%s','%d'),
                 );
 
                 if ($result !== false) {
@@ -382,7 +380,6 @@ class Admin {
                         'button_text' => $button_text,
                         'button_icon' => $button_icon,
                         'payment_icons' => $payment_icons,
-                        'shipping_cost' => $shipping_cost,
                         'shipping_provider' => $shipping_provider,
                         'price_label' => $price_label,
                         'shipping_label' => $shipping_label,
@@ -397,7 +394,7 @@ class Admin {
                         'rating_link' => $rating_link,
                         'sort_order' => $sort_order,
                     ],
-                    array('%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%f','%s','%s','%s','%s','%d','%s','%s','%s','%d','%d','%f','%s','%d')
+                    array('%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%d','%s','%s','%s','%d','%d','%f','%s','%d')
                 );
 
                 if ($result !== false) {

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -48,11 +48,6 @@ class Ajax {
         // Find best matching Stripe link
         $link = $this->find_best_stripe_link($variant_id, $extra_ids_raw, $duration_id, $condition_id, $product_color_id, $frame_color_id);
         
-        // Get shipping cost from category
-        $category = $wpdb->get_row($wpdb->prepare(
-            "SELECT shipping_cost FROM {$wpdb->prefix}federwiegen_categories WHERE id = %d",
-            $variant->category_id
-        ));
         
         if ($variant && $duration) {
             $variant_price = floatval($variant->base_price);
@@ -73,7 +68,7 @@ class Ajax {
             $final_price = ($variant_price * (1 - $discount)) + $extras_price;
             $shipping_cost = defined('FEDERWIEGEN_SHIPPING_COST')
                 ? floatval(constant('FEDERWIEGEN_SHIPPING_COST'))
-                : ($category ? floatval($category->shipping_cost) : 0);
+                : 0;
             
             wp_send_json_success(array(
                 'base_price' => $base_price,

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -71,7 +71,9 @@ class Ajax {
             $base_price = $variant_price + $extras_price;
             $discount = floatval($duration->discount);
             $final_price = ($variant_price * (1 - $discount)) + $extras_price;
-            $shipping_cost = $category ? floatval($category->shipping_cost) : 0;
+            $shipping_cost = defined('FEDERWIEGEN_SHIPPING_COST')
+                ? floatval(constant('FEDERWIEGEN_SHIPPING_COST'))
+                : ($category ? floatval($category->shipping_cost) : 0);
             
             wp_send_json_success(array(
                 'base_price' => $base_price,

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -50,7 +50,16 @@ class Ajax {
         
         
         if ($variant && $duration) {
-            $variant_price = floatval($variant->base_price);
+            $variant_price = 0;
+            if (!empty($variant->stripe_price_id)) {
+                $price_res = StripeService::get_price_amount($variant->stripe_price_id);
+                if (is_wp_error($price_res)) {
+                    wp_send_json_error('Price fetch failed');
+                }
+                $variant_price = floatval($price_res);
+            } else {
+                $variant_price = floatval($variant->base_price);
+            }
             $extras_price = 0;
             foreach ($extras as $ex) {
                 $extras_price += floatval($ex->price);

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -910,9 +910,15 @@ function federwiegen_create_subscription() {
             throw new \Exception($customer->get_error_message());
         }
 
+        $shipping_price_id = sanitize_text_field($body['shipping_price_id'] ?? '');
+        $items = [[ 'price' => $price_id ]];
+        if ($shipping_price_id) {
+            $items[] = ['price' => $shipping_price_id];
+        }
+
         $subscription = StripeService::create_subscription([
             'customer' => $customer->id,
-            'items' => [[ 'price' => $price_id ]],
+            'items' => $items,
             'payment_behavior' => 'default_incomplete',
             'payment_settings' => [
                 'payment_method_types' => ['card', 'paypal', 'sepa_debit'],

--- a/includes/Database.php
+++ b/includes/Database.php
@@ -24,6 +24,7 @@ class Database {
         // Add image columns to variants table if they don't exist
         $table_variants = $wpdb->prefix . 'federwiegen_variants';
         $columns_to_add = array(
+            'stripe_price_id' => 'VARCHAR(255) DEFAULT ""',
             'price_from' => 'DECIMAL(10,2) DEFAULT 0',
             'image_url_1' => 'TEXT',
             'image_url_2' => 'TEXT',
@@ -38,7 +39,8 @@ class Database {
         foreach ($columns_to_add as $column => $type) {
             $column_exists = $wpdb->get_results("SHOW COLUMNS FROM $table_variants LIKE '$column'");
             if (empty($column_exists)) {
-                $wpdb->query("ALTER TABLE $table_variants ADD COLUMN $column $type AFTER base_price");
+                $after = $column === 'stripe_price_id' ? 'name' : 'base_price';
+                $wpdb->query("ALTER TABLE $table_variants ADD COLUMN $column $type AFTER $after");
             }
         }
         
@@ -502,6 +504,7 @@ class Database {
             category_id mediumint(9) DEFAULT 1,
             name varchar(255) NOT NULL,
             description text,
+            stripe_price_id varchar(255) DEFAULT '',
             base_price decimal(10,2) NOT NULL,
             price_from decimal(10,2) DEFAULT 0,
             image_url_1 text,
@@ -778,9 +781,9 @@ class Database {
         $existing_variants = $wpdb->get_var("SELECT COUNT(*) FROM {$wpdb->prefix}federwiegen_variants");
         if ($existing_variants == 0) {
             $variants = array(
-                array('Federwiege + Gestell & Motor', 'Komplettset mit stabilem Gestell und leisem Motor', 89.00),
-                array('Federwiege + Türklammer & Motor', 'Platzsparende Lösung mit praktischer Türklammer', 79.00),
-                array('Wiege + Gestell & Motor mit App-Steuerung', 'Premium-Variante mit smarter App-Steuerung', 119.00)
+                array('Federwiege + Gestell & Motor', 'Komplettset mit stabilem Gestell und leisem Motor', 'price_1QutK3RxDui5dUOqWEiBal7P'),
+                array('Federwiege + Türklammer & Motor', 'Platzsparende Lösung mit praktischer Türklammer', ''),
+                array('Wiege + Gestell & Motor mit App-Steuerung', 'Premium-Variante mit smarter App-Steuerung', '')
             );
             
             foreach ($variants as $index => $variant) {
@@ -790,7 +793,7 @@ class Database {
                         'category_id' => 1,
                         'name' => $variant[0],
                         'description' => $variant[1],
-                        'base_price' => $variant[2],
+                        'stripe_price_id' => $variant[2],
                         'price_from' => 0,
                         'image_url_1' => '',
                         'image_url_2' => '',

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -323,8 +323,32 @@ class Plugin {
             'shipping'    => intval($_POST['shipping'] ?? 0),
         ];
 
-        $zahlung_url = site_url('/zahlung/') . '?' . http_build_query($params);
-        wp_safe_redirect($zahlung_url);
+        $checkout_url = self::get_checkout_page_url();
+        if (!$checkout_url) {
+            $checkout_url = site_url('/zahlung/');
+        }
+        $checkout_url = add_query_arg($params, $checkout_url);
+        wp_safe_redirect($checkout_url);
         exit;
+    }
+
+    /**
+     * Find the page containing the checkout shortcode and return its URL.
+     * Returns null if no such page is found.
+     */
+    public static function get_checkout_page_url() {
+        $pages = get_posts([
+            'post_type'      => 'page',
+            'post_status'    => 'publish',
+            'posts_per_page' => -1,
+        ]);
+
+        foreach ($pages as $page) {
+            if (has_shortcode($page->post_content, 'stripe_elements_form')) {
+                return get_permalink($page->ID);
+            }
+        }
+
+        return null;
     }
 }

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -45,6 +45,9 @@ class Plugin {
 
         add_filter('admin_footer_text', [$this->admin, 'custom_admin_footer']);
         add_action('admin_head', [$this->admin, 'custom_admin_styles']);
+
+        // Handle "Jetzt mieten" form submissions before headers are sent
+        add_action('template_redirect', [$this, 'handle_rent_request']);
     }
 
     public function check_for_updates() {
@@ -298,5 +301,30 @@ class Plugin {
         echo '<script type="application/ld+json">' . "\n";
         echo json_encode($schema, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
         echo "\n" . '</script>' . "\n";
+    }
+
+    /**
+     * Handle the product form submission and redirect to the checkout page
+     * before any output is sent to the browser.
+     */
+    public function handle_rent_request() {
+        if (empty($_POST['jetzt_mieten'])) {
+            return;
+        }
+
+        $params = [
+            'produkt'     => sanitize_text_field($_POST['produkt'] ?? ''),
+            'extra'       => sanitize_text_field($_POST['extra'] ?? ''),
+            'dauer'       => intval($_POST['dauer'] ?? 0),
+            'dauer_name'  => sanitize_text_field($_POST['dauer_name'] ?? ''),
+            'zustand'     => sanitize_text_field($_POST['zustand'] ?? ''),
+            'farbe'       => sanitize_text_field($_POST['farbe'] ?? ''),
+            'preis'       => intval($_POST['preis'] ?? 0),
+            'shipping'    => intval($_POST['shipping'] ?? 0),
+        ];
+
+        $zahlung_url = site_url('/zahlung/') . '?' . http_build_query($params);
+        wp_safe_redirect($zahlung_url);
+        exit;
     }
 }

--- a/includes/StripeService.php
+++ b/includes/StripeService.php
@@ -54,6 +54,19 @@ class StripeService {
         return \Stripe\Subscription::create($params);
     }
 
+    public static function get_price_amount($price_id) {
+        $init = self::init();
+        if (is_wp_error($init)) {
+            return $init;
+        }
+        try {
+            $price = \Stripe\Price::retrieve($price_id);
+            return $price->unit_amount / 100;
+        } catch (\Exception $e) {
+            return new \WP_Error('stripe_price', $e->getMessage());
+        }
+    }
+
     public static function get_publishable_key() {
         return get_option('federwiegen_stripe_publishable_key', '');
     }

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -203,10 +203,15 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
                                 <h4><?php echo esc_html($variant->name); ?></h4>
                                 <p><?php echo esc_html($variant->description); ?></p>
                                 <?php
-                                    $display_price = ($variant->price_from > 0) ? $variant->price_from : $variant->base_price;
-                                    $prefix = ($variant->price_from > 0) ? 'ab ' : '';
+                                    $display_price = 0;
+                                    if (!empty($variant->stripe_price_id)) {
+                                        $p = \FederwiegenVerleih\StripeService::get_price_amount($variant->stripe_price_id);
+                                        if (!is_wp_error($p)) {
+                                            $display_price = $p;
+                                        }
+                                    }
                                 ?>
-                                <p class="federwiegen-option-price"><?php echo $prefix . number_format($display_price, 2, ',', '.'); ?>€<?php echo $price_period === 'month' ? '/Monat' : ''; ?></p>
+                                <p class="federwiegen-option-price"><?php echo number_format($display_price, 2, ',', '.'); ?>€<?php echo $price_period === 'month' ? '/Monat' : ''; ?></p>
                                 <?php if (!($variant->available ?? 1)): ?>
                                     <div class="federwiegen-availability-notice">
                                         <span class="federwiegen-unavailable-badge">❌ Nicht verfügbar</span>

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -8,7 +8,8 @@ if (isset($_POST['jetzt_mieten'])) {
         'dauer_name' => sanitize_text_field($_POST['dauer_name']),
         'zustand' => sanitize_text_field($_POST['zustand']),
         'farbe'   => sanitize_text_field($_POST['farbe']),
-        'preis'   => intval($_POST['preis'])
+        'preis'   => intval($_POST['preis']),
+        'shipping' => intval($_POST['shipping'])
     ];
 
     $zahlung_url = site_url('/zahlung/') . '?' . http_build_query($params);
@@ -367,6 +368,7 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
                         <input type="hidden" name="zustand" id="federwiegen-field-zustand">
                         <input type="hidden" name="farbe" id="federwiegen-field-farbe">
                         <input type="hidden" name="preis" id="federwiegen-field-preis">
+                        <input type="hidden" name="shipping" id="federwiegen-field-shipping">
                         <input type="hidden" name="jetzt_mieten" value="1">
                     <div class="federwiegen-availability-wrapper" id="federwiegen-availability-wrapper" style="display:none;">
                         <div id="federwiegen-availability-status" class="federwiegen-availability-status available">

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -47,7 +47,9 @@ if (isset($category) && property_exists($category, 'payment_icons')) {
 }
 
 // Shipping
-$shipping_cost = isset($category) ? ($category->shipping_cost ?? 0) : 0;
+$shipping_cost = defined('FEDERWIEGEN_SHIPPING_COST')
+    ? constant('FEDERWIEGEN_SHIPPING_COST')
+    : (isset($category) ? ($category->shipping_cost ?? 0) : 0);
 $shipping_provider = isset($category) ? ($category->shipping_provider ?? '') : '';
 $price_label = isset($category) ? ($category->price_label ?? 'Monatlicher Mietpreis') : 'Monatlicher Mietpreis';
 $shipping_label = isset($category) ? ($category->shipping_label ?? 'Einmalige Versandkosten:') : 'Einmalige Versandkosten:';

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -49,7 +49,7 @@ if (isset($category) && property_exists($category, 'payment_icons')) {
 // Shipping
 $shipping_cost = defined('FEDERWIEGEN_SHIPPING_COST')
     ? constant('FEDERWIEGEN_SHIPPING_COST')
-    : (isset($category) ? ($category->shipping_cost ?? 0) : 0);
+    : 0;
 $shipping_provider = isset($category) ? ($category->shipping_provider ?? '') : '';
 $price_label = isset($category) ? ($category->price_label ?? 'Monatlicher Mietpreis') : 'Monatlicher Mietpreis';
 $shipping_label = isset($category) ? ($category->shipping_label ?? 'Einmalige Versandkosten:') : 'Einmalige Versandkosten:';

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -1,22 +1,5 @@
 <?php
 
-if (isset($_POST['jetzt_mieten'])) {
-    $params = [
-        'produkt' => sanitize_text_field($_POST['produkt']),
-        'extra'   => sanitize_text_field($_POST['extra']),
-        'dauer'   => intval($_POST['dauer']),
-        'dauer_name' => sanitize_text_field($_POST['dauer_name']),
-        'zustand' => sanitize_text_field($_POST['zustand']),
-        'farbe'   => sanitize_text_field($_POST['farbe']),
-        'preis'   => intval($_POST['preis']),
-        'shipping' => intval($_POST['shipping'])
-    ];
-
-    $zahlung_url = site_url('/zahlung/') . '?' . http_build_query($params);
-    wp_redirect($zahlung_url);
-    exit;
-}
-
 global $wpdb;
 
 // Get category data


### PR DESCRIPTION
## Summary
- remove old submenu pages for Popup, Branding, Debug and Stripe Integration
- clean up unused admin page methods
- link Branding card on dashboard to settings tab

## Testing
- `php -l includes/Admin.php` *(fails: command not found)*
- `php -l admin/main-page.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6868fee1e2e883309a4bced20fc18b65