### PR TITLE
Improve shop archive layout

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1127,6 +1127,23 @@
     overflow: hidden;
 }
 
+.produkt-star-rating.small {
+    --star-size: 16px;
+}
+
+.produkt-card-rating {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    justify-content: center;
+    margin-bottom: 8px;
+}
+
+.produkt-card-price {
+    font-weight: 600;
+    margin-bottom: 12px;
+}
+
 /* Exit Intent Popup */
 .produkt-exit-popup {
     position: fixed;
@@ -1354,17 +1371,22 @@ body.produkt-popup-open {
 
 .produkt-shop-card {
     background: #fff;
-    border: 1px solid var(--produkt-border-color);
-    border-radius: 8px;
+    border: 1px solid #e0e0e0;
+    border-radius: 0;
     padding: 15px;
     text-align: center;
+    transition: box-shadow 0.3s ease;
+}
+
+.produkt-shop-card:hover {
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.08);
 }
 
 .produkt-shop-image {
     width: 100%;
-    height: 180px;
+    aspect-ratio: 1;
     object-fit: cover;
-    border-radius: 4px;
+    border-radius: 8px;
     margin-bottom: 10px;
 }
 

--- a/templates/product-archive.php
+++ b/templates/product-archive.php
@@ -10,9 +10,20 @@ if (!defined('ABSPATH')) { exit; }
                 <img class="produkt-shop-image" src="<?php echo esc_url($cat->default_image); ?>" alt="<?php echo esc_attr($cat->product_title); ?>">
             <?php endif; ?>
             <h2><?php echo esc_html($cat->product_title); ?></h2>
-            <?php if (!empty($cat->product_description)): ?>
-                <p><?php echo esc_html(wp_trim_words($cat->product_description, 20)); ?></p>
+
+            <?php if ($cat->show_rating && floatval($cat->rating_value) > 0): ?>
+                <div class="produkt-card-rating">
+                    <span class="produkt-star-rating small" style="--rating: <?php echo esc_attr(floatval($cat->rating_value)); ?>;"></span>
+                    <span class="produkt-rating-number"><?php echo esc_html(number_format(floatval($cat->rating_value), 1, ',', '')); ?></span>
+                </div>
             <?php endif; ?>
+
+            <?php if ($cat->min_price > 0): ?>
+                <div class="produkt-card-price">
+                    <?php echo ($cat->variant_count > 1 ? 'ab ' : '') . number_format($cat->min_price, 2, ',', '.') . '€'; ?>
+                </div>
+            <?php endif; ?>
+
             <a class="produkt-shop-button" href="<?php echo esc_url($url); ?>">Jetzt ansehen</a>
         </div>
         <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- compute minimum variant price for each category
- redesign product archive layout with rating and price
- add hover styling and star rating tweaks

## Testing
- `php -l includes/Plugin.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_b_686cd1911380833083954d3b2e30726f