### PR TITLE
Add modern admin UI styles

### DIFF
--- a/admin/main-page.php
+++ b/admin/main-page.php
@@ -36,19 +36,19 @@ foreach ($branding_results as $result) {
     
     <!-- Kompakte Statistiken -->
     <div class="produkt-stats-compact">
-        <div class="produkt-stat-item">
+        <div class="stat-card">
             <div class="produkt-stat-number"><?php echo $categories_count; ?></div>
             <div class="produkt-stat-label">Kategorien</div>
         </div>
-        <div class="produkt-stat-item">
+        <div class="stat-card">
             <div class="produkt-stat-number"><?php echo $variants_count; ?></div>
             <div class="produkt-stat-label">Ausführungen</div>
         </div>
-        <div class="produkt-stat-item">
+        <div class="stat-card">
             <div class="produkt-stat-number"><?php echo $extras_count; ?></div>
             <div class="produkt-stat-label">Extras</div>
         </div>
-        <div class="produkt-stat-item">
+        <div class="stat-card">
             <div class="produkt-stat-number"><?php echo $durations_count; ?></div>
             <div class="produkt-stat-label">Mietdauern</div>
         </div>
@@ -181,7 +181,7 @@ foreach ($branding_results as $result) {
     margin-bottom: 30px;
 }
 
-.produkt-stat-item {
+.stat-card {
     background: white;
     border: 1px solid #ddd;
     border-radius: 8px;

--- a/admin/orders-page.php
+++ b/admin/orders-page.php
@@ -349,6 +349,7 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
 function showOrderDetails(orderId) {
     // Find order data from PHP
     const orders = <?php echo json_encode($orders); ?>;
+    const orderLogs = <?php echo json_encode($order_logs); ?>;
     const order = orders.find(o => o.id == orderId);
     
     if (!order) return;
@@ -393,11 +394,21 @@ function showOrderDetails(orderId) {
     
     detailsHtml += `
         </ul>
-        
-        
+
+
         <h4>🖥️ Technische Daten</h4>
         <p><strong>User Agent:</strong> ${order.user_agent}</p>
     `;
+
+    const logs = orderLogs[order.id] || [];
+    if (logs.length) {
+        detailsHtml += '<h4>📑 Verlauf</h4><ul>';
+        logs.forEach(l => {
+            const date = new Date(l.created_at).toLocaleString('de-DE');
+            detailsHtml += `<li>[${date}] ${l.event}${l.message ? ' - ' + l.message : ''}</li>`;
+        });
+        detailsHtml += '</ul>';
+    }
     
     document.getElementById('order-details-content').innerHTML = detailsHtml;
     document.getElementById('order-details-modal').style.display = 'block';

--- a/admin/orders-page.php
+++ b/admin/orders-page.php
@@ -144,7 +144,7 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
         </div>
         <?php else: ?>
         
-        <div style="overflow-x: auto;">
+        <div class="table-responsive">
             <table class="wp-list-table widefat fixed striped">
                 <thead>
                     <tr>
@@ -225,11 +225,11 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
                         </td>
                         <td>
                             <?php if ($order->status === 'offen'): ?>
-                                <span style="color: #dc3232; font-weight: bold;">🕓 Offen</span>
+                                <span class="badge badge-warning">Offen</span>
                             <?php elseif ($order->status === 'gekündigt'): ?>
-                                <span style="color: #757575; font-weight: bold;">❌ Gekündigt</span>
+                                <span class="badge badge-danger">Gekündigt</span>
                             <?php else: ?>
-                                <span style="color: #2e7d32; font-weight: bold;">✅ Abgeschlossen</span>
+                                <span class="badge badge-success">Abgeschlossen</span>
                             <?php endif; ?>
                         </td>
                         <td>
@@ -310,12 +310,13 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
 </div>
 
 <!-- Order Details Modal -->
-<div id="order-details-modal" style="display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); z-index: 10000;">
-    <div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); background: white; border-radius: 8px; padding: 30px; max-width: 600px; width: 90%; max-height: 80%; overflow-y: auto;">
+<div id="order-details-modal" class="modal-overlay">
+    <div class="modal-content">
+        <button type="button" class="modal-close" onclick="closeOrderDetails()">&times;</button>
         <h3 style="margin-top: 0;">📋 Bestelldetails</h3>
         <div id="order-details-content"></div>
         <div style="text-align: right; margin-top: 20px;">
-            <button type="button" class="button button-primary" onclick="closeOrderDetails()">Schließen</button>
+            <button type="button" class="button-primary" onclick="closeOrderDetails()">Schließen</button>
         </div>
     </div>
 </div>

--- a/admin/orders-page.php
+++ b/admin/orders-page.php
@@ -215,6 +215,9 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
                                 <?php echo number_format($order->final_price, 2, ',', '.'); ?>€
                             </strong><br>
                             <small style="color: #666;">/Monat</small>
+                            <?php if ($order->shipping_cost > 0): ?>
+                                <br><span style="color:#666;">+ <?php echo number_format($order->shipping_cost, 2, ',', '.'); ?>€ einmalig</span>
+                            <?php endif; ?>
                         </td>
                         <td>
                             <?php if ($order->discount_amount > 0): ?>
@@ -361,6 +364,7 @@ function showOrderDetails(orderId) {
                 <p><strong>Bestellnummer:</strong> #${order.id}</p>
                 <p><strong>Datum:</strong> ${new Date(order.created_at).toLocaleString('de-DE')}</p>
                 <p><strong>Preis:</strong> ${parseFloat(order.final_price).toFixed(2).replace('.', ',')}€/Monat</p>
+                ${order.shipping_cost > 0 ? `<p><strong>Versand:</strong> ${parseFloat(order.shipping_cost).toFixed(2).replace('.', ',')}€ (einmalig)</p>` : ''}
                 <p><strong>Rabatt:</strong> ${order.discount_amount > 0 ? '-'+parseFloat(order.discount_amount).toFixed(2).replace('.', ',')+'€' : '–'}</p>
             </div>
             <div>

--- a/assets/admin-style.css
+++ b/assets/admin-style.css
@@ -1,3 +1,11 @@
+:root {
+    --pv-gray-light: #f8f9fa;
+    --pv-gray: #e9ecef;
+    --pv-blue: #007cba;
+    --pv-green: #28a745;
+    --pv-red: #dc3545;
+}
+
 @charset "UTF-8";
 /* Admin Styles for Produkt Verleih Plugin */
 .produkt-admin-dashboard {
@@ -139,26 +147,26 @@
 
 .produkt-nav-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 10px;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 15px;
 }
 
 .produkt-nav-item {
     display: flex;
     align-items: center;
     gap: 10px;
-    padding: 10px 15px;
-    background: #f8f9fa;
-    border: 1px solid #e9ecef;
-    border-radius: 6px;
+    padding: 20px;
+    background: var(--pv-gray-light);
+    border: 1px solid var(--pv-gray);
+    border-radius: 8px;
     text-decoration: none;
     color: #3c434a;
-    transition: all 0.2s ease;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .produkt-nav-item:hover {
-    background: var(--produkt-primary);
-    color: var(--produkt-text);
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
     text-decoration: none;
 }
 
@@ -662,6 +670,12 @@
     }
     
     .produkt-nav-grid {
+        grid-template-columns: 1fr 1fr;
+    }
+}
+
+@media (max-width: 480px) {
+    .produkt-nav-grid {
         grid-template-columns: 1fr;
     }
 }
@@ -778,4 +792,128 @@
     font-size: 1rem;
     font-weight: 600;
     color: #2a372a;
+}
+/* Modern UI Enhancements */
+.navigation-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 15px;
+    margin-bottom: 30px;
+}
+.navigation-grid a {
+    background: var(--pv-gray-light);
+    border: 1px solid var(--pv-gray);
+    border-radius: 8px;
+    padding: 20px;
+    text-align: center;
+    text-decoration: none;
+    color: #3c434a;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+.navigation-grid a:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+}
+.navigation-grid a .dashicons {
+    font-size: 24px;
+    margin-bottom: 8px;
+}
+
+.stat-card {
+    background: white;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    padding: 20px;
+    text-align: center;
+}
+
+/* Badges */
+.badge {
+    display: inline-block;
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 12px;
+    font-weight: 600;
+}
+.badge-success { background: var(--pv-green); color: white; }
+.badge-warning { background: #ffc107; color: #212529; }
+.badge-danger { background: var(--pv-red); color: white; }
+
+/* Buttons */
+.button-primary {
+    background: var(--pv-blue);
+    border: none;
+    color: white;
+    padding: 10px 16px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-weight: 600;
+}
+.button-primary:hover {
+    background: #0063a5;
+}
+.button-danger {
+    background: var(--pv-red);
+    border: none;
+    color: white;
+}
+
+/* Modal */
+.modal-overlay {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0,0,0,0.5);
+    z-index: 10000;
+}
+.modal-content {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: white;
+    border-radius: 8px;
+    padding: 30px;
+    max-height: 80%;
+    overflow-y: auto;
+    width: 90%;
+    max-width: 600px;
+}
+.modal-close {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: transparent;
+    border: none;
+    font-size: 20px;
+    cursor: pointer;
+}
+
+/* Responsive tables */
+.table-responsive {
+    overflow-x: auto;
+}
+.table-responsive table {
+    width: 100%;
+    border-collapse: collapse;
+}
+.table-responsive th,
+.table-responsive td {
+    padding: 12px 8px;
+    border-bottom: 1px solid #ddd;
+}
+
+@media (max-width: 768px) {
+    .navigation-grid {
+        grid-template-columns: 1fr 1fr;
+    }
+}
+
+@media (max-width: 480px) {
+    .navigation-grid {
+        grid-template-columns: 1fr;
+    }
 }

--- a/assets/style.css
+++ b/assets/style.css
@@ -743,7 +743,7 @@
     height: 0.6rem;
     border-radius: 50%;
     margin-right: 0.4rem;
-    background: var(--produkt-text-color);
+    background: #28a745;
 }
 
 .produkt-availability-status.unavailable {

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -553,6 +553,16 @@ class Admin {
             $branding[$result->setting_key] = $result->setting_value;
         }
 
+        $order_logs = [];
+        foreach ($orders as $o) {
+            $order_logs[$o->id] = $wpdb->get_results(
+                $wpdb->prepare(
+                    "SELECT event, message, created_at FROM {$wpdb->prefix}produkt_order_logs WHERE order_id = %d ORDER BY created_at",
+                    $o->id
+                )
+            );
+        }
+
         $this->load_template('orders', compact(
             'categories',
             'selected_category',
@@ -560,6 +570,7 @@ class Admin {
             'date_to',
             'current_category',
             'orders',
+            'order_logs',
             'total_orders',
             'total_revenue',
             'avg_order_value',

--- a/includes/Database.php
+++ b/includes/Database.php
@@ -384,7 +384,9 @@ class Database {
                 product_color_id mediumint(9) DEFAULT NULL,
                 frame_color_id mediumint(9) DEFAULT NULL,
                 final_price decimal(10,2) NOT NULL,
+                shipping_cost decimal(10,2) DEFAULT 0,
                 stripe_session_id varchar(255) DEFAULT '',
+                stripe_subscription_id varchar(255) DEFAULT '',
                 amount_total int DEFAULT 0,
                 discount_amount decimal(10,2) DEFAULT 0,
                 produkt_name varchar(255) DEFAULT '',
@@ -423,6 +425,7 @@ class Database {
                 'customer_postal'   => "varchar(20) DEFAULT ''",
                 'customer_city'     => "varchar(100) DEFAULT ''",
                 'customer_country'  => "varchar(2) DEFAULT ''",
+                'shipping_cost'     => 'decimal(10,2) DEFAULT 0',
                 'status'            => "varchar(20) DEFAULT 'offen'"
             );
 
@@ -744,6 +747,7 @@ class Database {
             product_color_id mediumint(9) DEFAULT NULL,
             frame_color_id mediumint(9) DEFAULT NULL,
             final_price decimal(10,2) NOT NULL,
+            shipping_cost decimal(10,2) DEFAULT 0,
             stripe_session_id varchar(255) DEFAULT '',
             stripe_subscription_id varchar(255) DEFAULT '',
             amount_total int DEFAULT 0,

--- a/includes/Database.php
+++ b/includes/Database.php
@@ -514,6 +514,25 @@ class Database {
         if (empty($availability_column)) {
             $wpdb->query("ALTER TABLE $table_variant_options ADD COLUMN available TINYINT(1) DEFAULT 1 AFTER option_id");
         }
+
+        // Create order logs table if it doesn't exist
+        $table_logs = $wpdb->prefix . 'produkt_order_logs';
+        $logs_exists = $wpdb->get_var("SHOW TABLES LIKE '$table_logs'");
+        if (!$logs_exists) {
+            $charset_collate = $wpdb->get_charset_collate();
+            $sql = "CREATE TABLE $table_logs (
+                id mediumint(9) NOT NULL AUTO_INCREMENT,
+                order_id mediumint(9) NOT NULL,
+                event varchar(50) NOT NULL,
+                message text DEFAULT '',
+                created_at datetime DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (id),
+                KEY order_id (order_id)
+            ) $charset_collate;";
+
+            require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
+            dbDelta($sql);
+        }
     }
     
     public function create_tables() {
@@ -800,6 +819,20 @@ class Database {
         ) $charset_collate;";
 
         dbDelta($sql_notifications);
+
+        // Order logs table
+        $table_logs = $wpdb->prefix . 'produkt_order_logs';
+        $sql_logs = "CREATE TABLE $table_logs (
+            id mediumint(9) NOT NULL AUTO_INCREMENT,
+            order_id mediumint(9) NOT NULL,
+            event varchar(50) NOT NULL,
+            message text DEFAULT '',
+            created_at datetime DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (id),
+            KEY order_id (order_id)
+        ) $charset_collate;";
+
+        dbDelta($sql_logs);
     }
     
     public function insert_default_data() {

--- a/includes/Webhook.php
+++ b/includes/Webhook.php
@@ -177,8 +177,12 @@ function send_produkt_welcome_email(array $order, int $order_id) {
 
     $address = trim($order['customer_street'] . ', ' . $order['customer_postal'] . ' ' . $order['customer_city']);
 
-    $message  = '<html><body style="font-family:Arial,sans-serif;color:#333;">';
-    $message .= '<h2 style="color:#007cba;">Herzlich willkommen und vielen Dank für Ihre Bestellung!</h2>';
+    $site_title = get_bloginfo('name');
+    $message  = '<html><body style="font-family:Arial,sans-serif;color:#333;margin:0;padding:0;">';
+    $message .= '<div style="max-width:600px;margin:auto;">';
+    $message .= '<div style="background:#007cba;color:#fff;padding:20px;text-align:center;font-size:20px;font-weight:bold;">' . esc_html($site_title) . '</div>';
+    $message .= '<div style="padding:20px;">';
+    $message .= '<h2 style="color:#007cba;margin-top:0;">Herzlich willkommen und vielen Dank für Ihre Bestellung!</h2>';
     $message .= '<p>Hallo ' . esc_html($first . ' ' . $last) . ',</p>';
     $message .= '<p>herzlichen Dank für Ihre Bestellung!<br>Wir freuen uns sehr, Sie als neuen Kunden begrüßen zu dürfen.</p>';
 
@@ -211,6 +215,9 @@ function send_produkt_welcome_email(array $order, int $order_id) {
     $message .= '</table>';
 
     $message .= '<p>Bitte prüfen Sie die Angaben und antworten Sie auf diese E-Mail, falls Sie Fragen oder Änderungswünsche haben.</p>';
+    $message .= '</div>';
+    $message .= '<div style="background:#f8f9fa;color:#555;padding:20px;text-align:center;font-size:12px;">Kleine Helden Verleih GbR<br>Kadir Üner &amp; Tim Braunleder<br>Siegenkamp 28<br>52499 Baesweiler</div>';
+    $message .= '</div>';
     $message .= '</body></html>';
 
     $headers = ['Content-Type: text/html; charset=UTF-8'];
@@ -230,8 +237,12 @@ function send_admin_order_email(array $order, int $order_id, string $session_id)
 
     $address = trim($order['customer_street'] . ', ' . $order['customer_postal'] . ' ' . $order['customer_city'] . ', ' . $order['customer_country']);
 
-    $message  = '<html><body style="font-family:Arial,sans-serif;color:#333;">';
-    $message .= '<h2 style="color:#007cba;">Neue Bestellung eingegangen</h2>';
+    $site_title = get_bloginfo('name');
+    $message  = '<html><body style="font-family:Arial,sans-serif;color:#333;margin:0;padding:0;">';
+    $message .= '<div style="max-width:600px;margin:auto;">';
+    $message .= '<div style="background:#007cba;color:#fff;padding:20px;text-align:center;font-size:20px;font-weight:bold;">' . esc_html($site_title) . '</div>';
+    $message .= '<div style="padding:20px;">';
+    $message .= '<h2 style="color:#007cba;margin-top:0;">Neue Bestellung eingegangen</h2>';
 
     $message .= '<h3>Bestelldetails</h3>';
     $message .= '<table style="width:100%;border-collapse:collapse;">';
@@ -263,6 +274,9 @@ function send_admin_order_email(array $order, int $order_id, string $session_id)
     $message .= '</table>';
 
     $message .= '<p>Session-ID: ' . esc_html($session_id) . '</p>';
+    $message .= '</div>';
+    $message .= '<div style="background:#f8f9fa;color:#555;padding:20px;text-align:center;font-size:12px;">Kleine Helden Verleih GbR<br>Kadir Üner &amp; Tim Braunleder<br>Siegenkamp 28<br>52499 Baesweiler</div>';
+    $message .= '</div>';
     $message .= '</body></html>';
 
     $headers = ['Content-Type: text/html; charset=UTF-8'];


### PR DESCRIPTION
## Summary
- modernize navigation grid and item styles
- add color variables and new utility classes for badges, buttons and modals
- implement responsive table container and stat cards
- update Orders and Dashboard pages to use new classes

## Testing
- `php -l admin/orders-page.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_686b9a8775108330b0ddbfe3ff32ba0d