### PR TITLE
Switch extras to Stripe price IDs

### DIFF
--- a/admin/extras-page.php
+++ b/admin/extras-page.php
@@ -20,6 +20,11 @@ $column_exists = $wpdb->get_results("SHOW COLUMNS FROM $table_name LIKE 'image_u
 if (empty($column_exists)) {
     $wpdb->query("ALTER TABLE $table_name ADD COLUMN image_url TEXT AFTER price");
 }
+// Ensure stripe_price_id column exists
+$price_id_exists = $wpdb->get_results("SHOW COLUMNS FROM $table_name LIKE 'stripe_price_id'");
+if (empty($price_id_exists)) {
+    $wpdb->query("ALTER TABLE $table_name ADD COLUMN stripe_price_id VARCHAR(255) DEFAULT '' AFTER name");
+}
 
 // Ensure category_id column exists
 $category_column_exists = $wpdb->get_results("SHOW COLUMNS FROM $table_name LIKE 'category_id'");
@@ -32,7 +37,7 @@ if (isset($_POST['submit'])) {
     \FederwiegenVerleih\Admin::verify_admin_action();
     $category_id = intval($_POST['category_id']);
     $name = sanitize_text_field($_POST['name']);
-    $price = floatval($_POST['price']);
+    $stripe_price_id = sanitize_text_field($_POST['stripe_price_id']);
     $image_url = esc_url_raw($_POST['image_url']);
     $active = isset($_POST['active']) ? 1 : 0;
     $sort_order = intval($_POST['sort_order']);
@@ -44,13 +49,13 @@ if (isset($_POST['submit'])) {
             array(
                 'category_id' => $category_id,
                 'name' => $name,
-                'price' => $price,
+                'stripe_price_id' => $stripe_price_id,
                 'image_url' => $image_url,
                 'active' => $active,
                 'sort_order' => $sort_order
             ),
             array('id' => intval($_POST['id'])),
-            array('%d', '%s', '%f', '%s', '%d', '%d'),
+            array('%d', '%s', '%s', '%s', '%d', '%d'),
             array('%d')
         );
         
@@ -66,12 +71,12 @@ if (isset($_POST['submit'])) {
             array(
                 'category_id' => $category_id,
                 'name' => $name,
-                'price' => $price,
+                'stripe_price_id' => $stripe_price_id,
                 'image_url' => $image_url,
                 'active' => $active,
                 'sort_order' => $sort_order
             ),
-            array('%d', '%s', '%f', '%s', '%d', '%d')
+            array('%d', '%s', '%s', '%s', '%d', '%d')
         );
         
         if ($result !== false) {

--- a/admin/main-page.php
+++ b/admin/main-page.php
@@ -111,7 +111,7 @@ foreach ($branding_results as $result) {
                 </div>
             </a>
             
-            <a href="<?php echo admin_url('admin.php?page=federwiegen-branding'); ?>" class="federwiegen-nav-card">
+            <a href="<?php echo admin_url('admin.php?page=federwiegen-settings&tab=branding'); ?>" class="federwiegen-nav-card">
                 <div class="federwiegen-nav-icon">🎨</div>
                 <div class="federwiegen-nav-content">
                     <h4>Branding</h4>

--- a/admin/tabs/categories-add-tab.php
+++ b/admin/tabs/categories-add-tab.php
@@ -61,10 +61,6 @@
                     <input type="text" name="product_title" required placeholder="Titel unter dem Produktbild">
                 </div>
                 <div class="federwiegen-form-group">
-                    <label>Versandkosten (€)</label>
-                    <input type="number" name="shipping_cost" step="0.01" min="0">
-                </div>
-                <div class="federwiegen-form-group">
                     <label>Versanddienstleister</label>
                     <div class="federwiegen-shipping-radios">
                         <?php $shipping_providers = [

--- a/admin/tabs/categories-edit-tab.php
+++ b/admin/tabs/categories-edit-tab.php
@@ -201,10 +201,6 @@
                 <h4>🚚 Versand</h4>
                 <div class="federwiegen-form-row">
                     <div class="federwiegen-form-group">
-                        <label>Versandkosten (€)</label>
-                        <input type="number" name="shipping_cost" value="<?php echo esc_attr($edit_item->shipping_cost); ?>" step="0.01" min="0">
-                    </div>
-                    <div class="federwiegen-form-group">
                         <label>Versanddienstleister</label>
                         <div class="federwiegen-shipping-radios">
                             <?php $shipping_providers = [

--- a/admin/tabs/categories-list-tab.php
+++ b/admin/tabs/categories-list-tab.php
@@ -53,13 +53,6 @@
                         <?php endif; ?>
                     </div>
                     
-                    <div class="federwiegen-category-shipping">
-                        <strong><?php echo number_format($category->shipping_cost ?? 0, 2, ',', '.'); ?>€</strong>
-                        <small>Versand</small>
-                        <?php if (!empty($category->shipping_provider)): ?>
-                            <img src="<?php echo esc_url(FEDERWIEGEN_PLUGIN_URL . 'assets/shipping-icons/' . $category->shipping_provider . '.svg'); ?>" alt="<?php echo esc_attr($category->shipping_provider); ?>">
-                        <?php endif; ?>
-                    </div>
                 </div>
                 
                 <div class="federwiegen-category-actions">

--- a/admin/tabs/durations-add-tab.php
+++ b/admin/tabs/durations-add-tab.php
@@ -38,6 +38,18 @@
                 </div>
             </div>
         </div>
+
+        <!-- Price IDs per Variant -->
+        <div class="federwiegen-form-section">
+            <h4>💳 Preis IDs pro Ausführung</h4>
+            <?php foreach ($variants as $variant): ?>
+            <div class="federwiegen-form-group">
+                <label><?php echo esc_html($variant->name); ?></label>
+                <input type="text" name="variant_price_id[<?php echo $variant->id; ?>]" placeholder="<?php echo esc_attr($variant->stripe_price_id); ?>">
+                <small>Leer lassen, um Standard zu verwenden</small>
+            </div>
+            <?php endforeach; ?>
+        </div>
         
         
         <!-- Actions -->

--- a/admin/tabs/durations-edit-tab.php
+++ b/admin/tabs/durations-edit-tab.php
@@ -2,6 +2,16 @@
 // Durations Edit Tab Content
 ?>
 
+<?php
+    $price_rows = $wpdb->get_results($wpdb->prepare("SELECT variant_id, stripe_price_id FROM $table_prices WHERE duration_id = %d", $edit_item->id), OBJECT_K);
+    $duration_prices = array();
+    if ($price_rows) {
+        foreach ($price_rows as $pid => $obj) {
+            $duration_prices[$pid] = $obj->stripe_price_id;
+        }
+    }
+?>
+
 <div class="federwiegen-edit-duration">
     <div class="federwiegen-form-header">
         <h3>✏️ Mietdauer bearbeiten</h3>
@@ -27,17 +37,29 @@
                 </div>
             </div>
             
-            <div class="federwiegen-form-row">
-                <div class="federwiegen-form-group">
-                    <label>Rabatt (%)</label>
-                    <input type="number" name="discount" value="<?php echo ($edit_item->discount * 100); ?>" step="0.01" min="0" max="100">
-                    <small>z.B. 10 für 10% Rabatt</small>
-                </div>
-                <div class="federwiegen-form-group">
-                    <label>Sortierung</label>
-                    <input type="number" name="sort_order" value="<?php echo $edit_item->sort_order; ?>" min="0">
-                </div>
+        <div class="federwiegen-form-row">
+            <div class="federwiegen-form-group">
+                <label>Rabatt (%)</label>
+                <input type="number" name="discount" value="<?php echo ($edit_item->discount * 100); ?>" step="0.01" min="0" max="100">
+                <small>z.B. 10 für 10% Rabatt</small>
             </div>
+            <div class="federwiegen-form-group">
+                <label>Sortierung</label>
+                <input type="number" name="sort_order" value="<?php echo $edit_item->sort_order; ?>" min="0">
+            </div>
+        </div>
+    </div>
+
+        <!-- Price IDs per Variant -->
+        <div class="federwiegen-form-section">
+            <h4>💳 Preis IDs pro Ausführung</h4>
+            <?php foreach ($variants as $variant): ?>
+            <div class="federwiegen-form-group">
+                <label><?php echo esc_html($variant->name); ?></label>
+                <input type="text" name="variant_price_id[<?php echo $variant->id; ?>]" value="<?php echo esc_attr($duration_prices[$variant->id] ?? ''); ?>" placeholder="<?php echo esc_attr($variant->stripe_price_id); ?>">
+                <small>Leer lassen, um Standard zu verwenden</small>
+            </div>
+            <?php endforeach; ?>
         </div>
         
         

--- a/admin/tabs/extras-add-tab.php
+++ b/admin/tabs/extras-add-tab.php
@@ -21,8 +21,8 @@
                     <input type="text" name="name" required placeholder="z.B. Himmel, Zubehör-Set">
                 </div>
                 <div class="federwiegen-form-group">
-                    <label>Preis (€) *</label>
-                    <input type="number" name="price" step="0.01" min="0" required placeholder="9.99">
+                    <label>Stripe Preis ID *</label>
+                    <input type="text" name="stripe_price_id" required placeholder="price_123...">
                 </div>
             </div>
         </div>

--- a/admin/tabs/extras-edit-tab.php
+++ b/admin/tabs/extras-edit-tab.php
@@ -22,8 +22,8 @@
                     <input type="text" name="name" value="<?php echo esc_attr($edit_item->name); ?>" required>
                 </div>
                 <div class="federwiegen-form-group">
-                    <label>Preis (€) *</label>
-                    <input type="number" name="price" value="<?php echo $edit_item->price; ?>" step="0.01" min="0" required>
+                    <label>Stripe Preis ID *</label>
+                    <input type="text" name="stripe_price_id" value="<?php echo esc_attr($edit_item->stripe_price_id); ?>" required>
                 </div>
             </div>
         </div>

--- a/admin/tabs/extras-list-tab.php
+++ b/admin/tabs/extras-list-tab.php
@@ -44,8 +44,12 @@
                 
                 <div class="federwiegen-extra-meta">
                     <div class="federwiegen-extra-price">
-                        <strong><?php echo number_format($extra->price, 2, ',', '.'); ?>€</strong>
-                        <small>/Monat</small>
+                        <?php if (!empty($extra->stripe_price_id)) {
+                            $p = \FederwiegenVerleih\StripeService::get_price_amount($extra->stripe_price_id);
+                            if (!is_wp_error($p)) {
+                                echo '<strong>' . number_format($p, 2, ',', '.') . "€</strong><small>/Monat</small>";
+                            }
+                        } ?>
                     </div>
                     
                     <div class="federwiegen-extra-info">

--- a/admin/tabs/variants-add-tab.php
+++ b/admin/tabs/variants-add-tab.php
@@ -21,12 +21,8 @@
                     <input type="text" name="name" required placeholder="z.B. Premium Federwiege">
                 </div>
                 <div class="federwiegen-form-group">
-                    <label>Grundpreis (€) *</label>
-                    <input type="number" name="base_price" step="0.01" min="0" required placeholder="29.99">
-                </div>
-                <div class="federwiegen-form-group">
-                    <label>Preis ab (€)</label>
-                    <input type="number" name="price_from" step="0.01" min="0" placeholder="">
+                    <label>Stripe Preis ID *</label>
+                    <input type="text" name="stripe_price_id" required placeholder="price_123...">
                 </div>
             </div>
             

--- a/admin/tabs/variants-edit-tab.php
+++ b/admin/tabs/variants-edit-tab.php
@@ -22,12 +22,8 @@
                     <input type="text" name="name" value="<?php echo esc_attr($edit_item->name); ?>" required>
                 </div>
                 <div class="federwiegen-form-group">
-                    <label>Grundpreis (€) *</label>
-                    <input type="number" name="base_price" value="<?php echo $edit_item->base_price; ?>" step="0.01" min="0" required>
-                </div>
-                <div class="federwiegen-form-group">
-                    <label>Preis ab (€)</label>
-                    <input type="number" name="price_from" value="<?php echo $edit_item->price_from; ?>" step="0.01" min="0">
+                    <label>Stripe Preis ID *</label>
+                    <input type="text" name="stripe_price_id" value="<?php echo esc_attr($edit_item->stripe_price_id); ?>" required>
                 </div>
             </div>
             

--- a/admin/tabs/variants-list-tab.php
+++ b/admin/tabs/variants-list-tab.php
@@ -65,8 +65,17 @@
                 <p class="federwiegen-variant-description"><?php echo esc_html($variant->description); ?></p>
                 
                 <div class="federwiegen-variant-meta">
+                    <?php
+                        $price = 0;
+                        if (!empty($variant->stripe_price_id)) {
+                            $p = \FederwiegenVerleih\StripeService::get_price_amount($variant->stripe_price_id);
+                            if (!is_wp_error($p)) {
+                                $price = $p;
+                            }
+                        }
+                    ?>
                     <div class="federwiegen-variant-price">
-                        <strong><?php echo number_format($variant->base_price, 2, ',', '.'); ?>€</strong>
+                        <strong><?php echo number_format($price, 2, ',', '.'); ?>€</strong>
                         <small>/Monat</small>
                     </div>
                     

--- a/admin/variants-page.php
+++ b/admin/variants-page.php
@@ -24,6 +24,12 @@ foreach ($image_columns as $column) {
     }
 }
 
+// Ensure stripe_price_id column exists
+$price_column_exists = $wpdb->get_results("SHOW COLUMNS FROM $table_name LIKE 'stripe_price_id'");
+if (empty($price_column_exists)) {
+    $wpdb->query("ALTER TABLE $table_name ADD COLUMN stripe_price_id VARCHAR(255) DEFAULT '' AFTER name");
+}
+
 // Ensure category_id column exists
 $category_column_exists = $wpdb->get_results("SHOW COLUMNS FROM $table_name LIKE 'category_id'");
 if (empty($category_column_exists)) {
@@ -49,8 +55,7 @@ if (isset($_POST['submit'])) {
     $category_id = intval($_POST['category_id']);
     $name = sanitize_text_field($_POST['name']);
     $description = sanitize_textarea_field($_POST['description']);
-    $base_price = floatval($_POST['base_price']);
-    $price_from = isset($_POST['price_from']) ? floatval($_POST['price_from']) : 0;
+    $stripe_price_id = sanitize_text_field($_POST['stripe_price_id']);
     $available = isset($_POST['available']) ? 1 : 0;
     $availability_note = sanitize_text_field($_POST['availability_note']);
     $delivery_time = sanitize_text_field($_POST['delivery_time']);
@@ -69,8 +74,7 @@ if (isset($_POST['submit'])) {
             'category_id' => $category_id,
             'name' => $name,
             'description' => $description,
-            'base_price' => $base_price,
-            'price_from' => $price_from,
+            'stripe_price_id' => $stripe_price_id,
             'available' => $available,
             'availability_note' => $availability_note,
             'delivery_time' => $delivery_time,
@@ -82,7 +86,7 @@ if (isset($_POST['submit'])) {
             $table_name,
             $update_data,
             array('id' => intval($_POST['id'])),
-            array_merge(array('%d', '%s', '%s', '%f', '%f', '%d', '%s', '%s', '%d', '%d'), array_fill(0, 5, '%s')),
+            array_merge(array('%d', '%s', '%s', '%s', '%d', '%s', '%s', '%d', '%d'), array_fill(0, 5, '%s')),
             array('%d')
         );
         
@@ -97,8 +101,7 @@ if (isset($_POST['submit'])) {
             'category_id' => $category_id,
             'name' => $name,
             'description' => $description,
-            'base_price' => $base_price,
-            'price_from' => $price_from,
+            'stripe_price_id' => $stripe_price_id,
             'available' => $available,
             'availability_note' => $availability_note,
             'delivery_time' => $delivery_time,
@@ -109,7 +112,7 @@ if (isset($_POST['submit'])) {
         $result = $wpdb->insert(
             $table_name,
             $insert_data,
-            array_merge(array('%d', '%s', '%s', '%f', '%f', '%d', '%s', '%s', '%d', '%d'), array_fill(0, 5, '%s'))
+            array_merge(array('%d', '%s', '%s', '%s', '%d', '%s', '%s', '%d', '%d'), array_fill(0, 5, '%s'))
         );
         
         if ($result !== false) {

--- a/assets/script.js
+++ b/assets/script.js
@@ -14,6 +14,7 @@ jQuery(document).ready(function($) {
     let touchStartX = 0;
     let touchEndX = 0;
     let currentPrice = 0;
+    let currentShippingCost = 0;
     let colorNotificationTimeout = null;
 
     // Get category ID from container
@@ -161,6 +162,7 @@ jQuery(document).ready(function($) {
         $('#federwiegen-field-zustand').val(conditionName);
         $('#federwiegen-field-farbe').val(colorName);
         $('#federwiegen-field-preis').val(Math.round(currentPrice * 100));
+        $('#federwiegen-field-shipping').val(Math.round(currentShippingCost * 100));
 
         $('#federwiegen-order-form').submit();
     });
@@ -585,6 +587,7 @@ jQuery(document).ready(function($) {
                     if (response.success) {
                         const data = response.data;
                         currentPrice = data.final_price;
+                        currentShippingCost = data.shipping_cost || 0;
                         
                         // Update price display
                         $('#federwiegen-final-price').text(formatPrice(data.final_price) + '€');

--- a/assets/script.js
+++ b/assets/script.js
@@ -15,6 +15,7 @@ jQuery(document).ready(function($) {
     let touchEndX = 0;
     let currentPrice = 0;
     let currentShippingCost = 0;
+    let currentPriceId = '';
     let colorNotificationTimeout = null;
 
     // Get category ID from container
@@ -163,6 +164,9 @@ jQuery(document).ready(function($) {
         $('#federwiegen-field-farbe').val(colorName);
         $('#federwiegen-field-preis').val(Math.round(currentPrice * 100));
         $('#federwiegen-field-shipping').val(Math.round(currentShippingCost * 100));
+        $('#federwiegen-field-variant-id').val(selectedVariant);
+        $('#federwiegen-field-duration-id').val(selectedDuration);
+        $('#federwiegen-field-price-id').val(currentPriceId);
 
         $('#federwiegen-order-form').submit();
     });
@@ -604,6 +608,7 @@ jQuery(document).ready(function($) {
 
                         // Update button based on availability
                         currentStripeLink = data.stripe_link;
+                        currentPriceId = data.price_id || '';
                         const isAvailable = data.available !== false;
 
                         $('#federwiegen-rent-button').prop('disabled', !isAvailable);

--- a/assets/script.js
+++ b/assets/script.js
@@ -596,15 +596,11 @@ jQuery(document).ready(function($) {
                         // Update price display
                         $('#federwiegen-final-price').text(formatPrice(data.final_price) + '€');
                         
-                        if (data.discount > 0) {
-                            $('#federwiegen-original-price').text(formatPrice(data.base_price) + '€').show();
-                            const savings = data.base_price - data.final_price;
-                            const saveSuffix = federwiegen_ajax.price_period === 'month' ? ' pro Monat!' : '!';
-                            $('#federwiegen-savings').text(`Sie sparen ${formatPrice(savings)}€${saveSuffix}`).show();
-                        } else {
-                            $('#federwiegen-original-price').hide();
-                            $('#federwiegen-savings').hide();
-                        }
+                        // The discount percentage is used only for the badge.
+                        // Prices come directly from Stripe, so don't show any
+                        // original price or savings calculation.
+                        $('#federwiegen-original-price').hide();
+                        $('#federwiegen-savings').hide();
 
                         // Update button based on availability
                         currentStripeLink = data.stripe_link;

--- a/assets/script.js
+++ b/assets/script.js
@@ -154,14 +154,17 @@ jQuery(document).ready(function($) {
             .map(function() { return $(this).text().trim(); }).get().join(',');
         const durationName = $('.federwiegen-option[data-type="duration"].selected .federwiegen-duration-name').text().trim();
         const conditionName = $('.federwiegen-option[data-type="condition"].selected .federwiegen-condition-name').text().trim();
-        const colorName = $('.federwiegen-option[data-type="product-color"].selected').data('color-name') || '';
+        const productColorName = $('.federwiegen-option[data-type="product-color"].selected').data('color-name') || '';
+        const frameColorName = $('.federwiegen-option[data-type="frame-color"].selected').data('color-name') || '';
 
         $('#federwiegen-field-produkt').val(variantName);
         $('#federwiegen-field-extra').val(extraNames);
         $('#federwiegen-field-dauer').val(selectedDuration);
         $('#federwiegen-field-dauer-name').val(durationName);
         $('#federwiegen-field-zustand').val(conditionName);
-        $('#federwiegen-field-farbe').val(colorName);
+        $('#federwiegen-field-farbe').val(productColorName);
+        $('#federwiegen-field-produktfarbe').val(productColorName);
+        $('#federwiegen-field-gestellfarbe').val(frameColorName);
         $('#federwiegen-field-preis').val(Math.round(currentPrice * 100));
         $('#federwiegen-field-shipping').val(Math.round(currentShippingCost * 100));
         $('#federwiegen-field-variant-id').val(selectedVariant);

--- a/assets/style.css
+++ b/assets/style.css
@@ -1280,7 +1280,7 @@ body.federwiegen-popup-open {
     margin-right: 0.5rem;
 }
 
-#card-element {
+#payment-element {
     padding: 10px;
     border: 1px solid #ccc;
     border-radius: 4px;

--- a/assets/style.css
+++ b/assets/style.css
@@ -1214,21 +1214,33 @@ body.federwiegen-popup-open {
 }
 
 /* Checkout styles */
-.federwiegen-checkout {
-    max-width: 600px;
+.federwiegen-checkout-wrapper {
+    max-width: 1100px;
     margin: 0 auto;
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    gap: 2rem;
+}
+
+.federwiegen-checkout-left,
+.federwiegen-checkout-right {
     background: #fff;
     padding: 2rem;
     border-radius: 1rem;
     box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1);
 }
 
-.federwiegen-checkout h2 {
-    font-size: 1.75rem;
-    font-weight: bold;
-    text-align: center;
+@media (max-width: 768px) {
+    .federwiegen-checkout-wrapper {
+        grid-template-columns: 1fr;
+    }
+}
+
+.federwiegen-checkout-left h3 {
+    font-size: 1.2rem;
+    font-weight: 600;
     color: #2a372a;
-    margin-bottom: 1rem;
+    margin-bottom: 0.5rem;
 }
 
 .federwiegen-checkout-summary {

--- a/federwiegen-verleih.php
+++ b/federwiegen-verleih.php
@@ -134,8 +134,11 @@ function federwiegen_stripe_elements_form() {
           <?php if (!empty($_GET['zustand'])): ?>
           <li>Zustand: <?php echo esc_html($_GET['zustand']); ?></li>
           <?php endif; ?>
-          <?php if (!empty($_GET['farbe'])): ?>
-          <li>Farbe: <?php echo esc_html($_GET['farbe']); ?></li>
+          <?php if (!empty($_GET['produktfarbe'])): ?>
+          <li>Produktfarbe: <?php echo esc_html($_GET['produktfarbe']); ?></li>
+          <?php endif; ?>
+          <?php if (!empty($_GET['gestellfarbe'])): ?>
+          <li>Gestellfarbe: <?php echo esc_html($_GET['gestellfarbe']); ?></li>
           <?php endif; ?>
           <?php if ($preis_cents): ?>
           <li>Preis: <?php echo number_format($preis_cents / 100, 2, ',', '.'); ?> €</li>
@@ -165,6 +168,8 @@ function federwiegen_stripe_elements_form() {
         dauer_name: getUrlParameter('dauer_name'),
         zustand: getUrlParameter('zustand'),
         farbe: getUrlParameter('farbe'),
+        produktfarbe: getUrlParameter('produktfarbe'),
+        gestellfarbe: getUrlParameter('gestellfarbe'),
         preis: getUrlParameter('preis'),
         shipping: getUrlParameter('shipping'),
         variant_id: getUrlParameter('variant_id'),
@@ -213,6 +218,8 @@ function federwiegen_stripe_elements_form() {
           dauer_name: baseData.dauer_name,
           zustand: baseData.zustand,
           farbe: baseData.farbe,
+          produktfarbe: baseData.produktfarbe,
+          gestellfarbe: baseData.gestellfarbe,
           preis: baseData.preis,
           shipping: baseData.shipping,
           variant_id: baseData.variant_id,

--- a/federwiegen-verleih.php
+++ b/federwiegen-verleih.php
@@ -187,7 +187,7 @@ function federwiegen_stripe_elements_form() {
       const SHIPPING_PRICE_ID = '<?php echo esc_js(FEDERWIEGEN_SHIPPING_PRICE_ID); ?>';
 
       const stripe = Stripe('<?php echo esc_js($publishable_key); ?>');
-      const elements = stripe.elements();
+      let elements = null;
       let clientSecret = null;
 
       async function initStripePaymentElement() {
@@ -204,7 +204,7 @@ function federwiegen_stripe_elements_form() {
           }
 
           clientSecret = result.client_secret;
-          elements.update({ clientSecret });
+          elements = stripe.elements({ clientSecret });
           const paymentElement = elements.create('payment');
           paymentElement.mount('#payment-element');
 

--- a/federwiegen-verleih.php
+++ b/federwiegen-verleih.php
@@ -46,6 +46,11 @@ add_action('plugins_loaded', function () {
 
 add_shortcode('stripe_elements_form', 'federwiegen_stripe_elements_form');
 function federwiegen_stripe_elements_form() {
+    $publishable_key = \FederwiegenVerleih\StripeService::get_publishable_key();
+    if (empty($publishable_key)) {
+        return '<p>Stripe API-Schl\xC3\xBCssel fehlt. Bitte in den Plugin-Einstellungen eintragen.</p>';
+    }
+
     ob_start(); ?>
 
     <div class="federwiegen-checkout-wrapper">
@@ -181,7 +186,7 @@ function federwiegen_stripe_elements_form() {
 
       const SHIPPING_PRICE_ID = '<?php echo esc_js(FEDERWIEGEN_SHIPPING_PRICE_ID); ?>';
 
-      const stripe = Stripe('<?php echo esc_js(\FederwiegenVerleih\StripeService::get_publishable_key()); ?>');
+      const stripe = Stripe('<?php echo esc_js($publishable_key); ?>');
       const elements = stripe.elements();
       const paymentElement = elements.create('payment');
       paymentElement.mount('#payment-element');
@@ -243,6 +248,10 @@ function federwiegen_stripe_elements_form() {
             throw new Error('Serverfehler');
           }
           const responseData = await res.json();
+          if (!responseData.client_secret) {
+            messageEl.textContent = 'Fehler: client_secret fehlt.';
+            return;
+          }
           const shipping = {
             name: document.getElementById('fullname').value,
             phone: document.getElementById('phone').value,

--- a/federwiegen-verleih.php
+++ b/federwiegen-verleih.php
@@ -188,8 +188,31 @@ function federwiegen_stripe_elements_form() {
 
       const stripe = Stripe('<?php echo esc_js($publishable_key); ?>');
       const elements = stripe.elements();
-      const paymentElement = elements.create('payment');
-      paymentElement.mount('#payment-element');
+      let clientSecret = null;
+
+      async function initStripePaymentElement() {
+        try {
+          const res = await fetch('<?php echo admin_url("admin-ajax.php?action=create_subscription"); ?>', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ ...baseData })
+          });
+          const result = await res.json();
+          if (!result.client_secret) {
+            document.getElementById('payment-message').textContent = 'Fehler: Kein client_secret erhalten.';
+            return;
+          }
+
+          clientSecret = result.client_secret;
+          elements.update({ clientSecret });
+          const paymentElement = elements.create('payment');
+          paymentElement.mount('#payment-element');
+
+          form.addEventListener('submit', handleSubmit);
+        } catch (e) {
+          document.getElementById('payment-message').textContent = e.message;
+        }
+      }
 
       const sameAddressCheckbox = document.getElementById('same-address');
       const billingFields = document.getElementById('billing-fields');
@@ -198,7 +221,8 @@ function federwiegen_stripe_elements_form() {
       });
 
       const form = document.getElementById('checkout-form');
-      form.addEventListener('submit', async (event) => {
+
+      async function handleSubmit(event) {
         event.preventDefault();
 
         if (!document.getElementById('agb').checked) {
@@ -206,93 +230,48 @@ function federwiegen_stripe_elements_form() {
           return;
         }
 
-        const formData = {
-          fullname: document.getElementById('fullname').value,
-          email: document.getElementById('email').value,
+        const shipping = {
+          name: document.getElementById('fullname').value,
           phone: document.getElementById('phone').value,
-          street: document.getElementById('street').value,
-          postal: document.getElementById('postal').value,
-          city: document.getElementById('city').value,
-          country: document.getElementById('country').value,
-          bill_fullname: document.getElementById('bill_fullname').value,
-          bill_street: document.getElementById('bill_street').value,
-          bill_postal: document.getElementById('bill_postal').value,
-          bill_city: document.getElementById('bill_city').value,
-          bill_country: document.getElementById('bill_country').value,
-          produkt: baseData.produkt,
-          extra: baseData.extra,
-          dauer: baseData.dauer,
-          dauer_name: baseData.dauer_name,
-          zustand: baseData.zustand,
-          farbe: baseData.farbe,
-          produktfarbe: baseData.produktfarbe,
-          gestellfarbe: baseData.gestellfarbe,
-          preis: baseData.preis,
-          shipping: baseData.shipping,
-          variant_id: baseData.variant_id,
-          duration_id: baseData.duration_id,
-          price_id: baseData.price_id,
-          shipping_price_id: SHIPPING_PRICE_ID
+          address: {
+            line1: document.getElementById('street').value,
+            postal_code: document.getElementById('postal').value,
+            city: document.getElementById('city').value,
+            country: document.getElementById('country').value,
+          }
+        };
+
+        const billing = {
+          name: document.getElementById('bill_fullname').value || shipping.name,
+          email: document.getElementById('email').value,
+          address: {
+            line1: document.getElementById('bill_street').value || shipping.address.line1,
+            postal_code: document.getElementById('bill_postal').value || shipping.address.postal_code,
+            city: document.getElementById('bill_city').value || shipping.address.city,
+            country: document.getElementById('bill_country').value || shipping.address.country,
+          }
         };
 
         const messageEl = document.getElementById('payment-message');
         messageEl.textContent = '';
 
-        try {
-          const res = await fetch('<?php echo admin_url("admin-ajax.php?action=create_subscription"); ?>', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(formData)
-          });
-          if (!res.ok) {
-            throw new Error('Serverfehler');
-          }
-          const responseData = await res.json();
-          if (!responseData.client_secret) {
-            messageEl.textContent = 'Fehler: client_secret fehlt.';
-            return;
-          }
-          const shipping = {
-            name: document.getElementById('fullname').value,
-            phone: document.getElementById('phone').value,
-            address: {
-              line1: document.getElementById('street').value,
-              postal_code: document.getElementById('postal').value,
-              city: document.getElementById('city').value,
-              country: document.getElementById('country').value,
-            }
-          };
-
-          const billing = {
-            name: document.getElementById('bill_fullname').value || shipping.name,
-            email: document.getElementById('email').value,
-            address: {
-              line1: document.getElementById('bill_street').value || shipping.address.line1,
-              postal_code: document.getElementById('bill_postal').value || shipping.address.postal_code,
-              city: document.getElementById('bill_city').value || shipping.address.city,
-              country: document.getElementById('bill_country').value || shipping.address.country,
-            }
-          };
-
-          elements.update({ clientSecret: responseData.client_secret });
-          const { error, paymentIntent } = await stripe.confirmPayment({
-            elements,
-            confirmParams: {
-              payment_method_data: { billing_details: billing },
-              shipping: shipping
-            },
-            redirect: 'if_required',
-            clientSecret: responseData.client_secret
-          });
-          if (error) {
-            messageEl.textContent = error.message;
-          } else if (paymentIntent.status === 'succeeded') {
-            messageEl.textContent = 'Zahlung erfolgreich!';
-          }
-        } catch (err) {
-          messageEl.textContent = err.message;
+        const { error, paymentIntent } = await stripe.confirmPayment({
+          elements,
+          confirmParams: {
+            payment_method_data: { billing_details: billing },
+            shipping: shipping
+          },
+          redirect: 'if_required',
+          clientSecret
+        });
+        if (error) {
+          messageEl.textContent = error.message;
+        } else if (paymentIntent && paymentIntent.status === 'succeeded') {
+          messageEl.textContent = 'Zahlung erfolgreich!';
         }
-      });
+      }
+
+      initStripePaymentElement();
     </script>
     </div>
 

--- a/federwiegen-verleih.php
+++ b/federwiegen-verleih.php
@@ -195,7 +195,10 @@ function federwiegen_stripe_elements_form() {
           const res = await fetch('<?php echo admin_url("admin-ajax.php?action=create_subscription"); ?>', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ ...baseData })
+            body: JSON.stringify({
+              ...baseData,
+              shipping_price_id: SHIPPING_PRICE_ID
+            })
           });
           const result = await res.json();
           if (!result.client_secret) {

--- a/federwiegen-verleih.php
+++ b/federwiegen-verleih.php
@@ -24,6 +24,8 @@ define('FEDERWIEGEN_PLUGIN_FILE', __FILE__);
 define('FEDERWIEGEN_SHIPPING_PRICE_ID', 'price_1QKQDzRxDui5dUOqdlAFIJcr');
 // Display amount for shipping in Euros
 define('FEDERWIEGEN_SHIPPING_COST', 9.99);
+// Payment Method Configuration ID for PayPal
+define('FEDERWIEGEN_PMC_ID', 'pmc_1QKPcvRxDui5dUOqaNaxNjsL');
 
 // Control whether default demo data is inserted on activation
 if (!defined('FEDERWIEGEN_LOAD_DEFAULT_DATA')) {

--- a/federwiegen-verleih.php
+++ b/federwiegen-verleih.php
@@ -158,21 +158,6 @@ function federwiegen_stripe_elements_form() {
         return results === null ? '' : decodeURIComponent(results[1].replace(/\+/g, ' '));
       }
 
-      function getPriceId(dauer) {
-        switch (parseInt(dauer, 10)) {
-          case 1:
-            return 'price_1QutK3RxDui5dUOqWEiBal7P';
-          case 2:
-            return 'price_1RgsfURxDui5dUOqCrHj06pj';
-          case 4:
-            return 'price_1RgslZRxDui5dUOqDKCSmqkU';
-          case 6:
-            return 'price_1RgssSRxDui5dUOqOUj6o0ZB';
-          default:
-            return '';
-        }
-      }
-
       const baseData = {
         produkt: getUrlParameter('produkt'),
         extra: getUrlParameter('extra'),
@@ -181,7 +166,10 @@ function federwiegen_stripe_elements_form() {
         zustand: getUrlParameter('zustand'),
         farbe: getUrlParameter('farbe'),
         preis: getUrlParameter('preis'),
-        shipping: getUrlParameter('shipping')
+        shipping: getUrlParameter('shipping'),
+        variant_id: getUrlParameter('variant_id'),
+        duration_id: getUrlParameter('duration_id'),
+        price_id: getUrlParameter('price_id')
       };
 
       const SHIPPING_PRICE_ID = '<?php echo esc_js(FEDERWIEGEN_SHIPPING_PRICE_ID); ?>';
@@ -227,7 +215,9 @@ function federwiegen_stripe_elements_form() {
           farbe: baseData.farbe,
           preis: baseData.preis,
           shipping: baseData.shipping,
-          price_id: getPriceId(baseData.dauer),
+          variant_id: baseData.variant_id,
+          duration_id: baseData.duration_id,
+          price_id: baseData.price_id,
           shipping_price_id: SHIPPING_PRICE_ID
         };
 

--- a/federwiegen-verleih.php
+++ b/federwiegen-verleih.php
@@ -201,8 +201,9 @@ function federwiegen_stripe_elements_form() {
             })
           });
           const result = await res.json();
-          if (!result.client_secret) {
-            document.getElementById('payment-message').textContent = 'Fehler: Kein client_secret erhalten.';
+          if (!result.client_secret || result.success === false) {
+            const msg = (result.data && result.data.message) || result.message || 'Fehler: Kein client_secret erhalten.';
+            document.getElementById('payment-message').textContent = msg;
             return;
           }
 

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -109,31 +109,14 @@ class Admin {
             array($this, 'analytics_page')
         );
 
+        // New settings menu with Stripe integration tab
         add_submenu_page(
             'federwiegen-verleih',
-            'Popup',
-            'Popup',
+            'Einstellungen',
+            'Einstellungen',
             'manage_options',
-            'federwiegen-popup',
-            array($this, 'popup_page')
-        );
-        
-        add_submenu_page(
-            'federwiegen-verleih',
-            'Branding',
-            'Branding',
-            'manage_options',
-            'federwiegen-branding',
-            array($this, 'branding_page')
-        );
-        
-        add_submenu_page(
-            'federwiegen-verleih',
-            'Debug',
-            'Debug',
-            'manage_options',
-            'federwiegen-debug',
-            array($this, 'debug_page')
+            'federwiegen-settings',
+            array($this, 'settings_page')
         );
     }
     
@@ -309,7 +292,6 @@ class Admin {
             $button_icon = esc_url_raw($_POST['button_icon']);
             $payment_icons = isset($_POST['payment_icons']) ? array_map('sanitize_text_field', (array) $_POST['payment_icons']) : array();
             $payment_icons = implode(',', $payment_icons);
-            $shipping_cost = floatval($_POST['shipping_cost']);
             $shipping_provider = sanitize_text_field($_POST['shipping_provider'] ?? '');
             $shipping_label = sanitize_text_field($_POST['shipping_label']);
             $price_label = sanitize_text_field($_POST['price_label']);
@@ -351,7 +333,6 @@ class Admin {
                         'button_text' => $button_text,
                         'button_icon' => $button_icon,
                         'payment_icons' => $payment_icons,
-                        'shipping_cost' => $shipping_cost,
                         'shipping_provider' => $shipping_provider,
                         'price_label' => $price_label,
                         'shipping_label' => $shipping_label,
@@ -367,7 +348,7 @@ class Admin {
                         'sort_order' => $sort_order,
                     ],
                     ['id' => intval($_POST['id'])],
-                    array('%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%f','%s','%s','%s','%s','%d','%s','%s','%s','%d','%d','%f','%s','%d'),
+                    array('%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%d','%s','%s','%s','%d','%d','%f','%s','%d'),
                 );
 
                 if ($result !== false) {
@@ -399,7 +380,6 @@ class Admin {
                         'button_text' => $button_text,
                         'button_icon' => $button_icon,
                         'payment_icons' => $payment_icons,
-                        'shipping_cost' => $shipping_cost,
                         'shipping_provider' => $shipping_provider,
                         'price_label' => $price_label,
                         'shipping_label' => $shipping_label,
@@ -414,7 +394,7 @@ class Admin {
                         'rating_link' => $rating_link,
                         'sort_order' => $sort_order,
                     ],
-                    array('%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%f','%s','%s','%s','%s','%d','%s','%s','%s','%d','%d','%f','%s','%d')
+                    array('%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%d','%s','%s','%s','%d','%d','%f','%s','%d')
                 );
 
                 if ($result !== false) {
@@ -577,15 +557,8 @@ class Admin {
         include FEDERWIEGEN_PLUGIN_PATH . 'admin/analytics-page.php';
     }
     
-    public function branding_page() {
-        include FEDERWIEGEN_PLUGIN_PATH . 'admin/branding-page.php';
+    public function settings_page() {
+        include FEDERWIEGEN_PLUGIN_PATH . 'admin/settings-page.php';
     }
 
-    public function debug_page() {
-        include FEDERWIEGEN_PLUGIN_PATH . 'admin/debug-page.php';
-    }
-
-    public function popup_page() {
-        include FEDERWIEGEN_PLUGIN_PATH . 'admin/popup-page.php';
-    }
 }

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -967,7 +967,11 @@ function federwiegen_create_subscription() {
             'payment_behavior' => 'default_incomplete',
             'payment_settings' => [
                 'payment_method_types' => ['card', 'paypal'],
-                'payment_method_configuration' => FEDERWIEGEN_PMC_ID,
+                'payment_method_options' => [
+                    'paypal' => [
+                        'payment_method_configuration' => FEDERWIEGEN_PMC_ID,
+                    ],
+                ],
             ],
             'expand' => ['latest_invoice.payment_intent'],
             'metadata' => [

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -92,7 +92,9 @@ class Ajax {
 
             $base_price = $variant_price + $extras_price;
             $discount = floatval($duration->discount);
-            $final_price = ($variant_price * (1 - $discount)) + $extras_price;
+            // Do not apply the discount to the calculated price. It is only used
+            // for displaying the badge on the duration option.
+            $final_price = $base_price;
             $shipping_cost = defined('FEDERWIEGEN_SHIPPING_COST')
                 ? floatval(constant('FEDERWIEGEN_SHIPPING_COST'))
                 : 0;

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -310,6 +310,12 @@ class Ajax {
                         ));
                         if ($extra) {
                             $extra->available = intval($option->available);
+                            if (!empty($extra->stripe_price_id)) {
+                                $amount = StripeService::get_price_amount($extra->stripe_price_id);
+                                if (!is_wp_error($amount)) {
+                                    $extra->price = $amount;
+                                }
+                            }
                             $extras[] = $extra;
                         }
                         break;
@@ -365,7 +371,15 @@ class Ajax {
                     "SELECT * FROM {$wpdb->prefix}federwiegen_extras WHERE category_id = %d ORDER BY sort_order",
                     $variant->category_id
                 ));
-                foreach ($extras as $e) { $e->available = 1; }
+                foreach ($extras as $e) {
+                    $e->available = 1;
+                    if (!empty($e->stripe_price_id)) {
+                        $amount = StripeService::get_price_amount($e->stripe_price_id);
+                        if (!is_wp_error($amount)) {
+                            $e->price = $amount;
+                        }
+                    }
+                }
             }
         }
 

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -966,13 +966,8 @@ function federwiegen_create_subscription() {
             'items' => $items,
             'payment_behavior' => 'default_incomplete',
             'payment_settings' => [
-                'payment_method_types' => ['card', 'paypal', 'sepa_debit'],
-                'payment_method_options' => [
-                    'paypal' => [
-                        'setup_future_usage' => 'off_session',
-                        'payment_method_configuration' => FEDERWIEGEN_PMC_ID,
-                    ],
-                ],
+                'payment_method_types' => ['card', 'paypal'],
+                'payment_method_configuration' => FEDERWIEGEN_PMC_ID,
             ],
             'expand' => ['latest_invoice.payment_intent'],
             'metadata' => [

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -858,12 +858,13 @@ function federwiegen_create_payment_intent() {
     try {
         $preis = intval($body['preis']);
         $beschreibung = sprintf(
-            '%s | Extra: %s | Abo: %s | Zustand: %s | Farbe: %s',
+            '%s | Extra: %s | Abo: %s | Zustand: %s | Produktfarbe: %s | Gestellfarbe: %s',
             sanitize_text_field($body['produkt']),
             sanitize_text_field($body['extra']),
             sanitize_text_field($body['dauer_name'] ?? $body['dauer']),
             sanitize_text_field($body['zustand']),
-            sanitize_text_field($body['farbe'])
+            sanitize_text_field($body['produktfarbe'] ?? $body['farbe']),
+            sanitize_text_field($body['gestellfarbe'] ?? '')
         );
 
         $intent = StripeService::create_payment_intent([
@@ -878,6 +879,8 @@ function federwiegen_create_payment_intent() {
                 'dauer_name'  => $body['dauer_name'] ?? '',
                 'zustand'     => $body['zustand'],
                 'farbe'       => $body['farbe'],
+                'produktfarbe' => $body['produktfarbe'] ?? '',
+                'gestellfarbe' => $body['gestellfarbe'] ?? '',
             ],
         ]);
         if (is_wp_error($intent)) {
@@ -959,6 +962,8 @@ function federwiegen_create_subscription() {
                 'dauer_name'  => $body['dauer_name'] ?? '',
                 'zustand'     => $body['zustand'] ?? '',
                 'farbe'       => $body['farbe'] ?? '',
+                'produktfarbe' => $body['produktfarbe'] ?? '',
+                'gestellfarbe' => $body['gestellfarbe'] ?? '',
                 'fullname'    => $body['fullname'] ?? '',
                 'email'       => $body['email'] ?? '',
                 'phone'       => $body['phone'] ?? '',

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -967,6 +967,12 @@ function federwiegen_create_subscription() {
             'payment_behavior' => 'default_incomplete',
             'payment_settings' => [
                 'payment_method_types' => ['card', 'paypal', 'sepa_debit'],
+                'payment_method_options' => [
+                    'paypal' => [
+                        'setup_future_usage' => 'off_session',
+                        'payment_method_configuration' => FEDERWIEGEN_PMC_ID,
+                    ],
+                ],
             ],
             'expand' => ['latest_invoice.payment_intent'],
             'metadata' => [

--- a/includes/Database.php
+++ b/includes/Database.php
@@ -24,6 +24,7 @@ class Database {
         // Add image columns to variants table if they don't exist
         $table_variants = $wpdb->prefix . 'federwiegen_variants';
         $columns_to_add = array(
+            'stripe_price_id' => 'VARCHAR(255) DEFAULT ""',
             'price_from' => 'DECIMAL(10,2) DEFAULT 0',
             'image_url_1' => 'TEXT',
             'image_url_2' => 'TEXT',
@@ -38,7 +39,8 @@ class Database {
         foreach ($columns_to_add as $column => $type) {
             $column_exists = $wpdb->get_results("SHOW COLUMNS FROM $table_variants LIKE '$column'");
             if (empty($column_exists)) {
-                $wpdb->query("ALTER TABLE $table_variants ADD COLUMN $column $type AFTER base_price");
+                $after = $column === 'stripe_price_id' ? 'name' : 'base_price';
+                $wpdb->query("ALTER TABLE $table_variants ADD COLUMN $column $type AFTER $after");
             }
         }
         
@@ -50,11 +52,15 @@ class Database {
             $wpdb->query("ALTER TABLE $table_variants DROP COLUMN image_url");
         }
         
-        // Add image_url column to extras table if it doesn't exist
+        // Add image_url and stripe_price_id columns to extras table if they don't exist
         $table_extras = $wpdb->prefix . 'federwiegen_extras';
         $extra_column_exists = $wpdb->get_results("SHOW COLUMNS FROM $table_extras LIKE 'image_url'");
         if (empty($extra_column_exists)) {
             $wpdb->query("ALTER TABLE $table_extras ADD COLUMN image_url TEXT AFTER price");
+        }
+        $price_id_exists = $wpdb->get_results("SHOW COLUMNS FROM $table_extras LIKE 'stripe_price_id'");
+        if (empty($price_id_exists)) {
+            $wpdb->query("ALTER TABLE $table_extras ADD COLUMN stripe_price_id VARCHAR(255) DEFAULT '' AFTER name");
         }
         
         // Create categories table if it doesn't exist
@@ -502,6 +508,7 @@ class Database {
             category_id mediumint(9) DEFAULT 1,
             name varchar(255) NOT NULL,
             description text,
+            stripe_price_id varchar(255) DEFAULT '',
             base_price decimal(10,2) NOT NULL,
             price_from decimal(10,2) DEFAULT 0,
             image_url_1 text,
@@ -517,12 +524,13 @@ class Database {
             PRIMARY KEY (id)
         ) $charset_collate;";
         
-        // Extras table (updated with image field and category_id)
+        // Extras table (updated with image field, category_id and Stripe price)
         $table_extras = $wpdb->prefix . 'federwiegen_extras';
         $sql_extras = "CREATE TABLE $table_extras (
             id mediumint(9) NOT NULL AUTO_INCREMENT,
             category_id mediumint(9) DEFAULT 1,
             name varchar(255) NOT NULL,
+            stripe_price_id varchar(255) DEFAULT '',
             price decimal(10,2) NOT NULL,
             image_url text,
             active tinyint(1) DEFAULT 1,
@@ -778,9 +786,9 @@ class Database {
         $existing_variants = $wpdb->get_var("SELECT COUNT(*) FROM {$wpdb->prefix}federwiegen_variants");
         if ($existing_variants == 0) {
             $variants = array(
-                array('Federwiege + Gestell & Motor', 'Komplettset mit stabilem Gestell und leisem Motor', 89.00),
-                array('Federwiege + Türklammer & Motor', 'Platzsparende Lösung mit praktischer Türklammer', 79.00),
-                array('Wiege + Gestell & Motor mit App-Steuerung', 'Premium-Variante mit smarter App-Steuerung', 119.00)
+                array('Federwiege + Gestell & Motor', 'Komplettset mit stabilem Gestell und leisem Motor', 'price_1QutK3RxDui5dUOqWEiBal7P'),
+                array('Federwiege + Türklammer & Motor', 'Platzsparende Lösung mit praktischer Türklammer', ''),
+                array('Wiege + Gestell & Motor mit App-Steuerung', 'Premium-Variante mit smarter App-Steuerung', '')
             );
             
             foreach ($variants as $index => $variant) {
@@ -790,7 +798,7 @@ class Database {
                         'category_id' => 1,
                         'name' => $variant[0],
                         'description' => $variant[1],
-                        'base_price' => $variant[2],
+                        'stripe_price_id' => $variant[2],
                         'price_from' => 0,
                         'image_url_1' => '',
                         'image_url_2' => '',
@@ -810,8 +818,8 @@ class Database {
         $existing_extras = $wpdb->get_var("SELECT COUNT(*) FROM {$wpdb->prefix}federwiegen_extras");
         if ($existing_extras == 0) {
             $extras = array(
-                array('Kein Extra', 0.00),
-                array('Himmel', 15.00)
+                array('Kein Extra', '' , 0.00),
+                array('Himmel', '', 15.00)
             );
             
             foreach ($extras as $index => $extra) {
@@ -820,7 +828,8 @@ class Database {
                     array(
                         'category_id' => 1,
                         'name' => $extra[0],
-                        'price' => $extra[1],
+                        'stripe_price_id' => $extra[1],
+                        'price' => $extra[2],
                         'image_url' => '',
                         'sort_order' => $index
                     )

--- a/includes/Database.php
+++ b/includes/Database.php
@@ -320,7 +320,26 @@ class Database {
                 PRIMARY KEY (id),
                 UNIQUE KEY variant_option (variant_id, option_type, option_id)
             ) $charset_collate;";
-            
+
+            require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
+            dbDelta($sql);
+        }
+
+        // Create duration price table if it doesn't exist
+        $table_duration_prices = $wpdb->prefix . 'federwiegen_duration_prices';
+        $duration_prices_exists = $wpdb->get_var("SHOW TABLES LIKE '$table_duration_prices'");
+
+        if (!$duration_prices_exists) {
+            $charset_collate = $wpdb->get_charset_collate();
+            $sql = "CREATE TABLE $table_duration_prices (
+                id mediumint(9) NOT NULL AUTO_INCREMENT,
+                duration_id mediumint(9) NOT NULL,
+                variant_id mediumint(9) NOT NULL,
+                stripe_price_id varchar(255) DEFAULT '',
+                PRIMARY KEY (id),
+                UNIQUE KEY duration_variant (duration_id, variant_id)
+            ) $charset_collate;";
+
             require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
             dbDelta($sql);
         }
@@ -651,6 +670,17 @@ class Database {
             PRIMARY KEY (id),
             UNIQUE KEY variant_option (variant_id, option_type, option_id)
         ) $charset_collate;";
+
+        // Variant price IDs per duration
+        $table_duration_prices = $wpdb->prefix . 'federwiegen_duration_prices';
+        $sql_duration_prices = "CREATE TABLE $table_duration_prices (
+            id mediumint(9) NOT NULL AUTO_INCREMENT,
+            duration_id mediumint(9) NOT NULL,
+            variant_id mediumint(9) NOT NULL,
+            stripe_price_id varchar(255) DEFAULT '',
+            PRIMARY KEY (id),
+            UNIQUE KEY duration_variant (duration_id, variant_id)
+        ) $charset_collate;";
         
         // Orders table
         $table_orders = $wpdb->prefix . 'federwiegen_orders';
@@ -688,6 +718,7 @@ class Database {
         dbDelta($sql_colors);
         dbDelta($sql_color_variant_images);
         dbDelta($sql_variant_options);
+        dbDelta($sql_duration_prices);
         dbDelta($sql_orders);
 
         // Notifications table

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -331,6 +331,8 @@ class Plugin {
             'dauer_name'  => sanitize_text_field($_POST['dauer_name'] ?? ''),
             'zustand'     => sanitize_text_field($_POST['zustand'] ?? ''),
             'farbe'       => sanitize_text_field($_POST['farbe'] ?? ''),
+            'produktfarbe' => sanitize_text_field($_POST['produktfarbe'] ?? ''),
+            'gestellfarbe' => sanitize_text_field($_POST['gestellfarbe'] ?? ''),
             'preis'       => intval($_POST['preis'] ?? 0),
             'shipping'    => intval($_POST['shipping'] ?? 0),
             'variant_id'  => intval($_POST['variant_id'] ?? 0),

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -333,6 +333,9 @@ class Plugin {
             'farbe'       => sanitize_text_field($_POST['farbe'] ?? ''),
             'preis'       => intval($_POST['preis'] ?? 0),
             'shipping'    => intval($_POST['shipping'] ?? 0),
+            'variant_id'  => intval($_POST['variant_id'] ?? 0),
+            'duration_id' => intval($_POST['duration_id'] ?? 0),
+            'price_id'    => sanitize_text_field($_POST['price_id'] ?? ''),
         ];
 
         $checkout_url = self::get_checkout_page_url();

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -45,6 +45,9 @@ class Plugin {
 
         add_filter('admin_footer_text', [$this->admin, 'custom_admin_footer']);
         add_action('admin_head', [$this->admin, 'custom_admin_styles']);
+
+        // Handle "Jetzt mieten" form submissions before headers are sent
+        add_action('template_redirect', [$this, 'handle_rent_request']);
     }
 
     public function check_for_updates() {
@@ -234,7 +237,7 @@ class Plugin {
         }
 
         $variants = $wpdb->get_results($wpdb->prepare(
-            "SELECT * FROM {$wpdb->prefix}federwiegen_variants WHERE category_id = %d ORDER BY base_price",
+            "SELECT * FROM {$wpdb->prefix}federwiegen_variants WHERE category_id = %d ORDER BY sort_order",
             $category->id
         ));
 
@@ -242,8 +245,20 @@ class Plugin {
             return;
         }
 
-        $min_price = $variants[0]->base_price;
-        $max_price = end($variants)->base_price;
+        $prices = array();
+        foreach ($variants as $v) {
+            if (!empty($v->stripe_price_id)) {
+                $p = StripeService::get_price_amount($v->stripe_price_id);
+                if (!is_wp_error($p)) {
+                    $prices[] = $p;
+                }
+            }
+        }
+        if (empty($prices)) {
+            return;
+        }
+        $min_price = min($prices);
+        $max_price = max($prices);
 
         $schema = [
             '@context' => 'https://schema.org',
@@ -298,5 +313,54 @@ class Plugin {
         echo '<script type="application/ld+json">' . "\n";
         echo json_encode($schema, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
         echo "\n" . '</script>' . "\n";
+    }
+
+    /**
+     * Handle the product form submission and redirect to the checkout page
+     * before any output is sent to the browser.
+     */
+    public function handle_rent_request() {
+        if (empty($_POST['jetzt_mieten'])) {
+            return;
+        }
+
+        $params = [
+            'produkt'     => sanitize_text_field($_POST['produkt'] ?? ''),
+            'extra'       => sanitize_text_field($_POST['extra'] ?? ''),
+            'dauer'       => intval($_POST['dauer'] ?? 0),
+            'dauer_name'  => sanitize_text_field($_POST['dauer_name'] ?? ''),
+            'zustand'     => sanitize_text_field($_POST['zustand'] ?? ''),
+            'farbe'       => sanitize_text_field($_POST['farbe'] ?? ''),
+            'preis'       => intval($_POST['preis'] ?? 0),
+            'shipping'    => intval($_POST['shipping'] ?? 0),
+        ];
+
+        $checkout_url = self::get_checkout_page_url();
+        if (!$checkout_url) {
+            $checkout_url = site_url('/zahlung/');
+        }
+        $checkout_url = add_query_arg($params, $checkout_url);
+        wp_safe_redirect($checkout_url);
+        exit;
+    }
+
+    /**
+     * Find the page containing the checkout shortcode and return its URL.
+     * Returns null if no such page is found.
+     */
+    public static function get_checkout_page_url() {
+        $pages = get_posts([
+            'post_type'      => 'page',
+            'post_status'    => 'publish',
+            'posts_per_page' => -1,
+        ]);
+
+        foreach ($pages as $page) {
+            if (has_shortcode($page->post_content, 'stripe_elements_form')) {
+                return get_permalink($page->ID);
+            }
+        }
+
+        return null;
     }
 }

--- a/includes/StripeService.php
+++ b/includes/StripeService.php
@@ -54,6 +54,19 @@ class StripeService {
         return \Stripe\Subscription::create($params);
     }
 
+    public static function get_price_amount($price_id) {
+        $init = self::init();
+        if (is_wp_error($init)) {
+            return $init;
+        }
+        try {
+            $price = \Stripe\Price::retrieve($price_id);
+            return $price->unit_amount / 100;
+        } catch (\Exception $e) {
+            return new \WP_Error('stripe_price', $e->getMessage());
+        }
+    }
+
     public static function get_publishable_key() {
         return get_option('federwiegen_stripe_publishable_key', '');
     }

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -360,6 +360,8 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
                         <input type="hidden" name="dauer_name" id="federwiegen-field-dauer-name">
                         <input type="hidden" name="zustand" id="federwiegen-field-zustand">
                         <input type="hidden" name="farbe" id="federwiegen-field-farbe">
+                        <input type="hidden" name="produktfarbe" id="federwiegen-field-produktfarbe">
+                        <input type="hidden" name="gestellfarbe" id="federwiegen-field-gestellfarbe">
                         <input type="hidden" name="preis" id="federwiegen-field-preis">
                         <input type="hidden" name="shipping" id="federwiegen-field-shipping">
                         <input type="hidden" name="variant_id" id="federwiegen-field-variant-id">

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -362,6 +362,9 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
                         <input type="hidden" name="farbe" id="federwiegen-field-farbe">
                         <input type="hidden" name="preis" id="federwiegen-field-preis">
                         <input type="hidden" name="shipping" id="federwiegen-field-shipping">
+                        <input type="hidden" name="variant_id" id="federwiegen-field-variant-id">
+                        <input type="hidden" name="duration_id" id="federwiegen-field-duration-id">
+                        <input type="hidden" name="price_id" id="federwiegen-field-price-id">
                         <input type="hidden" name="jetzt_mieten" value="1">
                     <div class="federwiegen-availability-wrapper" id="federwiegen-availability-wrapper" style="display:none;">
                         <div id="federwiegen-availability-status" class="federwiegen-availability-status available">


### PR DESCRIPTION
## Summary
- allow editing Stripe price IDs for extras in admin forms
- show extra prices by looking up Stripe prices
- store extras with `stripe_price_id` in the database
- fetch extra prices from Stripe in AJAX calculations

## Testing
- ❌ `php -l includes/Database.php` (failed to run: command not found)
- ❌ `php -l admin/extras-page.php` (failed to run: command not found)
- ❌ `php -l templates/product-page.php` (failed to run: command not found)


------
https://chatgpt.com/codex/tasks/task_b_6868fee1e2e883309a4bced20fc18b65