### PR TITLE
Add product group categories

### DIFF
--- a/admin/groups-page.php
+++ b/admin/groups-page.php
@@ -1,0 +1,44 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+
+global $wpdb;
+$table = $wpdb->prefix . 'produkt_groups';
+
+if (isset($_POST['add_group'])) {
+    \ProduktVerleih\Admin::verify_admin_action();
+    $name = sanitize_text_field($_POST['name']);
+    $slug = sanitize_title($_POST['slug']);
+    if ($name && $slug) {
+        $wpdb->insert($table, [ 'name' => $name, 'slug' => $slug ]);
+        echo '<div class="notice notice-success"><p>✅ Kategorie gespeichert.</p></div>';
+    }
+}
+
+if (isset($_GET['delete']) && isset($_GET['fw_nonce']) && wp_verify_nonce($_GET['fw_nonce'], 'produkt_admin_action')) {
+    $wpdb->delete($table, ['id' => intval($_GET['delete'])]);
+    echo '<div class="notice notice-success"><p>✅ Kategorie gelöscht.</p></div>';
+}
+
+$groups = $wpdb->get_results("SELECT * FROM $table ORDER BY name");
+?>
+<div class="wrap">
+    <h1>Kategorien</h1>
+    <form method="post" style="margin-bottom:20px;">
+        <?php wp_nonce_field('produkt_admin_action', 'produkt_admin_nonce'); ?>
+        <input type="text" name="name" placeholder="Name" required>
+        <input type="text" name="slug" placeholder="Slug" required>
+        <button type="submit" name="add_group" class="button button-primary">Hinzufügen</button>
+    </form>
+    <table class="widefat striped">
+        <thead><tr><th>Name</th><th>Slug</th><th></th></tr></thead>
+        <tbody>
+        <?php foreach ($groups as $g): ?>
+            <tr>
+                <td><?php echo esc_html($g->name); ?></td>
+                <td><?php echo esc_html($g->slug); ?></td>
+                <td><a class="button" href="<?php echo admin_url('admin.php?page=produkt-groups&delete=' . $g->id . '&fw_nonce=' . wp_create_nonce('produkt_admin_action')); ?>">Löschen</a></td>
+            </tr>
+        <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>

--- a/admin/tabs/categories-add-tab.php
+++ b/admin/tabs/categories-add-tab.php
@@ -23,6 +23,14 @@
                     <input type="text" name="shortcode" required pattern="[a-z0-9_-]+" placeholder="z.B. nonomo-premium">
                     <small>Nur Kleinbuchstaben, Zahlen, _ und -</small>
                 </div>
+                <div class="produkt-form-group">
+                    <label>Kategorie</label>
+                    <select name="group_id">
+                        <?php foreach ($groups as $g): ?>
+                        <option value="<?php echo $g->id; ?>"><?php echo esc_html($g->name); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
             </div>
         </div>
         

--- a/admin/tabs/categories-edit-tab.php
+++ b/admin/tabs/categories-edit-tab.php
@@ -36,6 +36,14 @@
                     <input type="text" name="shortcode" value="<?php echo esc_attr($edit_item->shortcode); ?>" required pattern="[a-z0-9_-]+">
                     <small>Nur Kleinbuchstaben, Zahlen, _ und -</small>
                 </div>
+                <div class="produkt-form-group">
+                    <label>Kategorie</label>
+                    <select name="group_id">
+                        <?php foreach ($groups as $g): ?>
+                        <option value="<?php echo $g->id; ?>" <?php selected($edit_item->group_id, $g->id); ?>><?php echo esc_html($g->name); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
             </div>
         </div>
         

--- a/assets/style.css
+++ b/assets/style.css
@@ -1097,7 +1097,7 @@
 
 .produkt-rating-number {
     font-family: "Roca",sans-serif;
-    font-size: 16px;
+    font-size: 13px;
 }
 
 .produkt-star-rating {
@@ -1125,6 +1125,10 @@
     top: 0;
     width: calc(var(--rating) / 5 * 100%);
     overflow: hidden;
+}
+
+.produkt-star-black::after {
+    color: #000;
 }
 
 /* Exit Intent Popup */
@@ -1352,12 +1356,30 @@ body.produkt-popup-open {
     gap: 20px;
 }
 
+@media (min-width: 992px) {
+    .produkt-shop-grid {
+        grid-template-columns: repeat(4, 1fr);
+    }
+}
+
+.produkt-shop-card-link {
+    text-decoration: none;
+    color: inherit;
+    display: block;
+}
+
 .produkt-shop-card {
     background: #fff;
-    border: 1px solid var(--produkt-border-color);
+    border: none;
     border-radius: 8px;
     padding: 15px;
     text-align: center;
+    transition: box-shadow 0.2s ease;
+    cursor: pointer;
+}
+
+.produkt-shop-card:hover {
+    box-shadow: 0 4px 10px rgba(0,0,0,0.08);
 }
 
 .produkt-shop-image {
@@ -1378,6 +1400,24 @@ body.produkt-popup-open {
     font-size: 0.9rem;
     color: #000000;
     margin-bottom: 15px;
+}
+
+.produkt-group-title {
+    text-align: center;
+    font-size: 1.75rem;
+    margin-bottom: 20px;
+}
+
+.produkt-card-price {
+    font-size: 1rem;
+    font-weight: 600;
+    margin-top: 10px;
+    color: #000;
+}
+
+/* Smaller star size for cards in the archive grid */
+.produkt-shop-card .produkt-star-rating {
+    --star-size: 16px;
 }
 
 .produkt-shop-button {

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -559,6 +559,17 @@ class Plugin {
                 include PRODUKT_PLUGIN_PATH . 'templates/product-archive.php';
                 get_footer();
                 exit;
+            } else {
+                $categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_categories WHERE active = 1 ORDER BY sort_order");
+                $current_group = null;
+                $shop_page = get_post(get_option(PRODUKT_SHOP_PAGE_OPTION));
+                if ($shop_page) {
+                    add_filter('pre_get_document_title', function () use ($shop_page) { return $shop_page->post_title; });
+                }
+                get_header();
+                include PRODUKT_PLUGIN_PATH . 'templates/product-archive.php';
+                get_footer();
+                exit;
             }
         }
 

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -26,9 +26,11 @@ class Plugin {
         add_action('wp_enqueue_scripts', [$this->admin, 'enqueue_frontend_assets']);
         add_action('admin_enqueue_scripts', [$this->admin, 'enqueue_admin_assets']);
 
-        add_rewrite_rule('^shop/([^/]+)/?$', 'index.php?produkt_slug=$matches[1]', 'top');
+        add_rewrite_rule('^shop/([^/]+)/([^/]+)/?$', 'index.php?produkt_group=$matches[1]&produkt_slug=$matches[2]', 'top');
+        add_rewrite_rule('^shop/([^/]+)/?$', 'index.php?produkt_group=$matches[1]', 'top');
         add_filter('query_vars', function ($vars) {
             $vars[] = 'produkt_slug';
+            $vars[] = 'produkt_group';
             return $vars;
         });
         add_action('template_redirect', [$this, 'maybe_display_product_page']);
@@ -73,7 +75,8 @@ class Plugin {
             $this->db->insert_default_data();
         }
         update_option('produkt_version', PRODUKT_VERSION);
-        add_rewrite_rule('^shop/([^/]+)/?$', 'index.php?produkt_slug=$matches[1]', 'top');
+        add_rewrite_rule('^shop/([^/]+)/([^/]+)/?$', 'index.php?produkt_group=$matches[1]&produkt_slug=$matches[2]', 'top');
+        add_rewrite_rule('^shop/([^/]+)/?$', 'index.php?produkt_group=$matches[1]', 'top');
         $this->create_shop_page();
         flush_rewrite_rules();
     }
@@ -126,9 +129,20 @@ class Plugin {
         return ob_get_clean();
     }
 
-    public function render_product_grid() {
+    public function render_product_grid($atts = []) {
         global $wpdb;
-        $categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_categories WHERE active = 1 ORDER BY sort_order");
+        $atts = shortcode_atts(['group' => 0], $atts);
+        $group_id = intval($atts['group']);
+        $query = "SELECT * FROM {$wpdb->prefix}produkt_categories WHERE active = 1";
+        if ($group_id > 0) {
+            $query .= $wpdb->prepare(" AND group_id = %d", $group_id);
+        }
+        $query .= " ORDER BY sort_order";
+        $categories = $wpdb->get_results($query);
+        $current_group = null;
+        if ($group_id > 0) {
+            $current_group = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$wpdb->prefix}produkt_groups WHERE id = %d", $group_id));
+        }
         ob_start();
         include PRODUKT_PLUGIN_PATH . 'templates/product-archive.php';
         return ob_get_clean();
@@ -138,6 +152,7 @@ class Plugin {
         global $post, $wpdb;
 
         $slug = get_query_var('produkt_slug');
+        $group_part = get_query_var('produkt_group');
 
         if (!is_singular() && empty($slug)) {
             return;
@@ -145,11 +160,17 @@ class Plugin {
 
         $category = null;
         if ($slug) {
-            $categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_categories");
-            foreach ($categories as $cat) {
-                if (sanitize_title($cat->product_title) === sanitize_title($slug)) {
-                    $category = $cat;
-                    break;
+            $category = $wpdb->get_row($wpdb->prepare(
+                "SELECT * FROM {$wpdb->prefix}produkt_categories WHERE shortcode = %s",
+                sanitize_title($slug)
+            ));
+            if (!$category) {
+                $categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_categories");
+                foreach ($categories as $cat) {
+                    if (sanitize_title($cat->product_title) === sanitize_title($slug)) {
+                        $category = $cat;
+                        break;
+                    }
                 }
             }
         } else {
@@ -191,6 +212,7 @@ class Plugin {
         global $post, $wpdb;
 
         $slug = get_query_var('produkt_slug');
+        $group_part = get_query_var('produkt_group');
 
         if (!is_singular() && empty($slug)) {
             return;
@@ -198,11 +220,17 @@ class Plugin {
 
         $category = null;
         if ($slug) {
-            $categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_categories");
-            foreach ($categories as $cat) {
-                if (sanitize_title($cat->product_title) === sanitize_title($slug)) {
-                    $category = $cat;
-                    break;
+            $category = $wpdb->get_row($wpdb->prepare(
+                "SELECT * FROM {$wpdb->prefix}produkt_categories WHERE shortcode = %s",
+                sanitize_title($slug)
+            ));
+            if (!$category) {
+                $categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_categories");
+                foreach ($categories as $cat) {
+                    if (sanitize_title($cat->product_title) === sanitize_title($slug)) {
+                        $category = $cat;
+                        break;
+                    }
                 }
             }
         } else {
@@ -229,7 +257,15 @@ class Plugin {
         $og_title = !empty($category->meta_title) ? $category->meta_title : $category->page_title;
         $og_description = !empty($category->meta_description) ? $category->meta_description : $category->page_description;
         $og_image = !empty($category->default_image) ? $category->default_image : '';
-        $og_url = $slug ? home_url('/shop/' . sanitize_title($slug)) : get_permalink($post->ID);
+        $group_part = get_query_var('produkt_group');
+        $path = '/shop/';
+        if ($slug) {
+            if ($group_part) {
+                $path .= sanitize_title($group_part) . '/';
+            }
+            $path .= sanitize_title($slug);
+        }
+        $og_url = $slug ? home_url($path) : get_permalink($post->ID);
 
         echo '<!-- Open Graph Tags -->' . "\n";
         echo '<meta property="og:type" content="product">' . "\n";
@@ -255,6 +291,7 @@ class Plugin {
         global $post, $wpdb;
 
         $slug = get_query_var('produkt_slug');
+        $group_part = get_query_var('produkt_group');
 
         if (!is_singular() && empty($slug)) {
             return;
@@ -262,11 +299,17 @@ class Plugin {
 
         $category = null;
         if ($slug) {
-            $categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_categories");
-            foreach ($categories as $cat) {
-                if (sanitize_title($cat->product_title) === sanitize_title($slug)) {
-                    $category = $cat;
-                    break;
+            $category = $wpdb->get_row($wpdb->prepare(
+                "SELECT * FROM {$wpdb->prefix}produkt_categories WHERE shortcode = %s",
+                sanitize_title($slug)
+            ));
+            if (!$category) {
+                $categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_categories");
+                foreach ($categories as $cat) {
+                    if (sanitize_title($cat->product_title) === sanitize_title($slug)) {
+                        $category = $cat;
+                        break;
+                    }
                 }
             }
         } else {
@@ -337,7 +380,7 @@ class Plugin {
                     'unitText' => 'pro Monat'
                 ],
                 'availability' => 'https://schema.org/InStock',
-                'url' => $slug ? home_url('/shop/' . sanitize_title($slug)) : get_permalink($post->ID),
+                'url' => $slug ? home_url(($group_part ? '/shop/' . sanitize_title($group_part) . '/' : '/shop/') . sanitize_title($slug)) : get_permalink($post->ID),
                 'seller' => [
                     '@type' => 'Organization',
                     'name' => get_bloginfo('name')
@@ -431,35 +474,97 @@ class Plugin {
 
     public function maybe_display_product_page() {
         $slug = get_query_var('produkt_slug');
-        if (empty($slug)) {
+        $group_slug = get_query_var('produkt_group');
+        if (empty($slug) && empty($group_slug)) {
             return;
         }
 
         global $wpdb;
-        $categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_categories");
-        $category = null;
-        foreach ($categories as $cat) {
-            if (sanitize_title($cat->product_title) === sanitize_title($slug)) {
-                $category = $cat;
-                break;
-            }
-        }
 
-        if (!$category) {
+        if ($group_slug && $slug) {
+            $group = $wpdb->get_row($wpdb->prepare(
+                "SELECT * FROM {$wpdb->prefix}produkt_groups WHERE slug = %s",
+                sanitize_title($group_slug)
+            ));
+            if (!$group) {
+                global $wp_query;
+                $wp_query->set_404();
+                status_header(404);
+                return;
+            }
+            $category = $wpdb->get_row($wpdb->prepare(
+                "SELECT * FROM {$wpdb->prefix}produkt_categories WHERE group_id = %d AND shortcode = %s",
+                $group->id,
+                sanitize_title($slug)
+            ));
+            if (!$category) {
+                $categories = $wpdb->get_results($wpdb->prepare(
+                    "SELECT * FROM {$wpdb->prefix}produkt_categories WHERE group_id = %d",
+                    $group->id
+                ));
+                foreach ($categories as $cat) {
+                    if (sanitize_title($cat->product_title) === sanitize_title($slug)) {
+                        $category = $cat;
+                        break;
+                    }
+                }
+            }
+            if ($category) {
+                add_filter('pre_get_document_title', function () use ($category) {
+                    return $category->page_title ?: $category->product_title;
+                });
+                get_header();
+                include PRODUKT_PLUGIN_PATH . 'templates/product-page.php';
+                get_footer();
+                exit;
+            }
             global $wp_query;
             $wp_query->set_404();
             status_header(404);
             return;
         }
 
-        add_filter('pre_get_document_title', function () use ($category) {
-            return $category->page_title ?: $category->product_title;
-        });
+        if ($slug) {
+            $category = $wpdb->get_row($wpdb->prepare(
+                "SELECT * FROM {$wpdb->prefix}produkt_categories WHERE shortcode = %s",
+                sanitize_title($slug)
+            ));
+            if (!$category) {
+                $categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_categories");
+                foreach ($categories as $cat) {
+                    if (sanitize_title($cat->product_title) === sanitize_title($slug)) {
+                        $category = $cat;
+                        break;
+                    }
+                }
+            }
+            if ($category) {
+                add_filter('pre_get_document_title', function () use ($category) {
+                    return $category->page_title ?: $category->product_title;
+                });
+                get_header();
+                include PRODUKT_PLUGIN_PATH . 'templates/product-page.php';
+                get_footer();
+                exit;
+            }
+        }
 
-        get_header();
-        include PRODUKT_PLUGIN_PATH . 'templates/product-page.php';
-        get_footer();
-        exit;
+        if ($group_slug) {
+            $group = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$wpdb->prefix}produkt_groups WHERE slug = %s", sanitize_title($group_slug)));
+            if ($group) {
+                $categories = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}produkt_categories WHERE active = 1 AND group_id = %d ORDER BY sort_order", $group->id));
+                $current_group = $group;
+                add_filter('pre_get_document_title', function () use ($group) { return $group->name; });
+                get_header();
+                include PRODUKT_PLUGIN_PATH . 'templates/product-archive.php';
+                get_footer();
+                exit;
+            }
+        }
+
+        global $wp_query;
+        $wp_query->set_404();
+        status_header(404);
     }
 
     private function create_shop_page() {

--- a/produkt-verleih.php
+++ b/produkt-verleih.php
@@ -3,18 +3,18 @@
  * Plugin Name: H2 Concepts Rental Pro
   * Plugin URI: https://h2concepts.de
   * Description: Ein Plugin für den Verleih von Waren mit konfigurierbaren Produkten und Stripe-Integration
-* Version: 2.8.26
-  * Author: H2 Concepts
-  * License: GPL v2 or later
-  * Text Domain: h2-concepts
-  */
+* Version: 2.8.27
+ * Author: H2 Concepts
+ * License: GPL v2 or later
+ * Text Domain: h2-concepts
+ */
  
 if (!defined('ABSPATH')) {
     exit;
 }
 
 // Plugin constants
-const PRODUKT_PLUGIN_VERSION = '2.8.26';
+const PRODUKT_PLUGIN_VERSION = '2.8.27';
 const PRODUKT_PLUGIN_DIR = __DIR__ . '/';
 define('PRODUKT_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('PRODUKT_PLUGIN_PATH', PRODUKT_PLUGIN_DIR);
@@ -73,3 +73,4 @@ function produkt_simple_checkout_button() {
     </script>
     <?php return ob_get_clean();
 }
+const PRODUKT_PLUGIN_VERSION = '2.8.27';

--- a/produkt-verleih.php
+++ b/produkt-verleih.php
@@ -3,7 +3,7 @@
  * Plugin Name: H2 Concepts Rental Pro
   * Plugin URI: https://h2concepts.de
   * Description: Ein Plugin für den Verleih von Waren mit konfigurierbaren Produkten und Stripe-Integration
-* Version: 2.8.24
+* Version: 2.8.26
   * Author: H2 Concepts
   * License: GPL v2 or later
   * Text Domain: h2-concepts
@@ -14,7 +14,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Plugin constants
-const PRODUKT_PLUGIN_VERSION = '2.8.24';
+const PRODUKT_PLUGIN_VERSION = '2.8.26';
 const PRODUKT_PLUGIN_DIR = __DIR__ . '/';
 define('PRODUKT_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('PRODUKT_PLUGIN_PATH', PRODUKT_PLUGIN_DIR);

--- a/templates/product-archive.php
+++ b/templates/product-archive.php
@@ -2,19 +2,52 @@
 if (!defined('ABSPATH')) { exit; }
 ?>
 <div class="produkt-shop-archive produkt-container">
+    <?php if (!empty($current_group)): ?>
+        <h1 class="produkt-group-title"><?php echo esc_html($current_group->name); ?></h1>
+    <?php endif; ?>
     <div class="produkt-shop-grid">
         <?php foreach ($categories as $cat): ?>
-        <?php $url = home_url('/shop/' . sanitize_title($cat->product_title)); ?>
-        <div class="produkt-shop-card">
-            <?php if (!empty($cat->default_image)): ?>
-                <img class="produkt-shop-image" src="<?php echo esc_url($cat->default_image); ?>" alt="<?php echo esc_attr($cat->product_title); ?>">
-            <?php endif; ?>
-            <h2><?php echo esc_html($cat->product_title); ?></h2>
-            <?php if (!empty($cat->product_description)): ?>
-                <p><?php echo esc_html(wp_trim_words($cat->product_description, 20)); ?></p>
-            <?php endif; ?>
-            <a class="produkt-shop-button" href="<?php echo esc_url($url); ?>">Jetzt ansehen</a>
-        </div>
+        <?php
+            $path = '/shop/';
+            $group_slug = '';
+            if (!empty($current_group)) {
+                $group_slug = sanitize_title($current_group->slug ?: $current_group->name);
+            } elseif (!empty($cat->group_id)) {
+                $group_slug = $wpdb->get_var($wpdb->prepare(
+                    "SELECT slug FROM {$wpdb->prefix}produkt_groups WHERE id = %d",
+                    $cat->group_id
+                ));
+            }
+            if (!empty($group_slug)) {
+                $path .= $group_slug . '/';
+            }
+            $path .= sanitize_title($cat->shortcode ?: $cat->product_title);
+            $url = home_url($path);
+        ?>
+        <?php
+            $price = $wpdb->get_var($wpdb->prepare(
+                "SELECT base_price FROM {$wpdb->prefix}produkt_variants WHERE category_id = %d ORDER BY sort_order LIMIT 1",
+                $cat->id
+            ));
+        ?>
+        <a class="produkt-shop-card-link" href="<?php echo esc_url($url); ?>">
+            <div class="produkt-shop-card">
+                <?php if (!empty($cat->default_image)): ?>
+                    <img class="produkt-shop-image" src="<?php echo esc_url($cat->default_image); ?>" alt="<?php echo esc_attr($cat->product_title); ?>">
+                <?php endif; ?>
+                <h2><?php echo esc_html($cat->product_title); ?></h2>
+                <?php if ($cat->show_rating && floatval($cat->rating_value) > 0): ?>
+                    <?php $display = number_format(floatval($cat->rating_value), 1, ',', ''); ?>
+                    <div class="produkt-rating">
+                        <span class="produkt-rating-number"><?php echo esc_html($display); ?></span>
+                        <span class="produkt-star-rating produkt-star-black" style="--rating: <?php echo esc_attr($cat->rating_value); ?>;"></span>
+                    </div>
+                <?php endif; ?>
+                <?php if ($price !== null): ?>
+                    <div class="produkt-card-price"><?php echo number_format((float)$price, 2, ',', '.'); ?>€</div>
+                <?php endif; ?>
+            </div>
+        </a>
         <?php endforeach; ?>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- create simple product groups table and admin page
- allow assigning a group to each product
- filter product grid by group slug via /shop/<slug>
- show category heading on product archive
- support nested shop URLs using group slug and product slug
- handle category slugs at /shop/<slug> and fix schema markup
- bump plugin version to 2.8.25
- fix product links to include group slug when browsing archive
- bump plugin version to 2.8.26
- reduce star size on product archive

## Testing
- `php -l includes/Plugin.php` *(fails: php not installed)*
- `php -l produkt-verleih.php` *(fails: php not installed)*
- `php -l templates/product-archive.php` *(fails: php not installed)*


------
https://chatgpt.com/codex/tasks/task_b_686d3aaa0d1483309d45c53d79dc267a