### PR TITLE
Add uninstall button

### DIFF
--- a/admin/tabs/debug-tab.php
+++ b/admin/tabs/debug-tab.php
@@ -21,6 +21,13 @@ if (isset($_POST['force_update'])) {
     
 }
 
+// Uninstall plugin if requested
+if (isset($_POST['plugin_uninstall'])) {
+    \ProduktVerleih\Admin::verify_admin_action();
+    \ProduktVerleih\Plugin::uninstall_plugin();
+    echo '<div class="notice notice-success"><p>✅ Plugin-Daten wurden entfernt. Bitte deaktivieren Sie das Plugin manuell.</p></div>';
+}
+
 // Get table structure
 $table_variants = $wpdb->prefix . 'produkt_variants';
 
@@ -41,6 +48,12 @@ $sample_variant = $wpdb->get_row("SELECT * FROM $table_variants LIMIT 1");
             <?php wp_nonce_field('produkt_admin_action', 'produkt_admin_nonce'); ?>
             <button type="submit" name="force_update" class="button button-primary" onclick="return confirm('Sind Sie sicher? Dies führt Datenbankänderungen durch.')">
                 🔄 Datenbank reparieren
+            </button>
+        </form>
+        <form method="post" action="" style="margin-top:10px;">
+            <?php wp_nonce_field('produkt_admin_action', 'produkt_admin_nonce'); ?>
+            <button type="submit" name="plugin_uninstall" class="button button-secondary" onclick="return confirm('Plugin und alle Daten wirklich löschen?')">
+                🗑️ Plugin-Daten löschen
             </button>
         </form>
     </div>

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -298,7 +298,13 @@ class Admin {
         if (isset($_POST['submit_category'])) {
             self::verify_admin_action();
             $name = sanitize_text_field($_POST['name']);
-            $shortcode = sanitize_text_field($_POST['shortcode']);
+            $raw_slug = $_POST['shortcode'] ?? $_POST['name'] ?? '';
+            $slug = sanitize_title($raw_slug);
+
+            // Fallback, falls slug leer bleibt
+            if (empty($slug)) {
+                $slug = 'kategorie-' . uniqid();
+            }
             $meta_title = sanitize_text_field($_POST['meta_title']);
             $meta_description = sanitize_textarea_field($_POST['meta_description']);
             $product_title = sanitize_text_field($_POST['product_title']);
@@ -353,7 +359,7 @@ class Admin {
                     $table_name,
                     [
                         'name' => $name,
-                        'shortcode' => $shortcode,
+                        'shortcode' => $slug,
                         'meta_title' => $meta_title,
                         'meta_description' => $meta_description,
                         'product_title' => $product_title,
@@ -403,7 +409,7 @@ class Admin {
                     $table_name,
                     [
                         'name' => $name,
-                        'shortcode' => $shortcode,
+                        'shortcode' => $slug,
                         'meta_title' => $meta_title,
                         'meta_description' => $meta_description,
                         'product_title' => $product_title,

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -103,6 +103,46 @@ class Plugin {
         $plugin->deactivate();
     }
 
+    /**
+     * Remove all plugin data and drop tables.
+     */
+    public function uninstall() {
+        $this->db->drop_tables();
+
+        $options = array(
+            'produkt_version',
+            'produkt_popup_settings',
+            'produkt_stripe_publishable_key',
+            'produkt_stripe_secret_key',
+            'produkt_stripe_pmc_id',
+            'produkt_stripe_webhook_secret',
+            'produkt_tos_url',
+            'produkt_success_url',
+            'produkt_cancel_url',
+            'produkt_ct_shipping',
+            'produkt_ct_submit',
+            'produkt_ct_after_submit',
+            PRODUKT_SHOP_PAGE_OPTION,
+        );
+
+        foreach ($options as $opt) {
+            delete_option($opt);
+        }
+
+        $page_id = get_option(PRODUKT_SHOP_PAGE_OPTION);
+        if ($page_id) {
+            wp_delete_post($page_id, true);
+        }
+    }
+
+    /**
+     * Convenience wrapper for calling uninstall from hooks or actions.
+     */
+    public static function uninstall_plugin() {
+        $plugin = new self();
+        $plugin->uninstall();
+    }
+
     public function product_shortcode($atts) {
         global $wpdb;
 

--- a/includes/StripeService.php
+++ b/includes/StripeService.php
@@ -182,6 +182,70 @@ class StripeService {
         return $lowest;
     }
 
+    /**
+     * Determine the lowest price across all variant/duration combinations.
+     * Returns array with 'amount' and 'price_id' keys or null on failure.
+     */
+    public static function get_lowest_price_with_durations($variant_ids, $duration_ids, $expiration = 43200) {
+        if (empty($variant_ids) || empty($duration_ids)) {
+            return null;
+        }
+
+        sort($variant_ids);
+        sort($duration_ids);
+        $cache_key = 'lowest_price_cache_' . md5(implode('_', $variant_ids) . '|' . implode('_', $duration_ids));
+        $cached = get_transient($cache_key);
+        if ($cached !== false) {
+            return $cached;
+        }
+
+        global $wpdb;
+
+        $placeholders_v = implode(',', array_fill(0, count($variant_ids), '%d'));
+        $placeholders_d = implode(',', array_fill(0, count($duration_ids), '%d'));
+        $sql = "SELECT stripe_price_id FROM {$wpdb->prefix}produkt_duration_prices WHERE variant_id IN ($placeholders_v) AND duration_id IN ($placeholders_d)";
+        $query = $wpdb->prepare($sql, array_merge($variant_ids, $duration_ids));
+        $prices = $wpdb->get_col($query);
+
+        $lowest = null;
+        $lowest_id = '';
+        if (!empty($prices)) {
+            foreach ($prices as $pid) {
+                $amount = self::get_cached_price_amount($pid, $expiration);
+                if (is_wp_error($amount)) {
+                    continue;
+                }
+                if ($lowest === null || $amount < $lowest) {
+                    $lowest = $amount;
+                    $lowest_id = $pid;
+                }
+            }
+        }
+
+        // Fallback for single variant and duration
+        if (empty($prices) && count($variant_ids) === 1 && count($duration_ids) === 1) {
+            $fallback_id = $wpdb->get_var($wpdb->prepare(
+                "SELECT stripe_price_id FROM {$wpdb->prefix}produkt_duration_prices WHERE variant_id = %d AND duration_id = %d",
+                $variant_ids[0], $duration_ids[0]
+            ));
+            if ($fallback_id) {
+                $amount = self::get_cached_price_amount($fallback_id, $expiration);
+                if (!is_wp_error($amount)) {
+                    $lowest = $amount;
+                    $lowest_id = $fallback_id;
+                }
+            }
+        }
+
+        $result = null;
+        if ($lowest !== null) {
+            $result = ['amount' => $lowest, 'price_id' => $lowest_id];
+            set_transient($cache_key, $result, $expiration);
+        }
+
+        return $result;
+    }
+
     public static function get_publishable_key() {
         return get_option('produkt_stripe_publishable_key', '');
     }

--- a/produkt-verleih.php
+++ b/produkt-verleih.php
@@ -3,7 +3,7 @@
  * Plugin Name: H2 Concepts Rental Pro
   * Plugin URI: https://h2concepts.de
   * Description: Ein Plugin für den Verleih von Waren mit konfigurierbaren Produkten und Stripe-Integration
-* Version: 2.8.28
+* Version: 2.8.29
   * Author: H2 Concepts
   * License: GPL v2 or later
   * Text Domain: h2-concepts
@@ -14,7 +14,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Plugin constants
-const PRODUKT_PLUGIN_VERSION = '2.8.28';
+const PRODUKT_PLUGIN_VERSION = '2.8.29';
 const PRODUKT_PLUGIN_DIR = __DIR__ . '/';
 define('PRODUKT_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('PRODUKT_PLUGIN_PATH', PRODUKT_PLUGIN_DIR);

--- a/produkt-verleih.php
+++ b/produkt-verleih.php
@@ -3,7 +3,7 @@
  * Plugin Name: H2 Concepts Rental Pro
   * Plugin URI: https://h2concepts.de
   * Description: Ein Plugin für den Verleih von Waren mit konfigurierbaren Produkten und Stripe-Integration
-* Version: 2.8.24
+* Version: 2.8.28
   * Author: H2 Concepts
   * License: GPL v2 or later
   * Text Domain: h2-concepts
@@ -14,7 +14,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Plugin constants
-const PRODUKT_PLUGIN_VERSION = '2.8.24';
+const PRODUKT_PLUGIN_VERSION = '2.8.28';
 const PRODUKT_PLUGIN_DIR = __DIR__ . '/';
 define('PRODUKT_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('PRODUKT_PLUGIN_PATH', PRODUKT_PLUGIN_DIR);

--- a/produkt-verleih.php
+++ b/produkt-verleih.php
@@ -3,7 +3,7 @@
  * Plugin Name: H2 Concepts Rental Pro
   * Plugin URI: https://h2concepts.de
   * Description: Ein Plugin für den Verleih von Waren mit konfigurierbaren Produkten und Stripe-Integration
-* Version: 2.8.29
+* Version: 2.8.30
   * Author: H2 Concepts
   * License: GPL v2 or later
   * Text Domain: h2-concepts
@@ -14,7 +14,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Plugin constants
-const PRODUKT_PLUGIN_VERSION = '2.8.29';
+const PRODUKT_PLUGIN_VERSION = '2.8.30';
 const PRODUKT_PLUGIN_DIR = __DIR__ . '/';
 define('PRODUKT_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('PRODUKT_PLUGIN_PATH', PRODUKT_PLUGIN_DIR);

--- a/templates/product-archive.php
+++ b/templates/product-archive.php
@@ -2,40 +2,21 @@
 if (!defined('ABSPATH')) { exit; }
 
 use ProduktVerleih\Database;
-use Stripe\Stripe;
-use Stripe\Price;
+use ProduktVerleih\StripeService;
 
 function get_lowest_stripe_price_by_category($category_id) {
-    $price_ids = Database::getAllStripePriceIdsByCategory($category_id);
-    if (empty($price_ids)) return null;
+    global $wpdb;
 
-    $cache_key = 'lowest_price_category_' . md5($category_id . '_' . implode('_', $price_ids));
-    $cached = get_transient($cache_key);
-    if ($cached !== false) return $cached;
+    $variant_ids  = $wpdb->get_col($wpdb->prepare(
+        "SELECT id FROM {$wpdb->prefix}produkt_variants WHERE category_id = %d",
+        $category_id
+    ));
+    $duration_ids = $wpdb->get_col($wpdb->prepare(
+        "SELECT id FROM {$wpdb->prefix}produkt_durations WHERE category_id = %d",
+        $category_id
+    ));
 
-    Stripe::setApiKey(get_option('produkt_stripe_secret_key', ''));
-
-    $lowest = null;
-    foreach ($price_ids as $price_id) {
-        try {
-            $price = Price::retrieve($price_id);
-            if (!isset($price->unit_amount)) continue;
-            $amount = $price->unit_amount / 100;
-            if ($lowest === null || $amount < $lowest) {
-                $lowest = $amount;
-            }
-        } catch (\Exception $e) {
-            continue;
-        }
-    }
-
-    if ($lowest !== null) {
-        $formatted = number_format($lowest, 2, ',', '.');
-        set_transient($cache_key, $formatted, 12 * HOUR_IN_SECONDS);
-        return $formatted;
-    }
-
-    return null;
+    return StripeService::get_lowest_price_with_durations($variant_ids, $duration_ids);
 }
 ?>
 <div class="produkt-shop-archive produkt-container">
@@ -43,7 +24,7 @@ function get_lowest_stripe_price_by_category($category_id) {
         <?php foreach ($categories as $cat): ?>
         <?php $url = home_url('/shop/' . sanitize_title($cat->product_title)); ?>
         <?php
-            $price = get_lowest_stripe_price_by_category($cat->id);
+            $price_data = get_lowest_stripe_price_by_category($cat->id);
         ?>
         <a class="produkt-shop-card-link" href="<?php echo esc_url($url); ?>">
             <div class="produkt-shop-card">
@@ -58,8 +39,8 @@ function get_lowest_stripe_price_by_category($category_id) {
                         <span class="produkt-star-rating produkt-star-black" style="--rating: <?php echo esc_attr($cat->rating_value); ?>;"></span>
                     </div>
                 <?php endif; ?>
-                <?php if ($price): ?>
-                    <div class="produkt-card-price">ab <?php echo esc_html($price); ?>€</div>
+                <?php if ($price_data && isset($price_data['amount'])): ?>
+                    <div class="produkt-card-price">ab <?php echo esc_html(number_format((float)$price_data['amount'], 2, ',', '.')); ?>€</div>
                 <?php else: ?>
                     <div class="produkt-card-price">Preis auf Anfrage</div>
                 <?php endif; ?>

--- a/templates/product-archive.php
+++ b/templates/product-archive.php
@@ -1,15 +1,49 @@
 <?php
 if (!defined('ABSPATH')) { exit; }
+
+use ProduktVerleih\Database;
+use Stripe\Stripe;
+use Stripe\Price;
+
+function get_lowest_stripe_price_by_category($category_id) {
+    $price_ids = Database::getAllStripePriceIdsByCategory($category_id);
+    if (empty($price_ids)) return null;
+
+    $cache_key = 'lowest_price_category_' . md5($category_id . '_' . implode('_', $price_ids));
+    $cached = get_transient($cache_key);
+    if ($cached !== false) return $cached;
+
+    Stripe::setApiKey(get_option('produkt_stripe_secret_key', ''));
+
+    $lowest = null;
+    foreach ($price_ids as $price_id) {
+        try {
+            $price = Price::retrieve($price_id);
+            if (!isset($price->unit_amount)) continue;
+            $amount = $price->unit_amount / 100;
+            if ($lowest === null || $amount < $lowest) {
+                $lowest = $amount;
+            }
+        } catch (\Exception $e) {
+            continue;
+        }
+    }
+
+    if ($lowest !== null) {
+        $formatted = number_format($lowest, 2, ',', '.');
+        set_transient($cache_key, $formatted, 12 * HOUR_IN_SECONDS);
+        return $formatted;
+    }
+
+    return null;
+}
 ?>
 <div class="produkt-shop-archive produkt-container">
     <div class="produkt-shop-grid">
         <?php foreach ($categories as $cat): ?>
         <?php $url = home_url('/shop/' . sanitize_title($cat->product_title)); ?>
         <?php
-            $price = $wpdb->get_var($wpdb->prepare(
-                "SELECT base_price FROM {$wpdb->prefix}produkt_variants WHERE category_id = %d ORDER BY sort_order LIMIT 1",
-                $cat->id
-            ));
+            $price = get_lowest_stripe_price_by_category($cat->id);
         ?>
         <a class="produkt-shop-card-link" href="<?php echo esc_url($url); ?>">
             <div class="produkt-shop-card">
@@ -24,8 +58,10 @@ if (!defined('ABSPATH')) { exit; }
                         <span class="produkt-star-rating produkt-star-black" style="--rating: <?php echo esc_attr($cat->rating_value); ?>;"></span>
                     </div>
                 <?php endif; ?>
-                <?php if ($price !== null): ?>
-                    <div class="produkt-card-price"><?php echo number_format((float)$price, 2, ',', '.'); ?>€</div>
+                <?php if ($price): ?>
+                    <div class="produkt-card-price">ab <?php echo esc_html($price); ?>€</div>
+                <?php else: ?>
+                    <div class="produkt-card-price">Preis auf Anfrage</div>
                 <?php endif; ?>
             </div>
         </a>


### PR DESCRIPTION
## Summary
- add uninstall cleanup logic in Database and Plugin classes
- provide debug tab button to remove all plugin data
- bump plugin version to 2.8.27

## Testing
- `php -l includes/Database.php` *(fails: command not found)*
- `php -l admin/tabs/debug-tab.php` *(fails: command not found)*
- `php -l includes/Plugin.php` *(fails: command not found)*
- `php -l produkt-verleih.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686d7a7efd048330833b25987567274b