### PR TITLE
Prevent update routine errors on first plugin activation

### DIFF
--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -12,8 +12,13 @@ class Plugin {
         $this->admin = new Admin();
 
         add_action('init', [$this, 'init']);
-        // Run database update check as early as possible
-        $this->check_for_updates();
+        // Run database update check as early as possible unless plugin is
+        // currently being activated. During activation the tables don't exist
+        // yet and are created later in the activation routine, so running the
+        // update here would cause errors.
+        if (!defined('PRODUKT_PLUGIN_ACTIVATING')) {
+            $this->check_for_updates();
+        }
         add_action('wp_head', [$this, 'add_meta_tags']);
         add_action('wp_head', [$this, 'add_schema_markup']);
         add_action('wp_head', [$this, 'add_open_graph_tags']);
@@ -83,6 +88,12 @@ class Plugin {
     }
 
     public static function activate_plugin() {
+        // Indicate that the plugin is currently being activated so the
+        // constructor skips the update routine which expects the tables to
+        // already exist.
+        if (!defined('PRODUKT_PLUGIN_ACTIVATING')) {
+            define('PRODUKT_PLUGIN_ACTIVATING', true);
+        }
         $plugin = new self();
         $plugin->activate();
     }


### PR DESCRIPTION
## Summary
- skip update routine during activation to avoid missing-table errors
- mark activation status with a constant so the constructor can detect it

## Testing
- `php -l includes/Plugin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686d55c9c364833098b29b47593345de