### PR TITLE
Add missing variant durations table

### DIFF
--- a/includes/Database.php
+++ b/includes/Database.php
@@ -349,6 +349,26 @@ class Database {
             dbDelta($sql);
         }
 
+        // Create variant durations table if it doesn't exist
+        $table_variant_durations = $wpdb->prefix . 'produkt_variant_durations';
+        $variant_durations_exists = $wpdb->get_var("SHOW TABLES LIKE '$table_variant_durations'");
+
+        if (!$variant_durations_exists) {
+            $charset_collate = $wpdb->get_charset_collate();
+            $sql = "CREATE TABLE $table_variant_durations (
+                id mediumint(9) NOT NULL AUTO_INCREMENT,
+                variant_id mediumint(9) NOT NULL,
+                duration_id mediumint(9) NOT NULL,
+                available tinyint(1) DEFAULT 1,
+                sort_order int(11) DEFAULT 0,
+                PRIMARY KEY (id),
+                UNIQUE KEY variant_duration (variant_id, duration_id)
+            ) $charset_collate;";
+
+            require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
+            dbDelta($sql);
+        }
+
         // Create duration price table if it doesn't exist
         $table_duration_prices = $wpdb->prefix . 'produkt_duration_prices';
         $duration_prices_exists = $wpdb->get_var("SHOW TABLES LIKE '$table_duration_prices'");
@@ -726,6 +746,18 @@ class Database {
             UNIQUE KEY variant_option (variant_id, option_type, option_id)
         ) $charset_collate;";
 
+        // Variant durations table
+        $table_variant_durations = $wpdb->prefix . 'produkt_variant_durations';
+        $sql_variant_durations = "CREATE TABLE $table_variant_durations (
+            id mediumint(9) NOT NULL AUTO_INCREMENT,
+            variant_id mediumint(9) NOT NULL,
+            duration_id mediumint(9) NOT NULL,
+            available tinyint(1) DEFAULT 1,
+            sort_order int(11) DEFAULT 0,
+            PRIMARY KEY (id),
+            UNIQUE KEY variant_duration (variant_id, duration_id)
+        ) $charset_collate;";
+
         // Variant price IDs per duration
         $table_duration_prices = $wpdb->prefix . 'produkt_duration_prices';
         $sql_duration_prices = "CREATE TABLE $table_duration_prices (
@@ -787,6 +819,7 @@ class Database {
         dbDelta($sql_colors);
         dbDelta($sql_color_variant_images);
         dbDelta($sql_variant_options);
+        dbDelta($sql_variant_durations);
         dbDelta($sql_duration_prices);
         dbDelta($sql_orders);
 
@@ -1016,6 +1049,7 @@ class Database {
             'produkt_colors',
             'produkt_color_variant_images',
             'produkt_variant_options',
+            'produkt_variant_durations',
             'produkt_duration_prices',
             'produkt_orders',
             'produkt_order_logs',

--- a/produkt-verleih.php
+++ b/produkt-verleih.php
@@ -3,7 +3,7 @@
  * Plugin Name: H2 Concepts Rental Pro
   * Plugin URI: https://h2concepts.de
   * Description: Ein Plugin für den Verleih von Waren mit konfigurierbaren Produkten und Stripe-Integration
-* Version: 2.8.30
+* Version: 2.8.31
   * Author: H2 Concepts
   * License: GPL v2 or later
   * Text Domain: h2-concepts
@@ -14,7 +14,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Plugin constants
-const PRODUKT_PLUGIN_VERSION = '2.8.30';
+const PRODUKT_PLUGIN_VERSION = '2.8.31';
 const PRODUKT_PLUGIN_DIR = __DIR__ . '/';
 define('PRODUKT_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('PRODUKT_PLUGIN_PATH', PRODUKT_PLUGIN_DIR);


### PR DESCRIPTION
## Summary
- create `produkt_variant_durations` table during plugin setup and updates
- drop the new table during uninstall
- bump plugin version to 2.8.31

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686da44fb05c833095bc461762c041b4