### PR TITLE
Add slug for product categories

### DIFF
--- a/admin/main-page.php
+++ b/admin/main-page.php
@@ -121,7 +121,7 @@ foreach ($branding_results as $result) {
         <h3>🛒 Letzte Produkte</h3>
         <div class="produkt-category-cards">
             <?php foreach ($recent_products as $prod): ?>
-            <?php $prod_url = home_url('/shop/' . sanitize_title($prod->product_title)); ?>
+            <?php $prod_url = home_url('/shop/' . $prod->slug); ?>
             <div class="produkt-category-card">
                 <?php if (!empty($prod->default_image)): ?>
                     <img src="<?php echo esc_url($prod->default_image); ?>" class="produkt-recent-image" alt="<?php echo esc_attr($prod->name); ?>">

--- a/admin/main-page.php
+++ b/admin/main-page.php
@@ -13,7 +13,7 @@ $durations_count = $wpdb->get_var("SELECT COUNT(*) FROM {$wpdb->prefix}produkt_d
 
 // Get recently edited products (latest entries)
 $recent_products = $wpdb->get_results(
-    "SELECT id, name, product_title, default_image, shipping_provider, meta_title
+    "SELECT id, name, slug, product_title, default_image, shipping_provider, meta_title
        FROM {$wpdb->prefix}produkt_categories
        ORDER BY id DESC
        LIMIT 4"

--- a/admin/tabs/categories-add-tab.php
+++ b/admin/tabs/categories-add-tab.php
@@ -23,6 +23,11 @@
                     <input type="text" name="shortcode" required pattern="[a-z0-9_-]+" placeholder="z.B. nonomo-premium">
                     <small>Nur Kleinbuchstaben, Zahlen, _ und -</small>
                 </div>
+                <div class="produkt-form-group">
+                    <label>Slug *</label>
+                    <input type="text" name="slug" required pattern="[a-z0-9-]+" placeholder="z.B. wohnzimmer">
+                    <small>Wird in der URL verwendet</small>
+                </div>
             </div>
         </div>
         
@@ -318,8 +323,9 @@ document.addEventListener('DOMContentLoaded', function() {
     // Auto-generate shortcode from name
     const nameInput = document.querySelector('input[name="name"]');
     const shortcodeInput = document.querySelector('input[name="shortcode"]');
-    
-    if (nameInput && shortcodeInput) {
+    const slugInput = document.querySelector('input[name="slug"]');
+
+    if (nameInput && shortcodeInput && slugInput) {
         nameInput.addEventListener('input', function() {
             if (!shortcodeInput.value) {
                 const shortcode = this.value
@@ -329,6 +335,15 @@ document.addEventListener('DOMContentLoaded', function() {
                     .replace(/-+/g, '-')
                     .trim();
                 shortcodeInput.value = shortcode;
+            }
+            if (!slugInput.value) {
+                const slug = this.value
+                    .toLowerCase()
+                    .replace(/[^a-z0-9\s-]/g, '')
+                    .replace(/\s+/g, '-')
+                    .replace(/-+/g, '-')
+                    .trim();
+                slugInput.value = slug;
             }
         });
     }

--- a/admin/tabs/categories-edit-tab.php
+++ b/admin/tabs/categories-edit-tab.php
@@ -36,6 +36,11 @@
                     <input type="text" name="shortcode" value="<?php echo esc_attr($edit_item->shortcode); ?>" required pattern="[a-z0-9_-]+">
                     <small>Nur Kleinbuchstaben, Zahlen, _ und -</small>
                 </div>
+                <div class="produkt-form-group">
+                    <label>Slug *</label>
+                    <input type="text" name="slug" value="<?php echo esc_attr($edit_item->slug); ?>" required pattern="[a-z0-9-]+">
+                    <small>Wird in der URL verwendet</small>
+                </div>
             </div>
         </div>
         

--- a/admin/tabs/categories-list-tab.php
+++ b/admin/tabs/categories-list-tab.php
@@ -43,7 +43,7 @@
                     <code>[produkt_product category="<?php echo esc_html($category->shortcode); ?>"]</code>
                 </div>
 
-                <?php $product_url = home_url('/shop/' . sanitize_title($category->product_title)); ?>
+                <?php $product_url = home_url('/shop/' . $category->slug); ?>
                 <div class="produkt-category-url">
                     <code><?php echo esc_url($product_url); ?></code>
                 </div>

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -473,6 +473,9 @@ class Admin {
 
         $this->load_template('categories', compact('active_tab', 'edit_item', 'categories', 'branding'));
     }
+
+    }
+
     
     public function variants_page() {
         include PRODUKT_PLUGIN_PATH . 'admin/variants-page.php';

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -479,6 +479,7 @@ class Admin {
 
         $this->load_template('categories', compact('active_tab', 'edit_item', 'categories', 'branding'));
     }
+
     public function variants_page() {
         include PRODUKT_PLUGIN_PATH . 'admin/variants-page.php';
     }

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -111,7 +111,6 @@ class Admin {
                 return;
             }
         }
-        }
 
         wp_enqueue_style('produkt-style', PRODUKT_PLUGIN_URL . 'assets/style.css', array(), PRODUKT_VERSION);
         if (!empty($slug) || (isset($content) && has_shortcode($content, 'produkt_product'))) {

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -111,6 +111,7 @@ class Admin {
                 return;
             }
         }
+        }
 
         wp_enqueue_style('produkt-style', PRODUKT_PLUGIN_URL . 'assets/style.css', array(), PRODUKT_VERSION);
         if (!empty($slug) || (isset($content) && has_shortcode($content, 'produkt_product'))) {
@@ -288,6 +289,12 @@ class Admin {
             self::verify_admin_action();
             $name = sanitize_text_field($_POST['name']);
             $shortcode = sanitize_text_field($_POST['shortcode']);
+            $slug = sanitize_title($_POST['slug']);
+            $existing_slug = $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM {$wpdb->prefix}produkt_categories WHERE slug = %s AND id != %d", $slug, intval($_POST['id'] ?? 0)));
+            if ($existing_slug) {
+                echo '<div class="notice notice-error"><p>❌ Slug bereits vorhanden.</p></div>';
+                $active_tab = 'list';
+            } else {
             $meta_title = sanitize_text_field($_POST['meta_title']);
             $meta_description = sanitize_textarea_field($_POST['meta_description']);
             $product_title = sanitize_text_field($_POST['product_title']);
@@ -342,6 +349,7 @@ class Admin {
                     $table_name,
                     [
                         'name' => $name,
+                        'slug' => $slug,
                         'shortcode' => $shortcode,
                         'meta_title' => $meta_title,
                         'meta_description' => $meta_description,
@@ -379,7 +387,7 @@ class Admin {
                         'sort_order' => $sort_order,
                     ],
                     ['id' => intval($_POST['id'])],
-                    array('%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%d','%s','%s','%s','%d','%d','%d','%f','%s','%d'),
+                    array('%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%d','%s','%s','%s','%d','%d','%d','%f','%s','%d'),
                 );
 
                 if ($result !== false) {
@@ -392,6 +400,7 @@ class Admin {
                     $table_name,
                     [
                         'name' => $name,
+                        'slug' => $slug,
                         'shortcode' => $shortcode,
                         'meta_title' => $meta_title,
                         'meta_description' => $meta_description,
@@ -428,7 +437,7 @@ class Admin {
                         'rating_link' => $rating_link,
                         'sort_order' => $sort_order,
                     ],
-                    array('%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%d','%s','%s','%s','%d','%d','%d','%f','%s','%d')
+                    array('%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%d','%s','%s','%s','%d','%d','%d','%f','%s','%d')
                 );
 
                 if ($result !== false) {

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -480,6 +480,7 @@ class Admin {
         $this->load_template('categories', compact('active_tab', 'edit_item', 'categories', 'branding'));
     }
 
+
     public function variants_page() {
         include PRODUKT_PLUGIN_PATH . 'admin/variants-page.php';
     }

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -94,7 +94,6 @@ class Admin {
             'produkt-settings',
             array($this, 'settings_page')
         );
-    }
     
     public function enqueue_frontend_assets() {
         global $post;
@@ -182,7 +181,6 @@ class Admin {
                 'options' => $options
             )
         ));
-    }
     
     public function enqueue_admin_assets($hook) {
         if (strpos($hook, 'produkt') !== false) {
@@ -195,7 +193,6 @@ class Admin {
             // Ensure WordPress editor scripts are available for dynamic accordions
             wp_enqueue_editor();
         }
-    }
     
     private function get_branding_settings() {
         global $wpdb;
@@ -207,14 +204,12 @@ class Admin {
         }
         
         return $settings;
-    }
 
     private function load_template(string $slug, array $vars = []) {
         if (!empty($vars)) {
             extract($vars);
         }
         include PRODUKT_PLUGIN_PATH . "admin/{$slug}-page.php";
-    }
     
     public function custom_admin_footer($text) {
         $branding = $this->get_branding_settings();
@@ -228,7 +223,6 @@ class Admin {
         }
         
         return $text;
-    }
     
     public function custom_admin_styles() {
         if (!isset($_GET['page']) || strpos($_GET['page'], 'produkt') === false) {
@@ -273,11 +267,9 @@ class Admin {
             wp_die(__('Insufficient permissions.', 'h2-concepts'));
         }
         check_admin_referer('produkt_admin_action', $nonce_field);
-    }
     
     public function admin_page() {
         include PRODUKT_PLUGIN_PATH . 'admin/main-page.php';
-    }
     
     public function categories_page() {
         global $wpdb;
@@ -473,26 +465,22 @@ class Admin {
 
         $this->load_template('categories', compact('active_tab', 'edit_item', 'categories', 'branding'));
     }
-
-    }
-
-    
     public function variants_page() {
         include PRODUKT_PLUGIN_PATH . 'admin/variants-page.php';
     }
-    
+
     public function extras_page() {
         include PRODUKT_PLUGIN_PATH . 'admin/extras-page.php';
     }
-    
+
     public function durations_page() {
         include PRODUKT_PLUGIN_PATH . 'admin/durations-page.php';
     }
-    
+
     public function conditions_page() {
         include PRODUKT_PLUGIN_PATH . 'admin/conditions-page.php';
     }
-    
+
     public function colors_page() {
         include PRODUKT_PLUGIN_PATH . 'admin/colors-page.php';
     }
@@ -606,11 +594,9 @@ class Admin {
             'branding',
             'notice'
         ));
-    }
     
     
     public function settings_page() {
         include PRODUKT_PLUGIN_PATH . 'admin/settings-page.php';
-    }
 
 }

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -94,7 +94,9 @@ class Admin {
             'produkt-settings',
             array($this, 'settings_page')
         );
-    
+
+    }
+
     public function enqueue_frontend_assets() {
         global $post;
 
@@ -181,6 +183,8 @@ class Admin {
                 'options' => $options
             )
         ));
+
+    }
     
     public function enqueue_admin_assets($hook) {
         if (strpos($hook, 'produkt') !== false) {
@@ -193,7 +197,9 @@ class Admin {
             // Ensure WordPress editor scripts are available for dynamic accordions
             wp_enqueue_editor();
         }
-    
+
+    }
+
     private function get_branding_settings() {
         global $wpdb;
         
@@ -202,15 +208,18 @@ class Admin {
         foreach ($results as $result) {
             $settings[$result->setting_key] = $result->setting_value;
         }
-        
+
         return $settings;
+    }
 
     private function load_template(string $slug, array $vars = []) {
         if (!empty($vars)) {
             extract($vars);
         }
         include PRODUKT_PLUGIN_PATH . "admin/{$slug}-page.php";
-    
+
+    }
+
     public function custom_admin_footer($text) {
         $branding = $this->get_branding_settings();
         
@@ -223,7 +232,8 @@ class Admin {
         }
         
         return $text;
-    
+    }
+
     public function custom_admin_styles() {
         if (!isset($_GET['page']) || strpos($_GET['page'], 'produkt') === false) {
             return;
@@ -267,9 +277,13 @@ class Admin {
             wp_die(__('Insufficient permissions.', 'h2-concepts'));
         }
         check_admin_referer('produkt_admin_action', $nonce_field);
-    
+
+    }
+
     public function admin_page() {
         include PRODUKT_PLUGIN_PATH . 'admin/main-page.php';
+
+    }
     
     public function categories_page() {
         global $wpdb;
@@ -594,9 +608,12 @@ class Admin {
             'branding',
             'notice'
         ));
-    
-    
+
+    }
+
     public function settings_page() {
         include PRODUKT_PLUGIN_PATH . 'admin/settings-page.php';
+
+    }
 
 }

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -156,13 +156,10 @@ class Plugin {
 
         $category = null;
         if ($slug) {
-            $categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_categories");
-            foreach ($categories as $cat) {
-                if (sanitize_title($cat->product_title) === sanitize_title($slug)) {
-                    $category = $cat;
-                    break;
-                }
-            }
+            $category = $wpdb->get_row($wpdb->prepare(
+                "SELECT * FROM {$wpdb->prefix}produkt_categories WHERE slug = %s",
+                $slug
+            ));
         } else {
             $pattern = '/\[produkt_product[^\]]*category=["\']([^"\']*)["\'][^\]]*\]/';
             preg_match($pattern, $post->post_content, $matches);
@@ -209,13 +206,10 @@ class Plugin {
 
         $category = null;
         if ($slug) {
-            $categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_categories");
-            foreach ($categories as $cat) {
-                if (sanitize_title($cat->product_title) === sanitize_title($slug)) {
-                    $category = $cat;
-                    break;
-                }
-            }
+            $category = $wpdb->get_row($wpdb->prepare(
+                "SELECT * FROM {$wpdb->prefix}produkt_categories WHERE slug = %s",
+                $slug
+            ));
         } else {
             $pattern = '/\[produkt_product[^\]]*category=["\']([^"\']*)["\'][^\]]*\]/';
             preg_match($pattern, $post->post_content, $matches);
@@ -240,7 +234,7 @@ class Plugin {
         $og_title = !empty($category->meta_title) ? $category->meta_title : $category->page_title;
         $og_description = !empty($category->meta_description) ? $category->meta_description : $category->page_description;
         $og_image = !empty($category->default_image) ? $category->default_image : '';
-        $og_url = $slug ? home_url('/shop/' . sanitize_title($slug)) : get_permalink($post->ID);
+        $og_url = $slug ? home_url('/shop/' . $slug) : get_permalink($post->ID);
 
         echo '<!-- Open Graph Tags -->' . "\n";
         echo '<meta property="og:type" content="product">' . "\n";
@@ -273,13 +267,10 @@ class Plugin {
 
         $category = null;
         if ($slug) {
-            $categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_categories");
-            foreach ($categories as $cat) {
-                if (sanitize_title($cat->product_title) === sanitize_title($slug)) {
-                    $category = $cat;
-                    break;
-                }
-            }
+            $category = $wpdb->get_row($wpdb->prepare(
+                "SELECT * FROM {$wpdb->prefix}produkt_categories WHERE slug = %s",
+                $slug
+            ));
         } else {
             $pattern = '/\[produkt_product[^\]]*category=["\']([^"\']*)["\'][^\]]*\]/';
             preg_match($pattern, $post->post_content, $matches);
@@ -348,7 +339,7 @@ class Plugin {
                     'unitText' => 'pro Monat'
                 ],
                 'availability' => 'https://schema.org/InStock',
-                'url' => $slug ? home_url('/shop/' . sanitize_title($slug)) : get_permalink($post->ID),
+                'url' => $slug ? home_url('/shop/' . $slug) : get_permalink($post->ID),
                 'seller' => [
                     '@type' => 'Organization',
                     'name' => get_bloginfo('name')
@@ -447,14 +438,10 @@ class Plugin {
         }
 
         global $wpdb;
-        $categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_categories");
-        $category = null;
-        foreach ($categories as $cat) {
-            if (sanitize_title($cat->product_title) === sanitize_title($slug)) {
-                $category = $cat;
-                break;
-            }
-        }
+        $category = $wpdb->get_row($wpdb->prepare(
+            "SELECT * FROM {$wpdb->prefix}produkt_categories WHERE slug = %s",
+            $slug
+        ));
 
         if (!$category) {
             global $wp_query;

--- a/produkt-verleih.php
+++ b/produkt-verleih.php
@@ -3,7 +3,7 @@
  * Plugin Name: H2 Concepts Rental Pro
   * Plugin URI: https://h2concepts.de
   * Description: Ein Plugin für den Verleih von Waren mit konfigurierbaren Produkten und Stripe-Integration
-* Version: 2.8.25
+* Version: 2.8.26
   * Author: H2 Concepts
   * License: GPL v2 or later
   * Text Domain: h2-concepts
@@ -14,7 +14,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Plugin constants
-const PRODUKT_PLUGIN_VERSION = '2.8.25';
+const PRODUKT_PLUGIN_VERSION = '2.8.26';
 const PRODUKT_PLUGIN_DIR = __DIR__ . '/';
 define('PRODUKT_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('PRODUKT_PLUGIN_PATH', PRODUKT_PLUGIN_DIR);

--- a/produkt-verleih.php
+++ b/produkt-verleih.php
@@ -3,7 +3,7 @@
  * Plugin Name: H2 Concepts Rental Pro
   * Plugin URI: https://h2concepts.de
   * Description: Ein Plugin für den Verleih von Waren mit konfigurierbaren Produkten und Stripe-Integration
-* Version: 2.8.24
+* Version: 2.8.25
   * Author: H2 Concepts
   * License: GPL v2 or later
   * Text Domain: h2-concepts
@@ -14,7 +14,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Plugin constants
-const PRODUKT_PLUGIN_VERSION = '2.8.24';
+const PRODUKT_PLUGIN_VERSION = '2.8.25';
 const PRODUKT_PLUGIN_DIR = __DIR__ . '/';
 define('PRODUKT_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('PRODUKT_PLUGIN_PATH', PRODUKT_PLUGIN_DIR);

--- a/templates/product-archive.php
+++ b/templates/product-archive.php
@@ -4,7 +4,7 @@ if (!defined('ABSPATH')) { exit; }
 <div class="produkt-shop-archive produkt-container">
     <div class="produkt-shop-grid">
         <?php foreach ($categories as $cat): ?>
-        <?php $url = home_url('/shop/' . sanitize_title($cat->product_title)); ?>
+        <?php $url = home_url('/shop/' . $cat->slug); ?>
         <?php
             $price = $wpdb->get_var($wpdb->prepare(
                 "SELECT base_price FROM {$wpdb->prefix}produkt_variants WHERE category_id = %d ORDER BY sort_order LIMIT 1",


### PR DESCRIPTION
## Summary
- support category slugs in database
- expose slug field in category admin UI
- route `/shop/{slug}` pages via slug instead of product title
- update links and templates to use slug

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686d6163bd6083308ea088a315d47396