### PR TITLE
Replace Kategorie text with Produkt

### DIFF
--- a/admin/branding-page.php
+++ b/admin/branding-page.php
@@ -112,7 +112,7 @@ foreach ($results as $result) {
             </a>
             <a href="<?php echo admin_url('admin.php?page=produkt-categories'); ?>" class="produkt-nav-item">
                 <span class="dashicons dashicons-category"></span>
-                Kategorien
+                Produkte
             </a>
             <a href="<?php echo admin_url('admin.php?page=produkt-variants'); ?>" class="produkt-nav-item">
                 <span class="dashicons dashicons-images-alt2"></span>

--- a/admin/categories-page.php
+++ b/admin/categories-page.php
@@ -9,8 +9,8 @@ if (!defined('ABSPATH')) {
     <div class="produkt-admin-header-compact">
         <div class="produkt-admin-logo-compact">🏷️</div>
         <div class="produkt-admin-title-compact">
-            <h1>Kategorien verwalten</h1>
-            <p>Produktkategorien & SEO-Einstellungen</p>
+            <h1>Produkte verwalten</h1>
+            <p>Produkte & SEO-Einstellungen</p>
         </div>
     </div>
     
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
     <div class="produkt-breadcrumb">
         <a href="<?php echo admin_url('admin.php?page=produkt-verleih'); ?>">Dashboard</a> 
         <span>→</span> 
-        <strong>Kategorien</strong>
+        <strong>Produkte</strong>
     </div>
     
     <!-- Tab Navigation -->
@@ -29,7 +29,7 @@ if (!defined('ABSPATH')) {
         </a>
         <a href="<?php echo admin_url('admin.php?page=produkt-categories&tab=add'); ?>" 
            class="produkt-tab <?php echo $active_tab === 'add' ? 'active' : ''; ?>">
-            ➕ Neue Kategorie
+            ➕ Neues Produkt
         </a>
         <?php if ($edit_item): ?>
         <a href="<?php echo admin_url('admin.php?page=produkt-categories&tab=edit&edit=' . $edit_item->id); ?>" 

--- a/admin/colors-page.php
+++ b/admin/colors-page.php
@@ -166,7 +166,7 @@ $frame_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHE
         <form method="get" action="">
             <input type="hidden" name="page" value="produkt-colors">
             <input type="hidden" name="tab" value="<?php echo esc_attr($active_tab); ?>">
-            <label for="category-select"><strong>🏷️ Kategorie:</strong></label>
+            <label for="category-select"><strong>🏷️ Produkt:</strong></label>
             <select name="category" id="category-select" onchange="this.form.submit()">
                 <?php foreach ($categories as $category): ?>
                 <option value="<?php echo $category->id; ?>" <?php selected($selected_category, $category->id); ?>>

--- a/admin/conditions-page.php
+++ b/admin/conditions-page.php
@@ -115,7 +115,7 @@ $conditions = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE
         <form method="get" action="">
             <input type="hidden" name="page" value="produkt-conditions">
             <input type="hidden" name="tab" value="<?php echo esc_attr($active_tab); ?>">
-            <label for="category-select"><strong>🏷️ Kategorie:</strong></label>
+            <label for="category-select"><strong>🏷️ Produkt:</strong></label>
             <select name="category" id="category-select" onchange="this.form.submit()">
                 <?php foreach ($categories as $category): ?>
                 <option value="<?php echo $category->id; ?>" <?php selected($selected_category, $category->id); ?>>
@@ -261,11 +261,11 @@ $conditions = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE
                     <p>Verwalten Sie Produktzustände (Neu/Aufbereitet) mit individuellen Preisanpassungen.</p>
                     
                     <div class="produkt-list-card">
-                        <h4>Zustände für: <?php echo $current_category ? esc_html($current_category->name) : 'Unbekannte Kategorie'; ?></h4>
+                        <h4>Zustände für: <?php echo $current_category ? esc_html($current_category->name) : 'Unbekanntes Produkt'; ?></h4>
                         
                         <?php if (empty($conditions)): ?>
                         <div class="produkt-empty-state">
-                            <p>Noch keine Zustände für diese Kategorie vorhanden.</p>
+                            <p>Noch keine Zustände für dieses Produkt vorhanden.</p>
                             <p><strong>Tipp:</strong> Fügen Sie einen neuen Zustand hinzu!</p>
                         </div>
                         <?php else: ?>

--- a/admin/durations-page.php
+++ b/admin/durations-page.php
@@ -141,7 +141,7 @@ $variants = $wpdb->get_results($wpdb->prepare("SELECT id, name, stripe_price_id 
         <form method="get" action="">
             <input type="hidden" name="page" value="produkt-durations">
             <input type="hidden" name="tab" value="<?php echo esc_attr($active_tab); ?>">
-            <label for="category-select"><strong>🏷️ Kategorie:</strong></label>
+            <label for="category-select"><strong>🏷️ Produkt:</strong></label>
             <select name="category" id="category-select" onchange="this.form.submit()">
                 <?php foreach ($categories as $category): ?>
                 <option value="<?php echo $category->id; ?>" <?php selected($selected_category, $category->id); ?>>

--- a/admin/extras-page.php
+++ b/admin/extras-page.php
@@ -135,7 +135,7 @@ $extras = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE cat
         <form method="get" action="">
             <input type="hidden" name="page" value="produkt-extras">
             <input type="hidden" name="tab" value="<?php echo esc_attr($active_tab); ?>">
-            <label for="category-select"><strong>🏷️ Kategorie:</strong></label>
+            <label for="category-select"><strong>🏷️ Produkt:</strong></label>
             <select name="category" id="category-select" onchange="this.form.submit()">
                 <?php foreach ($categories as $category): ?>
                 <option value="<?php echo $category->id; ?>" <?php selected($selected_category, $category->id); ?>>

--- a/admin/main-page.php
+++ b/admin/main-page.php
@@ -38,7 +38,7 @@ foreach ($branding_results as $result) {
     <div class="produkt-stats-compact">
         <div class="stat-card">
             <div class="produkt-stat-number"><?php echo $categories_count; ?></div>
-            <div class="produkt-stat-label">Kategorien</div>
+            <div class="produkt-stat-label">Produkte</div>
         </div>
         <div class="stat-card">
             <div class="produkt-stat-number"><?php echo $variants_count; ?></div>
@@ -61,8 +61,8 @@ foreach ($branding_results as $result) {
             <a href="<?php echo admin_url('admin.php?page=produkt-categories'); ?>" class="produkt-nav-card">
                 <div class="produkt-nav-icon">🏷️</div>
                 <div class="produkt-nav-content">
-                    <h4>Kategorien</h4>
-                    <p>Produktkategorien & SEO-Einstellungen</p>
+                    <h4>Produkte</h4>
+                    <p>Produkte & SEO-Einstellungen</p>
                 </div>
             </a>
             
@@ -123,9 +123,9 @@ foreach ($branding_results as $result) {
         <h3>💡 Erste Schritte</h3>
         <div class="produkt-help-cards">
             <div class="produkt-help-card">
-                <h4>1. Kategorie erstellen</h4>
-                <p>Erstellen Sie eine neue Produktkategorie mit SEO-Einstellungen</p>
-                <a href="<?php echo admin_url('admin.php?page=produkt-categories'); ?>" class="button">Kategorien →</a>
+                <h4>1. Produkt erstellen</h4>
+                <p>Erstellen Sie ein neues Produkt mit SEO-Einstellungen</p>
+                <a href="<?php echo admin_url('admin.php?page=produkt-categories'); ?>" class="button">Produkte →</a>
             </div>
             <div class="produkt-help-card">
                 <h4>2. Ausführungen hinzufügen</h4>

--- a/admin/orders-page.php
+++ b/admin/orders-page.php
@@ -47,7 +47,7 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
             </a>
             <a href="<?php echo admin_url('admin.php?page=produkt-categories'); ?>" class="produkt-nav-item">
                 <span class="dashicons dashicons-category"></span>
-                Kategorien
+                Produkte
             </a>
         </div>
     </div>
@@ -59,9 +59,9 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
             <input type="hidden" name="page" value="produkt-orders">
             
             <div>
-                <label for="category-select"><strong>Kategorie:</strong></label>
+                <label for="category-select"><strong>Produkt:</strong></label>
                 <select name="category" id="category-select" style="min-width: 200px;">
-                    <option value="0" <?php selected($selected_category, 0); ?>>Alle Kategorien</option>
+                    <option value="0" <?php selected($selected_category, 0); ?>>Alle Produkte</option>
                     <?php foreach ($categories as $category): ?>
                     <option value="<?php echo $category->id; ?>" <?php selected($selected_category, $category->id); ?>>
                         <?php echo esc_html($category->name); ?>
@@ -85,7 +85,7 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
         
         <?php if ($current_category): ?>
         <div style="margin-top: 10px; padding: 10px; background: white; border-radius: 4px;">
-            <strong>📝 Aktuelle Kategorie:</strong> <?php echo esc_html($current_category->name); ?>
+            <strong>📝 Aktuelle Produkt:</strong> <?php echo esc_html($current_category->name); ?>
             <code>[produkt_product category="<?php echo esc_html($current_category->shortcode); ?>"]</code>
         </div>
         <?php endif; ?>
@@ -140,7 +140,7 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
         <?php if (empty($orders)): ?>
         <div style="text-align: center; padding: 40px;">
             <p style="font-size: 18px; color: #666;">Keine Bestellungen im gewählten Zeitraum gefunden.</p>
-            <p>Versuchen Sie einen anderen Zeitraum oder eine andere Kategorie.</p>
+            <p>Versuchen Sie einen anderen Zeitraum oder eine andere Produkt.</p>
         </div>
         <?php else: ?>
         
@@ -271,7 +271,7 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
             </button>
         </div>
         <p style="margin-top: 10px; color: #666; font-size: 13px;">
-            Exportiert werden alle Bestellungen im aktuell gewählten Filter-Zeitraum und der ausgewählten Kategorie.
+            Exportiert werden alle Bestellungen im aktuell gewählten Filter-Zeitraum und der ausgewählten Produkt.
         </p>
     </div>
     
@@ -303,7 +303,7 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
         </div>
         
         <div style="margin-top: 15px; padding: 15px; background: #d4edda; border: 1px solid #c3e6cb; border-radius: 4px;">
-            <strong>💡 Tipp:</strong> Nutzen Sie die Filterfunktionen um spezifische Zeiträume oder Kategorien zu analysieren. Die Export-Funktion hilft bei der weiteren Datenverarbeitung in Excel oder anderen Tools.
+            <strong>💡 Tipp:</strong> Nutzen Sie die Filterfunktionen um spezifische Zeiträume oder Produkte zu analysieren. Die Export-Funktion hilft bei der weiteren Datenverarbeitung in Excel oder anderen Tools.
         </div>
         
         <div style="margin-top: 10px; padding: 15px; background: #fff3cd; border: 1px solid #ffeaa7; border-radius: 4px;">

--- a/admin/pricing-page.php
+++ b/admin/pricing-page.php
@@ -47,7 +47,7 @@ foreach ($branding_results as $result) {
         <form method="get" action="">
             <input type="hidden" name="page" value="produkt-pricing">
             <input type="hidden" name="tab" value="<?php echo esc_attr($active_tab); ?>">
-            <label for="category-select"><strong>🏷️ Kategorie:</strong></label>
+            <label for="category-select"><strong>🏷️ Produkt:</strong></label>
             <select name="category" id="category-select" onchange="this.form.submit()">
                 <?php foreach ($categories as $category): ?>
                 <option value="<?php echo $category->id; ?>" <?php selected($selected_category, $category->id); ?>>

--- a/admin/products-page.php
+++ b/admin/products-page.php
@@ -47,7 +47,7 @@ foreach ($branding_results as $result) {
         <form method="get" action="">
             <input type="hidden" name="page" value="produkt-products">
             <input type="hidden" name="tab" value="<?php echo esc_attr($active_tab); ?>">
-            <label for="category-select"><strong>🏷️ Kategorie:</strong></label>
+            <label for="category-select"><strong>🏷️ Produkt:</strong></label>
             <select name="category" id="category-select" onchange="this.form.submit()">
                 <?php foreach ($categories as $category): ?>
                 <option value="<?php echo $category->id; ?>" <?php selected($selected_category, $category->id); ?>>

--- a/admin/tabs/categories-add-tab.php
+++ b/admin/tabs/categories-add-tab.php
@@ -4,8 +4,8 @@
 
 <div class="produkt-add-category">
     <div class="produkt-form-header">
-        <h3>➕ Neue Kategorie hinzufügen</h3>
-        <p>Erstellen Sie eine neue Produktkategorie mit SEO-Einstellungen und individueller Konfiguration.</p>
+        <h3>➕ Neues Produkt hinzufügen</h3>
+        <p>Erstellen Sie ein neues Produkt mit SEO-Einstellungen und individueller Konfiguration.</p>
     </div>
     
     <form method="post" action="" class="produkt-compact-form">
@@ -15,7 +15,7 @@
             <h4>📝 Grunddaten</h4>
             <div class="produkt-form-row">
                 <div class="produkt-form-group">
-                    <label>Kategorie-Name *</label>
+                    <label>Produkt-Name *</label>
                     <input type="text" name="name" required placeholder="z.B. Nonomo Produkt">
                 </div>
                 <div class="produkt-form-group">
@@ -256,7 +256,7 @@
         <!-- Actions -->
         <div class="produkt-form-actions">
             <button type="submit" name="submit_category" class="button button-primary button-large">
-                ✅ Kategorie erstellen
+                ✅ Produkt erstellen
             </button>
             <a href="<?php echo admin_url('admin.php?page=produkt-categories&tab=list'); ?>" class="button button-large">
                 ❌ Abbrechen

--- a/admin/tabs/categories-edit-tab.php
+++ b/admin/tabs/categories-edit-tab.php
@@ -4,8 +4,8 @@
 
 <div class="produkt-edit-category">
     <div class="produkt-form-header">
-        <h3>✏️ Kategorie bearbeiten</h3>
-        <p>Bearbeiten Sie die Kategorie "<?php echo esc_html($edit_item->name); ?>" mit allen Einstellungen und Inhalten.</p>
+        <h3>✏️ Produkt bearbeiten</h3>
+        <p>Bearbeiten Sie das Produkt "<?php echo esc_html($edit_item->name); ?>" mit allen Einstellungen und Inhalten.</p>
     </div>
     
     <form method="post" action="" class="produkt-compact-form">
@@ -28,7 +28,7 @@
             <h4>📝 Grunddaten</h4>
             <div class="produkt-form-row">
                 <div class="produkt-form-group">
-                    <label>Kategorie-Name *</label>
+                    <label>Produkt-Name *</label>
                     <input type="text" name="name" value="<?php echo esc_attr($edit_item->name); ?>" required>
                 </div>
                 <div class="produkt-form-group">
@@ -321,7 +321,7 @@
            </a>
             <a href="<?php echo admin_url('admin.php?page=produkt-categories&delete=' . $edit_item->id . '&fw_nonce=' . wp_create_nonce('produkt_admin_action')); ?>"
                class="button button-large produkt-delete-button"
-               onclick="return confirm('Sind Sie sicher, dass Sie diese Kategorie löschen möchten?\n\n\"<?php echo esc_js($edit_item->name); ?>\" und alle zugehörigen Daten werden unwiderruflich gelöscht!')"
+               onclick="return confirm('Sind Sie sicher, dass Sie dieses Produkt löschen möchten?\n\n\"<?php echo esc_js($edit_item->name); ?>\" und alle zugehörigen Daten werden unwiderruflich gelöscht!')"
                style="margin-left: auto;">
                 🗑️ Löschen
             </a>

--- a/admin/tabs/categories-list-tab.php
+++ b/admin/tabs/categories-list-tab.php
@@ -4,19 +4,19 @@
 
 <div class="produkt-categories-list">
     <div class="produkt-list-header">
-        <h3>📋 Alle Kategorien</h3>
+        <h3>📋 Alle Produkte</h3>
         <a href="<?php echo admin_url('admin.php?page=produkt-categories&tab=add'); ?>" class="button button-primary">
-            ➕ Neue Kategorie hinzufügen
+            ➕ Neues Produkt hinzufügen
         </a>
     </div>
     
     <?php if (empty($categories)): ?>
     <div class="produkt-empty-state">
         <div class="produkt-empty-icon">🏷️</div>
-        <h4>Noch keine Kategorien vorhanden</h4>
-        <p>Erstellen Sie Ihre erste Produktkategorie.</p>
+        <h4>Noch keine Produkte vorhanden</h4>
+        <p>Erstellen Sie Ihr erstes Produkt.</p>
         <a href="<?php echo admin_url('admin.php?page=produkt-categories&tab=add'); ?>" class="button button-primary">
-            ➕ Erste Kategorie erstellen
+            ➕ Erstes Produkt erstellen
         </a>
     </div>
     <?php else: ?>
@@ -61,7 +61,7 @@
                     </a>
                     <a href="<?php echo admin_url('admin.php?page=produkt-categories&delete=' . $category->id . '&fw_nonce=' . wp_create_nonce('produkt_admin_action')); ?>"
                        class="button button-small produkt-delete-button"
-                       onclick="return confirm('Sind Sie sicher, dass Sie diese Kategorie löschen möchten?\n\n\"<?php echo esc_js($category->name); ?>\" und alle zugehörigen Daten werden unwiderruflich gelöscht!')">
+                       onclick="return confirm('Sind Sie sicher, dass Sie dieses Produkt löschen möchten?\n\n\"<?php echo esc_js($category->name); ?>\" und alle zugehörigen Daten werden unwiderruflich gelöscht!')">
                         🗑️ Löschen
                     </a>
                 </div>

--- a/admin/tabs/conditions-tab.php
+++ b/admin/tabs/conditions-tab.php
@@ -124,7 +124,7 @@ $conditions = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE
         
         <?php if (empty($conditions)): ?>
         <div class="produkt-empty-state">
-            <p>Noch keine Zustände für diese Kategorie vorhanden.</p>
+            <p>Noch keine Zustände für dieses Produkt vorhanden.</p>
             <p><strong>Tipp:</strong> Fügen Sie oben einen neuen Zustand hinzu!</p>
         </div>
         <?php else: ?>

--- a/admin/tabs/durations-add-tab.php
+++ b/admin/tabs/durations-add-tab.php
@@ -5,7 +5,7 @@
 <div class="produkt-add-duration">
     <div class="produkt-form-header">
         <h3>➕ Neue Mietdauer hinzufügen</h3>
-        <p>Erstellen Sie eine neue Mietdauer für die Kategorie "<?php echo $current_category ? esc_html($current_category->name) : 'Unbekannt'; ?>"</p>
+        <p>Erstellen Sie eine neue Mietdauer für das Produkt "<?php echo $current_category ? esc_html($current_category->name) : 'Unbekannt'; ?>"</p>
     </div>
     
     <form method="post" action="" class="produkt-compact-form">

--- a/admin/tabs/durations-edit-tab.php
+++ b/admin/tabs/durations-edit-tab.php
@@ -15,7 +15,7 @@
 <div class="produkt-edit-duration">
     <div class="produkt-form-header">
         <h3>✏️ Mietdauer bearbeiten</h3>
-        <p>Bearbeiten Sie die Mietdauer "<?php echo esc_html($edit_item->name); ?>" für die Kategorie "<?php echo $current_category ? esc_html($current_category->name) : 'Unbekannt'; ?>"</p>
+        <p>Bearbeiten Sie die Mietdauer "<?php echo esc_html($edit_item->name); ?>" für das Produkt "<?php echo $current_category ? esc_html($current_category->name) : 'Unbekannt'; ?>"</p>
     </div>
     
     <form method="post" action="" class="produkt-compact-form">

--- a/admin/tabs/durations-list-tab.php
+++ b/admin/tabs/durations-list-tab.php
@@ -4,7 +4,7 @@
 
 <div class="produkt-durations-list">
     <div class="produkt-list-header">
-        <h3>⏰ Mietdauern für: <?php echo $current_category ? esc_html($current_category->name) : 'Unbekannte Kategorie'; ?></h3>
+        <h3>⏰ Mietdauern für: <?php echo $current_category ? esc_html($current_category->name) : 'Unbekanntes Produkt'; ?></h3>
         <a href="<?php echo admin_url('admin.php?page=produkt-durations&category=' . $selected_category . '&tab=add'); ?>" class="button button-primary">
             ➕ Neue Mietdauer hinzufügen
         </a>
@@ -14,7 +14,7 @@
     <div class="produkt-empty-state">
         <div class="produkt-empty-icon">⏰</div>
         <h4>Noch keine Mietdauern vorhanden</h4>
-        <p>Erstellen Sie Ihre erste Mietdauer für diese Kategorie.</p>
+        <p>Erstellen Sie Ihre erste Mietdauer für dieses Produkt.</p>
         <a href="<?php echo admin_url('admin.php?page=produkt-durations&category=' . $selected_category . '&tab=add'); ?>" class="button button-primary">
             ➕ Erste Mietdauer erstellen
         </a>

--- a/admin/tabs/durations-tab.php
+++ b/admin/tabs/durations-tab.php
@@ -129,7 +129,7 @@ $durations = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE 
         
         <?php if (empty($durations)): ?>
         <div class="produkt-empty-state">
-            <p>Noch keine Mietdauern für diese Kategorie vorhanden.</p>
+            <p>Noch keine Mietdauern für dieses Produkt vorhanden.</p>
             <p><strong>Tipp:</strong> Fügen Sie oben eine neue Mietdauer hinzu!</p>
         </div>
         <?php else: ?>

--- a/admin/tabs/extras-add-tab.php
+++ b/admin/tabs/extras-add-tab.php
@@ -5,7 +5,7 @@
 <div class="produkt-add-extra">
     <div class="produkt-form-header">
         <h3>➕ Neues Extra hinzufügen</h3>
-        <p>Erstellen Sie ein neues Extra für die Kategorie "<?php echo $current_category ? esc_html($current_category->name) : 'Unbekannt'; ?>"</p>
+        <p>Erstellen Sie ein neues Extra für das Produkt "<?php echo $current_category ? esc_html($current_category->name) : 'Unbekannt'; ?>"</p>
     </div>
     
     <form method="post" action="" class="produkt-compact-form">

--- a/admin/tabs/extras-edit-tab.php
+++ b/admin/tabs/extras-edit-tab.php
@@ -5,7 +5,7 @@
 <div class="produkt-edit-extra">
     <div class="produkt-form-header">
         <h3>✏️ Extra bearbeiten</h3>
-        <p>Bearbeiten Sie das Extra "<?php echo esc_html($edit_item->name); ?>" für die Kategorie "<?php echo $current_category ? esc_html($current_category->name) : 'Unbekannt'; ?>"</p>
+        <p>Bearbeiten Sie das Extra "<?php echo esc_html($edit_item->name); ?>" für das Produkt "<?php echo $current_category ? esc_html($current_category->name) : 'Unbekannt'; ?>"</p>
     </div>
     
     <form method="post" action="" class="produkt-compact-form">

--- a/admin/tabs/extras-list-tab.php
+++ b/admin/tabs/extras-list-tab.php
@@ -4,7 +4,7 @@
 
 <div class="produkt-extras-list">
     <div class="produkt-list-header">
-        <h3>🎁 Extras für: <?php echo $current_category ? esc_html($current_category->name) : 'Unbekannte Kategorie'; ?></h3>
+        <h3>🎁 Extras für: <?php echo $current_category ? esc_html($current_category->name) : 'Unbekanntes Produkt'; ?></h3>
         <a href="<?php echo admin_url('admin.php?page=produkt-extras&category=' . $selected_category . '&tab=add'); ?>" class="button button-primary">
             ➕ Neues Extra hinzufügen
         </a>
@@ -14,7 +14,7 @@
     <div class="produkt-empty-state">
         <div class="produkt-empty-icon">🎁</div>
         <h4>Noch keine Extras vorhanden</h4>
-        <p>Erstellen Sie Ihr erstes Extra für diese Kategorie.</p>
+        <p>Erstellen Sie Ihr erstes Extra für dieses Produkt.</p>
         <a href="<?php echo admin_url('admin.php?page=produkt-extras&category=' . $selected_category . '&tab=add'); ?>" class="button button-primary">
             ➕ Erstes Extra erstellen
         </a>

--- a/admin/tabs/extras-tab.php
+++ b/admin/tabs/extras-tab.php
@@ -136,7 +136,7 @@ $extras = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE cat
         
         <?php if (empty($extras)): ?>
         <div class="produkt-empty-state">
-            <p>Noch keine Extras für diese Kategorie vorhanden.</p>
+            <p>Noch keine Extras für dieses Produkt vorhanden.</p>
             <p><strong>Tipp:</strong> Fügen Sie oben ein neues Extra hinzu!</p>
         </div>
         <?php else: ?>

--- a/admin/tabs/variants-add-tab.php
+++ b/admin/tabs/variants-add-tab.php
@@ -5,7 +5,7 @@
 <div class="produkt-add-variant">
     <div class="produkt-form-header">
         <h3>➕ Neue Ausführung hinzufügen</h3>
-        <p>Erstellen Sie eine neue Produktausführung für die Kategorie "<?php echo $current_category ? esc_html($current_category->name) : 'Unbekannt'; ?>"</p>
+        <p>Erstellen Sie eine neue Produktausführung für das Produkt "<?php echo $current_category ? esc_html($current_category->name) : 'Unbekannt'; ?>"</p>
     </div>
     
     <form method="post" action="" class="produkt-compact-form">

--- a/admin/tabs/variants-edit-tab.php
+++ b/admin/tabs/variants-edit-tab.php
@@ -5,7 +5,7 @@
 <div class="produkt-edit-variant">
     <div class="produkt-form-header">
         <h3>✏️ Ausführung bearbeiten</h3>
-        <p>Bearbeiten Sie die Ausführung "<?php echo esc_html($edit_item->name); ?>" für die Kategorie "<?php echo $current_category ? esc_html($current_category->name) : 'Unbekannt'; ?>"</p>
+        <p>Bearbeiten Sie die Ausführung "<?php echo esc_html($edit_item->name); ?>" für das Produkt "<?php echo $current_category ? esc_html($current_category->name) : 'Unbekannt'; ?>"</p>
     </div>
     
     <form method="post" action="" class="produkt-compact-form">

--- a/admin/tabs/variants-list-tab.php
+++ b/admin/tabs/variants-list-tab.php
@@ -4,7 +4,7 @@
 
 <div class="produkt-variants-list">
     <div class="produkt-list-header">
-        <h3>📋 Ausführungen für: <?php echo $current_category ? esc_html($current_category->name) : 'Unbekannte Kategorie'; ?></h3>
+        <h3>📋 Ausführungen für: <?php echo $current_category ? esc_html($current_category->name) : 'Unbekanntes Produkt'; ?></h3>
         <a href="<?php echo admin_url('admin.php?page=produkt-variants&category=' . $selected_category . '&tab=add'); ?>" class="button button-primary">
             ➕ Neue Ausführung hinzufügen
         </a>
@@ -14,7 +14,7 @@
     <div class="produkt-empty-state">
         <div class="produkt-empty-icon">📦</div>
         <h4>Noch keine Ausführungen vorhanden</h4>
-        <p>Erstellen Sie Ihre erste Produktausführung für diese Kategorie.</p>
+        <p>Erstellen Sie Ihre erste Produktausführung für dieses Produkt.</p>
         <a href="<?php echo admin_url('admin.php?page=produkt-variants&category=' . $selected_category . '&tab=add'); ?>" class="button button-primary">
             ➕ Erste Ausführung erstellen
         </a>

--- a/admin/tabs/variants-tab.php
+++ b/admin/tabs/variants-tab.php
@@ -170,7 +170,7 @@ $variants = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE c
         
         <?php if (empty($variants)): ?>
         <div class="produkt-empty-state">
-            <p>Noch keine Ausführungen für diese Kategorie vorhanden.</p>
+            <p>Noch keine Ausführungen für dieses Produkt vorhanden.</p>
             <p><strong>Tipp:</strong> Fügen Sie oben eine neue Ausführung hinzu!</p>
         </div>
         <?php else: ?>

--- a/admin/variant-options-page.php
+++ b/admin/variant-options-page.php
@@ -136,7 +136,7 @@ $variant_options = $wpdb->get_results($wpdb->prepare("
         <form method="get" action="">
             <input type="hidden" name="page" value="produkt-variant-options">
             <input type="hidden" name="tab" value="<?php echo esc_attr($active_tab); ?>">
-            <label for="category-select"><strong>🏷️ Kategorie:</strong></label>
+            <label for="category-select"><strong>🏷️ Produkt:</strong></label>
             <select name="category" id="category-select" onchange="this.form.submit()">
                 <?php foreach ($categories as $category): ?>
                 <option value="<?php echo $category->id; ?>" <?php selected($selected_category, $category->id); ?>>
@@ -181,7 +181,7 @@ $variant_options = $wpdb->get_results($wpdb->prepare("
                 ?>
                 <div class="produkt-tab-section">
                     <h3>⚠️ Keine Ausführungen vorhanden</h3>
-                    <p>Bevor Sie Optionen zuordnen können, müssen Sie erst Ausführungen für diese Kategorie erstellen.</p>
+                    <p>Bevor Sie Optionen zuordnen können, müssen Sie erst Ausführungen für dieses Produkt erstellen.</p>
                     <a href="<?php echo admin_url('admin.php?page=produkt-variants&category=' . $selected_category); ?>" class="button button-primary">Ausführungen verwalten</a>
                 </div>
                 <?php
@@ -334,11 +334,11 @@ $variant_options = $wpdb->get_results($wpdb->prepare("
                     <p>Verknüpfen Sie Zustände, Farben und Extras mit spezifischen Ausführungen.</p>
                     
                     <div class="produkt-list-card">
-                        <h4>Zuordnungen für: <?php echo $current_category ? esc_html($current_category->name) : 'Unbekannte Kategorie'; ?></h4>
+                        <h4>Zuordnungen für: <?php echo $current_category ? esc_html($current_category->name) : 'Unbekanntes Produkt'; ?></h4>
                         
                         <?php if (empty($variant_options)): ?>
                         <div class="produkt-empty-state">
-                            <p>Noch keine Zuordnungen für diese Kategorie vorhanden.</p>
+                            <p>Noch keine Zuordnungen für dieses Produkt vorhanden.</p>
                             <?php if (!empty($variants)): ?>
                             <p><strong>Tipp:</strong> Fügen Sie eine neue Zuordnung hinzu!</p>
                             <?php endif; ?>

--- a/admin/variants-page.php
+++ b/admin/variants-page.php
@@ -178,7 +178,7 @@ foreach ($branding_results as $result) {
         <form method="get" action="">
             <input type="hidden" name="page" value="produkt-variants">
             <input type="hidden" name="tab" value="<?php echo esc_attr($active_tab); ?>">
-            <label for="category-select"><strong>🏷️ Kategorie:</strong></label>
+            <label for="category-select"><strong>🏷️ Produkt:</strong></label>
             <select name="category" id="category-select" onchange="this.form.submit()">
                 <?php foreach ($categories as $category): ?>
                 <option value="<?php echo $category->id; ?>" <?php selected($selected_category, $category->id); ?>>

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -16,11 +16,11 @@ class Admin {
             30
         );
         
-        // Submenu: Kategorien
+        // Submenu: Produkte
         add_submenu_page(
             'produkt-verleih',
-            'Kategorien',
-            'Kategorien',
+            'Produkte',
+            'Produkte',
             'manage_options',
             'produkt-categories',
             array($this, 'categories_page')
@@ -361,7 +361,7 @@ class Admin {
                 );
 
                 if ($result !== false) {
-                    echo '<div class="notice notice-success"><p>✅ Kategorie erfolgreich aktualisiert!</p></div>';
+                    echo '<div class="notice notice-success"><p>✅ Produkt erfolgreich aktualisiert!</p></div>';
                 } else {
                     echo '<div class="notice notice-error"><p>❌ Fehler beim Aktualisieren: ' . esc_html($wpdb->last_error) . '</p></div>';
                 }
@@ -409,7 +409,7 @@ class Admin {
                 );
 
                 if ($result !== false) {
-                    echo '<div class="notice notice-success"><p>✅ Kategorie erfolgreich hinzugefügt!</p></div>';
+                    echo '<div class="notice notice-success"><p>✅ Produkt erfolgreich hinzugefügt!</p></div>';
                 } else {
                     echo '<div class="notice notice-error"><p>❌ Fehler beim Hinzufügen: ' . esc_html($wpdb->last_error) . '</p></div>';
                 }
@@ -421,7 +421,7 @@ class Admin {
             $table_name = $wpdb->prefix . 'produkt_categories';
             $result = $wpdb->delete($table_name, ['id' => $category_id], ['%d']);
             if ($result !== false) {
-                echo '<div class="notice notice-success"><p>✅ Kategorie gelöscht!</p></div>';
+                echo '<div class="notice notice-success"><p>✅ Produkt gelöscht!</p></div>';
             } else {
                 echo '<div class="notice notice-error"><p>❌ Fehler beim Löschen: ' . esc_html($wpdb->last_error) . '</p></div>';
             }

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -537,7 +537,7 @@ class Ajax {
         $message     = "Ein Kunde möchte informiert werden, sobald das Produkt wieder verfügbar ist.\n";
         $message    .= 'E-Mail: ' . $email . "\n";
         if ($category_name) {
-            $message .= 'Kategorie: ' . $category_name . "\n";
+            $message .= 'Produkt: ' . $category_name . "\n";
         }
         if ($variant_name) {
             $message .= 'Ausführung: ' . $variant_name . "\n";

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -103,7 +103,7 @@ class Plugin {
         }
 
         if (!$category) {
-            return '<p>Keine aktive Produktkategorie gefunden.</p>';
+            return '<p>Kein aktives Produkt gefunden.</p>';
         }
 
         $page_title = !empty($atts['title']) ? $atts['title'] : $category->page_title;

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -410,8 +410,8 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
                     <?php endif; ?>
                     <?php else: ?>
                     <div style="padding: 20px; background: #fff3cd; border: 1px solid #ffeaa7; border-radius: 8px; text-align: center;">
-                        <h4>⚠️ Kategorie noch nicht vollständig konfiguriert</h4>
-                        <p>Für diese Produktkategorie sind noch nicht alle erforderlichen Daten hinterlegt.</p>
+                        <h4>⚠️ Produkt noch nicht vollständig konfiguriert</h4>
+                        <p>Für dieses Produkt sind noch nicht alle erforderlichen Daten hinterlegt.</p>
                         <p><strong>Bitte konfigurieren Sie die fehlenden Daten im Admin-Bereich.</strong></p>
                     </div>
                     <?php endif; ?>


### PR DESCRIPTION
## Summary
- rename all admin menu labels and texts from "Kategorie" to "Produkt"
- update success messages and help texts accordingly
- adjust template text on incomplete configuration

## Testing
- `grep -R "Kategorie" -n` shows no results
- `php` was not available so syntax checks were skipped

------
https://chatgpt.com/codex/tasks/task_b_686c171a090c83309d83b772da668d66