### PR TITLE
Fix missing table errors on first run

### DIFF
--- a/includes/Database.php
+++ b/includes/Database.php
@@ -4,6 +4,26 @@ namespace ProduktVerleih;
 class Database {
     public function update_database() {
         global $wpdb;
+
+        // Ensure all required tables exist before attempting updates
+        $core_tables = array(
+            'produkt_categories',
+            'produkt_variants',
+            'produkt_extras',
+            'produkt_durations'
+        );
+        $missing_table = false;
+        foreach ($core_tables as $table_suffix) {
+            $table = $wpdb->prefix . $table_suffix;
+            if (!$wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $table))) {
+                $missing_table = true;
+                break;
+            }
+        }
+        if ($missing_table) {
+            $this->create_tables();
+            return;
+        }
         
         // Add category_id column to all tables if it doesn't exist
         $tables_to_update = array(


### PR DESCRIPTION
## Summary
- detect missing plugin tables in `Database::update_database`
- create tables automatically if they don't exist

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_b_686d2750fe908330902b6efd7deffc7a