### PR TITLE
Add product category mapping tables

### DIFF
--- a/admin/categories-page.php
+++ b/admin/categories-page.php
@@ -1,98 +1,62 @@
 <?php
-use ProduktVerleih\Database;
-
-if (!current_user_can('manage_options')) {
-    return;
-}
-
-// Kategorie speichern
-if (isset($_POST['save_category'])) {
-    $name = sanitize_text_field($_POST['name']);
-    $slug = sanitize_title($_POST['slug']);
-    $description = sanitize_textarea_field($_POST['description']);
-    $id = isset($_POST['category_id']) ? intval($_POST['category_id']) : 0;
-
-    global $wpdb;
-    $table = $wpdb->prefix . 'produkt_product_categories';
-
-    if ($id > 0) {
-        $wpdb->update($table, [
-            'name' => $name,
-            'slug' => $slug,
-            'description' => $description
-        ], ['id' => $id]);
-    } else {
-        $wpdb->insert($table, [
-            'name' => $name,
-            'slug' => $slug,
-            'description' => $description
-        ]);
-    }
-}
-
-// Kategorie löschen
-if (isset($_GET['delete'])) {
-    $delete_id = intval($_GET['delete']);
-    global $wpdb;
-    $wpdb->delete($wpdb->prefix . 'produkt_product_categories', ['id' => $delete_id]);
-    $wpdb->delete($wpdb->prefix . 'produkt_product_to_category', ['category_id' => $delete_id]);
-}
-
-global $wpdb;
-$categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_product_categories ORDER BY name ASC");
-
-// Wenn Bearbeiten
-$edit_category = null;
-if (isset($_GET['edit'])) {
-    $edit_id = intval($_GET['edit']);
-    $edit_category = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$wpdb->prefix}produkt_product_categories WHERE id = %d", $edit_id));
+if (!defined('ABSPATH')) {
+    exit;
 }
 ?>
 
 <div class="wrap">
-    <h1>Kategorien verwalten</h1>
-
-    <h2><?= $edit_category ? 'Kategorie bearbeiten' : 'Neue Kategorie hinzufügen' ?></h2>
-
-    <form method="post">
-        <input type="hidden" name="category_id" value="<?= esc_attr($edit_category->id ?? '') ?>">
-        <table class="form-table">
-            <tr>
-                <th><label for="name">Name</label></th>
-                <td><input name="name" type="text" required value="<?= esc_attr($edit_category->name ?? '') ?>" class="regular-text"></td>
-            </tr>
-            <tr>
-                <th><label for="slug">Slug</label></th>
-                <td><input name="slug" type="text" required value="<?= esc_attr($edit_category->slug ?? '') ?>" class="regular-text"></td>
-            </tr>
-            <tr>
-                <th><label for="description">Beschreibung</label></th>
-                <td><textarea name="description" class="large-text"><?= esc_textarea($edit_category->description ?? '') ?></textarea></td>
-            </tr>
-        </table>
-        <p><input type="submit" name="save_category" class="button-primary" value="Speichern"></p>
-    </form>
-
-    <h2>Bestehende Kategorien</h2>
-    <table class="widefat striped">
-        <thead>
-            <tr>
-                <th>Name</th>
-                <th>Slug</th>
-                <th>Aktionen</th>
-            </tr>
-        </thead>
-        <tbody>
-            <?php foreach ($categories as $cat): ?>
-                <tr>
-                    <td><?= esc_html($cat->name) ?></td>
-                    <td><?= esc_html($cat->slug) ?></td>
-                    <td>
-                        <a href="?page=produkt-kategorien&edit=<?= $cat->id ?>" class="button">Bearbeiten</a>
-                        <a href="?page=produkt-kategorien&delete=<?= $cat->id ?>" class="button button-danger" onclick="return confirm('Wirklich löschen?')">Löschen</a>
-                    </td>
-                </tr>
-            <?php endforeach ?>
-        </tbody>
-    </table>
+    <!-- Kompakter Header -->
+    <div class="produkt-admin-header-compact">
+        <div class="produkt-admin-logo-compact">🏷️</div>
+        <div class="produkt-admin-title-compact">
+            <h1>Produkte verwalten</h1>
+            <p>Produkte & SEO-Einstellungen</p>
+        </div>
+    </div>
+    
+    <!-- Breadcrumb Navigation -->
+    <div class="produkt-breadcrumb">
+        <a href="<?php echo admin_url('admin.php?page=produkt-verleih'); ?>">Dashboard</a> 
+        <span>→</span> 
+        <strong>Produkte</strong>
+    </div>
+    
+    <!-- Tab Navigation -->
+    <div class="produkt-tab-nav">
+        <a href="<?php echo admin_url('admin.php?page=produkt-categories&tab=list'); ?>" 
+           class="produkt-tab <?php echo $active_tab === 'list' ? 'active' : ''; ?>">
+            📋 Übersicht
+        </a>
+        <a href="<?php echo admin_url('admin.php?page=produkt-categories&tab=add'); ?>" 
+           class="produkt-tab <?php echo $active_tab === 'add' ? 'active' : ''; ?>">
+            ➕ Neues Produkt
+        </a>
+        <?php if ($edit_item): ?>
+        <a href="<?php echo admin_url('admin.php?page=produkt-categories&tab=edit&edit=' . $edit_item->id); ?>" 
+           class="produkt-tab <?php echo $active_tab === 'edit' ? 'active' : ''; ?>">
+            ✏️ Bearbeiten
+        </a>
+        <?php endif; ?>
+    </div>
+    
+    <!-- Tab Content -->
+    <div class="produkt-tab-content">
+        <?php
+        switch ($active_tab) {
+            case 'add':
+                include PRODUKT_PLUGIN_PATH . 'admin/tabs/categories-add-tab.php';
+                break;
+            case 'edit':
+                if ($edit_item) {
+                    include PRODUKT_PLUGIN_PATH . 'admin/tabs/categories-edit-tab.php';
+                } else {
+                    include PRODUKT_PLUGIN_PATH . 'admin/tabs/categories-list-tab.php';
+                }
+                break;
+            case 'list':
+            default:
+                include PRODUKT_PLUGIN_PATH . 'admin/tabs/categories-list-tab.php';
+        }
+        ?>
+    </div>
 </div>

--- a/admin/main-page.php
+++ b/admin/main-page.php
@@ -126,7 +126,7 @@ foreach ($branding_results as $result) {
         <h3>🛒 Letzte Produkte</h3>
         <div class="produkt-category-cards">
             <?php foreach ($recent_products as $prod): ?>
-            <?php $prod_url = home_url('/shop/' . sanitize_title($prod->product_title)); ?>
+            <?php $prod_url = home_url('/shop/produkt/' . sanitize_title($prod->product_title)); ?>
             <div class="produkt-category-card">
                 <?php if (!empty($prod->default_image)): ?>
                     <img src="<?php echo esc_url($prod->default_image); ?>" class="produkt-recent-image" alt="<?php echo esc_attr($prod->name); ?>">

--- a/admin/product-categories-page.php
+++ b/admin/product-categories-page.php
@@ -1,0 +1,98 @@
+<?php
+use ProduktVerleih\Database;
+
+if (!current_user_can('manage_options')) {
+    return;
+}
+
+// Kategorie speichern
+if (isset($_POST['save_category'])) {
+    $name = sanitize_text_field($_POST['name']);
+    $slug = sanitize_title($_POST['slug']);
+    $description = sanitize_textarea_field($_POST['description']);
+    $id = isset($_POST['category_id']) ? intval($_POST['category_id']) : 0;
+
+    global $wpdb;
+    $table = $wpdb->prefix . 'produkt_product_categories';
+
+    if ($id > 0) {
+        $wpdb->update($table, [
+            'name' => $name,
+            'slug' => $slug,
+            'description' => $description
+        ], ['id' => $id]);
+    } else {
+        $wpdb->insert($table, [
+            'name' => $name,
+            'slug' => $slug,
+            'description' => $description
+        ]);
+    }
+}
+
+// Kategorie löschen
+if (isset($_GET['delete'])) {
+    $delete_id = intval($_GET['delete']);
+    global $wpdb;
+    $wpdb->delete($wpdb->prefix . 'produkt_product_categories', ['id' => $delete_id]);
+    $wpdb->delete($wpdb->prefix . 'produkt_product_to_category', ['category_id' => $delete_id]);
+}
+
+global $wpdb;
+$categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_product_categories ORDER BY name ASC");
+
+// Wenn Bearbeiten
+$edit_category = null;
+if (isset($_GET['edit'])) {
+    $edit_id = intval($_GET['edit']);
+    $edit_category = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$wpdb->prefix}produkt_product_categories WHERE id = %d", $edit_id));
+}
+?>
+
+<div class="wrap">
+    <h1>Kategorien verwalten</h1>
+
+    <h2><?= $edit_category ? 'Kategorie bearbeiten' : 'Neue Kategorie hinzufügen' ?></h2>
+
+    <form method="post">
+        <input type="hidden" name="category_id" value="<?= esc_attr($edit_category->id ?? '') ?>">
+        <table class="form-table">
+            <tr>
+                <th><label for="name">Name</label></th>
+                <td><input name="name" type="text" required value="<?= esc_attr($edit_category->name ?? '') ?>" class="regular-text"></td>
+            </tr>
+            <tr>
+                <th><label for="slug">Slug</label></th>
+                <td><input name="slug" type="text" required value="<?= esc_attr($edit_category->slug ?? '') ?>" class="regular-text"></td>
+            </tr>
+            <tr>
+                <th><label for="description">Beschreibung</label></th>
+                <td><textarea name="description" class="large-text"><?= esc_textarea($edit_category->description ?? '') ?></textarea></td>
+            </tr>
+        </table>
+        <p><input type="submit" name="save_category" class="button-primary" value="Speichern"></p>
+    </form>
+
+    <h2>Bestehende Kategorien</h2>
+    <table class="widefat striped">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Slug</th>
+                <th>Aktionen</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($categories as $cat): ?>
+                <tr>
+                    <td><?= esc_html($cat->name) ?></td>
+                    <td><?= esc_html($cat->slug) ?></td>
+                    <td>
+                        <a href="?page=produkt-kategorien&edit=<?= $cat->id ?>" class="button">Bearbeiten</a>
+                        <a href="?page=produkt-kategorien&delete=<?= $cat->id ?>" class="button button-danger" onclick="return confirm('Wirklich löschen?')">Löschen</a>
+                    </td>
+                </tr>
+            <?php endforeach ?>
+        </tbody>
+    </table>
+</div>

--- a/admin/tabs/categories-add-tab.php
+++ b/admin/tabs/categories-add-tab.php
@@ -10,6 +10,10 @@
     
     <form method="post" action="" class="produkt-compact-form">
         <?php wp_nonce_field('produkt_admin_action', 'produkt_admin_nonce'); ?>
+        <?php
+        global $wpdb;
+        $all_product_cats = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_product_categories ORDER BY name ASC");
+        ?>
         <!-- Grunddaten -->
         <div class="produkt-form-section">
             <h4>📝 Grunddaten</h4>
@@ -270,6 +274,17 @@
                     <label>Sortierung</label>
                     <input type="number" name="sort_order" min="0">
                 </div>
+            </div>
+            <div class="produkt-form-group">
+                <label>Kategorien</label>
+                <select name="product_categories[]" multiple style="width:100%; height:auto; min-height:100px;">
+                    <?php foreach ($all_product_cats as $cat): ?>
+                        <option value="<?php echo $cat->id; ?>">
+                            <?php echo esc_html($cat->name); ?>
+                        </option>
+                    <?php endforeach; ?>
+                </select>
+                <p class="description">Wählen Sie eine oder mehrere Kategorien für dieses Produkt.</p>
             </div>
         </div>
         

--- a/admin/tabs/categories-edit-tab.php
+++ b/admin/tabs/categories-edit-tab.php
@@ -11,6 +11,16 @@
     <form method="post" action="" class="produkt-compact-form">
         <?php wp_nonce_field('produkt_admin_action', 'produkt_admin_nonce'); ?>
         <input type="hidden" name="id" value="<?php echo esc_attr($edit_item->id); ?>">
+        <?php
+        global $wpdb;
+        $all_product_cats = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_product_categories ORDER BY name ASC");
+        $selected_product_cats = $wpdb->get_col(
+            $wpdb->prepare(
+                "SELECT category_id FROM {$wpdb->prefix}produkt_product_to_category WHERE produkt_id = %d",
+                $edit_item->id
+            )
+        );
+        ?>
 
         <div class="produkt-subtab-nav">
             <a href="#" class="produkt-subtab active" data-tab="general">Allgemein</a>
@@ -71,6 +81,17 @@
                     <label>Sortierung</label>
                     <input type="number" name="sort_order" value="<?php echo $edit_item->sort_order; ?>" min="0">
                 </div>
+            </div>
+            <div class="produkt-form-group">
+                <label>Kategorien</label>
+                <select name="product_categories[]" multiple style="width:100%; height:auto; min-height:100px;">
+                    <?php foreach ($all_product_cats as $cat): ?>
+                        <option value="<?php echo $cat->id; ?>" <?php echo in_array($cat->id, $selected_product_cats) ? 'selected' : ''; ?>>
+                            <?php echo esc_html($cat->name); ?>
+                        </option>
+                    <?php endforeach; ?>
+                </select>
+                <p class="description">Wählen Sie eine oder mehrere Kategorien für dieses Produkt.</p>
             </div>
         </div>
 

--- a/admin/tabs/categories-list-tab.php
+++ b/admin/tabs/categories-list-tab.php
@@ -43,7 +43,7 @@
                     <code>[produkt_product category="<?php echo esc_html($category->shortcode); ?>"]</code>
                 </div>
 
-                <?php $product_url = home_url('/shop/' . sanitize_title($category->product_title)); ?>
+                <?php $product_url = home_url('/shop/produkt/' . sanitize_title($category->product_title)); ?>
                 <div class="produkt-category-url">
                     <code><?php echo esc_url($product_url); ?></code>
                 </div>

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -123,12 +123,13 @@ class Admin {
         global $post;
 
         $slug = sanitize_title(get_query_var('produkt_slug'));
+        $category_slug = sanitize_title(get_query_var('produkt_category_slug'));
 
-        if (!is_singular() && empty($slug)) {
+        if (!is_singular() && empty($slug) && empty($category_slug)) {
             return;
         }
 
-        if (empty($slug)) {
+        if (empty($slug) && empty($category_slug)) {
             $content = $post->post_content ?? '';
             if (!has_shortcode($content, 'produkt_product') && !has_shortcode($content, 'stripe_elements_form') && !has_shortcode($content, 'produkt_shop_grid')) {
                 return;

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -136,6 +136,7 @@ class Admin {
             }
         }
 
+        wp_enqueue_emoji_styles();
         wp_enqueue_style('produkt-style', PRODUKT_PLUGIN_URL . 'assets/style.css', array(), PRODUKT_VERSION);
         if (!empty($slug) || (isset($content) && has_shortcode($content, 'produkt_product'))) {
             wp_enqueue_script('produkt-script', PRODUKT_PLUGIN_URL . 'assets/script.js', array('jquery'), PRODUKT_VERSION, true);
@@ -210,6 +211,7 @@ class Admin {
     
     public function enqueue_admin_assets($hook) {
         if (strpos($hook, 'produkt') !== false) {
+            wp_enqueue_admin_bar_header_styles();
             wp_enqueue_style('produkt-admin-style', PRODUKT_PLUGIN_URL . 'assets/admin-style.css', array(), PRODUKT_VERSION);
             wp_enqueue_script('produkt-admin-script', PRODUKT_PLUGIN_URL . 'assets/admin-script.js', array('jquery'), PRODUKT_VERSION, true);
 

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -125,11 +125,7 @@ class Admin {
         $slug = sanitize_title(get_query_var('produkt_slug'));
         $category_slug = sanitize_title(get_query_var('produkt_category_slug'));
 
-        if (!is_singular() && empty($slug) && empty($category_slug)) {
-            return;
-        }
-
-        if (empty($slug) && empty($category_slug)) {
+        if (!is_page('shop') && empty($slug) && empty($category_slug)) {
             $content = $post->post_content ?? '';
             if (!has_shortcode($content, 'produkt_product') && !has_shortcode($content, 'stripe_elements_form') && !has_shortcode($content, 'produkt_shop_grid')) {
                 return;

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -120,89 +120,18 @@ class Admin {
     }
     
     public function enqueue_frontend_assets() {
-        global $post;
-
-        $slug = sanitize_title(get_query_var('produkt_slug'));
-        $category_slug = sanitize_title(get_query_var('produkt_category_slug'));
-
-        if (!is_page('shop') && empty($slug) && empty($category_slug)) {
-            $content = $post->post_content ?? '';
-            if (!has_shortcode($content, 'produkt_product') && !has_shortcode($content, 'stripe_elements_form') && !has_shortcode($content, 'produkt_shop_grid')) {
-                return;
-            }
+        if (
+            is_page('shop') ||
+            get_query_var('produkt_category_slug') ||
+            get_query_var('produkt_slug')
+        ) {
+            wp_enqueue_style(
+                'produkt-style',
+                PRODUKT_PLUGIN_URL . 'assets/style.css',
+                [],
+                '1.0'
+            );
         }
-
-        wp_enqueue_emoji_styles();
-        wp_enqueue_style('produkt-style', PRODUKT_PLUGIN_URL . 'assets/style.css', array(), PRODUKT_VERSION);
-        if (!empty($slug) || (isset($content) && has_shortcode($content, 'produkt_product'))) {
-            wp_enqueue_script('produkt-script', PRODUKT_PLUGIN_URL . 'assets/script.js', array('jquery'), PRODUKT_VERSION, true);
-        }
-
-        $branding = $this->get_branding_settings();
-        $button_color = $branding['front_button_color'] ?? '#5f7f5f';
-        $text_color   = $branding['front_text_color'] ?? '#4a674a';
-        $border_color = $branding['front_border_color'] ?? '#a4b8a4';
-        $button_text_color = $branding['front_button_text_color'] ?? '#ffffff';
-        $custom_css = $branding['custom_css'] ?? '';
-        $inline_css = ":root{--produkt-button-bg:{$button_color};--produkt-text-color:{$text_color};--produkt-border-color:{$border_color};--produkt-button-text:{$button_text_color};}";
-        if (!empty($custom_css)) {
-            $inline_css .= "\n" . $custom_css;
-        }
-        wp_add_inline_style('produkt-style', $inline_css);
-
-        global $wpdb;
-        $category = null;
-        if ($slug) {
-            $categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_categories");
-            foreach ($categories as $cat) {
-                if (sanitize_title($cat->product_title) === sanitize_title($slug)) {
-                    $category = $cat;
-                    break;
-                }
-            }
-        } else {
-            $pattern = '/\[produkt_product[^\]]*category=["\']([^"\']*)["\'][^\]]*\]/';
-            preg_match($pattern, $post->post_content, $matches);
-            $category_shortcode = isset($matches[1]) ? $matches[1] : '';
-
-            if (!empty($category_shortcode)) {
-                $category = $wpdb->get_row($wpdb->prepare(
-                    "SELECT * FROM {$wpdb->prefix}produkt_categories WHERE shortcode = %s",
-                    $category_shortcode
-                ));
-            }
-        }
-        if (!$category) {
-            $category = $wpdb->get_row("SELECT * FROM {$wpdb->prefix}produkt_categories ORDER BY sort_order LIMIT 1");
-        }
-
-        $popup_settings = get_option('produkt_popup_settings');
-        if ($popup_settings === false) {
-            $legacy_key = base64_decode('ZmVkZXJ3aWVnZV9wb3B1cF9zZXR0aW5ncw==');
-            $popup_settings = get_option($legacy_key, []);
-        }
-        $options = [];
-        if (!empty($popup_settings['options'])) {
-            $opts = array_filter(array_map('trim', explode("\n", $popup_settings['options'])));
-            $options = array_values($opts);
-        }
-        $popup_enabled = isset($popup_settings['enabled']) ? intval($popup_settings['enabled']) : 0;
-        $popup_days    = isset($popup_settings['days']) ? intval($popup_settings['days']) : 7;
-
-        wp_localize_script('produkt-script', 'produkt_ajax', array(
-            'ajax_url' => admin_url('admin-ajax.php'),
-            'nonce' => wp_create_nonce('produkt_nonce'),
-            'price_period' => $category->price_period ?? 'month',
-            'price_label' => $category->price_label ?? 'Monatlicher Mietpreis',
-            'vat_included' => isset($category->vat_included) ? intval($category->vat_included) : 0,
-            'popup_settings' => array(
-                'enabled' => $popup_enabled,
-                'days'    => $popup_days,
-                'title'   => $popup_settings['title'] ?? '',
-                'content' => wpautop($popup_settings['content'] ?? ''),
-                'options' => $options
-            )
-        ));
     }
     
     public function enqueue_admin_assets($hook) {

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -122,7 +122,7 @@ class Admin {
     public function enqueue_frontend_assets() {
         global $post;
 
-        $slug = get_query_var('produkt_slug');
+        $slug = sanitize_title(get_query_var('produkt_slug'));
 
         if (!is_singular() && empty($slug)) {
             return;

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -45,7 +45,7 @@ class Admin {
             'manage_options',
             'produkt-kategorien',
             function () {
-                include PRODUKT_PLUGIN_PATH . 'admin/categories-page.php';
+                include PRODUKT_PLUGIN_PATH . 'admin/product-categories-page.php';
             }
         );
         
@@ -417,7 +417,18 @@ class Admin {
                     array('%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%d','%s','%s','%s','%d','%d','%d','%f','%s','%d'),
                 );
 
+                $produkt_id = intval($_POST['id']);
+
                 if ($result !== false) {
+                    if (isset($_POST['product_categories']) && is_array($_POST['product_categories'])) {
+                        $wpdb->delete($wpdb->prefix . 'produkt_product_to_category', ['produkt_id' => $produkt_id]);
+                        foreach ($_POST['product_categories'] as $cat_id) {
+                            $wpdb->insert($wpdb->prefix . 'produkt_product_to_category', [
+                                'produkt_id' => $produkt_id,
+                                'category_id' => intval($cat_id)
+                            ]);
+                        }
+                    }
                     echo '<div class="notice notice-success"><p>✅ Produkt erfolgreich aktualisiert!</p></div>';
                 } else {
                     echo '<div class="notice notice-error"><p>❌ Fehler beim Aktualisieren: ' . esc_html($wpdb->last_error) . '</p></div>';
@@ -469,7 +480,18 @@ class Admin {
                     array('%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%d','%s','%s','%s','%d','%d','%d','%f','%s','%d')
                 );
 
+                $produkt_id = $wpdb->insert_id;
+
                 if ($result !== false) {
+                    if (isset($_POST['product_categories']) && is_array($_POST['product_categories'])) {
+                        $wpdb->delete($wpdb->prefix . 'produkt_product_to_category', ['produkt_id' => $produkt_id]);
+                        foreach ($_POST['product_categories'] as $cat_id) {
+                            $wpdb->insert($wpdb->prefix . 'produkt_product_to_category', [
+                                'produkt_id' => $produkt_id,
+                                'category_id' => intval($cat_id)
+                            ]);
+                        }
+                    }
                     echo '<div class="notice notice-success"><p>✅ Produkt erfolgreich hinzugefügt!</p></div>';
                 } else {
                     echo '<div class="notice notice-error"><p>❌ Fehler beim Hinzufügen: ' . esc_html($wpdb->last_error) . '</p></div>';

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -36,6 +36,18 @@ class Admin {
             'produkt-categories',
             array($this, 'categories_page')
         );
+
+        // Manage simple product categories
+        add_submenu_page(
+            'produkt-verleih',
+            'Kategorien',
+            'Kategorien',
+            'manage_options',
+            'produkt-kategorien',
+            function () {
+                include PRODUKT_PLUGIN_PATH . 'admin/categories-page.php';
+            }
+        );
         
         // Submenu: Produktverwaltung
         add_submenu_page(

--- a/includes/Database.php
+++ b/includes/Database.php
@@ -1136,4 +1136,22 @@ class Database {
 
         return array_filter((array) $price_ids);
     }
+
+    /**
+     * Retrieve all product categories.
+     *
+     * @param bool $only_active If true, return only active categories
+     * @return array List of category objects
+     */
+    public static function get_all_categories($only_active = true) {
+        global $wpdb;
+
+        $sql = "SELECT * FROM {$wpdb->prefix}produkt_categories";
+        if ($only_active) {
+            $sql .= " WHERE active = 1";
+        }
+        $sql .= " ORDER BY sort_order";
+
+        return $wpdb->get_results($sql);
+    }
 }

--- a/includes/Database.php
+++ b/includes/Database.php
@@ -569,6 +569,26 @@ class Database {
         global $wpdb;
         
         $charset_collate = $wpdb->get_charset_collate();
+
+        // Simple category table for grouping products
+        $table_prod_categories = $wpdb->prefix . 'produkt_product_categories';
+        $sql_prod_categories = "CREATE TABLE IF NOT EXISTS $table_prod_categories (
+            id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+            name VARCHAR(255) NOT NULL,
+            slug VARCHAR(255) NOT NULL UNIQUE,
+            description TEXT DEFAULT NULL,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (id)
+        ) $charset_collate;";
+
+        // Mapping table between products and categories
+        $table_prod_to_cat = $wpdb->prefix . 'produkt_product_to_category';
+        $sql_prod_to_cat = "CREATE TABLE IF NOT EXISTS $table_prod_to_cat (
+            produkt_id INT UNSIGNED NOT NULL,
+            category_id INT UNSIGNED NOT NULL,
+            PRIMARY KEY (produkt_id, category_id),
+            KEY category_id (category_id)
+        ) $charset_collate;";
         
         // Categories table for different product categories (with SEO fields)
         $table_categories = $wpdb->prefix . 'produkt_categories';
@@ -818,6 +838,8 @@ class Database {
         ) $charset_collate;";
         
         require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
+        dbDelta($sql_prod_categories);
+        dbDelta($sql_prod_to_cat);
         dbDelta($sql_categories);
         dbDelta($sql_variants);
         dbDelta($sql_extras);
@@ -1053,6 +1075,8 @@ class Database {
         global $wpdb;
 
         $tables = array(
+            'produkt_product_categories',
+            'produkt_product_to_category',
             'produkt_categories',
             'produkt_variants',
             'produkt_extras',

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -32,8 +32,17 @@ class Plugin {
         add_action('admin_enqueue_scripts', [$this->admin, 'enqueue_admin_assets']);
 
         add_rewrite_rule('^shop/([^/]+)/?$', 'index.php?produkt_slug=$matches[1]', 'top');
+        add_rewrite_rule(
+            '^shop/([^/]+)/?$',
+            'index.php?produkt_category=$matches[1]',
+            'top'
+        );
         add_filter('query_vars', function ($vars) {
             $vars[] = 'produkt_slug';
+            return $vars;
+        });
+        add_filter('query_vars', function ($vars) {
+            $vars[] = 'produkt_category';
             return $vars;
         });
         add_action('template_redirect', [$this, 'maybe_display_product_page']);
@@ -79,6 +88,11 @@ class Plugin {
         }
         update_option('produkt_version', PRODUKT_VERSION);
         add_rewrite_rule('^shop/([^/]+)/?$', 'index.php?produkt_slug=$matches[1]', 'top');
+        add_rewrite_rule(
+            '^shop/([^/]+)/?$',
+            'index.php?produkt_category=$matches[1]',
+            'top'
+        );
         $this->create_shop_page();
         flush_rewrite_rules();
     }

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -191,7 +191,7 @@ class Plugin {
     public function add_meta_tags() {
         global $post, $wpdb;
 
-        $slug = get_query_var('produkt_slug');
+        $slug = sanitize_title(get_query_var('produkt_slug'));
 
         if (!is_singular() && empty($slug)) {
             return;
@@ -244,7 +244,7 @@ class Plugin {
     public function add_open_graph_tags() {
         global $post, $wpdb;
 
-        $slug = get_query_var('produkt_slug');
+        $slug = sanitize_title(get_query_var('produkt_slug'));
 
         if (!is_singular() && empty($slug)) {
             return;
@@ -308,7 +308,7 @@ class Plugin {
     public function add_schema_markup() {
         global $post, $wpdb;
 
-        $slug = get_query_var('produkt_slug');
+        $slug = sanitize_title(get_query_var('produkt_slug'));
 
         if (!is_singular() && empty($slug)) {
             return;
@@ -484,7 +484,7 @@ class Plugin {
     }
 
     public function maybe_display_product_page() {
-        $slug = get_query_var('produkt_slug');
+        $slug = sanitize_title(get_query_var('produkt_slug'));
         if (empty($slug)) {
             return;
         }

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -578,13 +578,10 @@ class Plugin {
     }
 }
 
-add_action('template_redirect', function () {
+add_action('template_include', function ($template) {
     if (isset($_SERVER['REQUEST_URI']) && preg_match('#^/shop(?:/([^/]+))?/?$#', $_SERVER['REQUEST_URI'], $matches)) {
         $_GET['produkt_category'] = isset($matches[1]) ? sanitize_title($matches[1]) : '';
-        global $wpdb;
-        $categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_categories WHERE active = 1 ORDER BY sort_order");
-        status_header(200);
-        include PRODUKT_PLUGIN_PATH . 'templates/product-archive.php';
-        exit;
+        return plugin_dir_path(__FILE__) . 'templates/product-archive.php';
     }
+    return $template;
 });

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -581,7 +581,7 @@ class Plugin {
 add_action('template_include', function ($template) {
     if (isset($_SERVER['REQUEST_URI']) && preg_match('#^/shop(?:/([^/]+))?/?$#', $_SERVER['REQUEST_URI'], $matches)) {
         $_GET['produkt_category'] = isset($matches[1]) ? sanitize_title($matches[1]) : '';
-        return plugin_dir_path(__FILE__) . 'templates/product-archive.php';
+        return PRODUKT_PLUGIN_PATH . 'templates/product-archive.php';
     }
     return $template;
 });

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -32,17 +32,10 @@ class Plugin {
         add_action('admin_enqueue_scripts', [$this->admin, 'enqueue_admin_assets']);
 
         add_rewrite_rule('^shop/produkt/([^/]+)/?$', 'index.php?produkt_slug=$matches[1]', 'top');
-        add_rewrite_rule(
-            '^shop/([^/]+)/?$',
-            'index.php?produkt_category=$matches[1]',
-            'top'
-        );
+        add_rewrite_rule('^shop/([^/]+)/?$', 'index.php?produkt_category_slug=$matches[1]', 'top');
         add_filter('query_vars', function ($vars) {
             $vars[] = 'produkt_slug';
-            return $vars;
-        });
-        add_filter('query_vars', function ($vars) {
-            $vars[] = 'produkt_category';
+            $vars[] = 'produkt_category_slug';
             return $vars;
         });
 
@@ -88,11 +81,7 @@ class Plugin {
         }
         update_option('produkt_version', PRODUKT_VERSION);
         add_rewrite_rule('^shop/produkt/([^/]+)/?$', 'index.php?produkt_slug=$matches[1]', 'top');
-        add_rewrite_rule(
-            '^shop/([^/]+)/?$',
-            'index.php?produkt_category=$matches[1]',
-            'top'
-        );
+        add_rewrite_rule('^shop/([^/]+)/?$', 'index.php?produkt_category_slug=$matches[1]', 'top');
         $this->create_shop_page();
         flush_rewrite_rules();
     }
@@ -193,14 +182,6 @@ class Plugin {
 
     public function render_product_grid() {
         global $wpdb;
-        if (
-            isset($_SERVER['REQUEST_URI']) &&
-            !preg_match('#^/shop/produkt/#', $_SERVER['REQUEST_URI']) &&
-            preg_match('#^/shop/([^/]+)/?$#', $_SERVER['REQUEST_URI'], $matches)
-        ) {
-            $_GET['produkt_category'] = sanitize_title($matches[1]);
-        }
-
         $categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_categories WHERE active = 1 ORDER BY sort_order");
         ob_start();
         include PRODUKT_PLUGIN_PATH . 'templates/product-archive.php';
@@ -583,15 +564,11 @@ class Plugin {
 }
 
 add_filter('template_include', function ($template) {
-    $uri = $_SERVER['REQUEST_URI'];
-
-    if (preg_match('#^/shop/produkt/([^/]+)/?$#', $uri, $matches)) {
-        $_GET['produkt_slug'] = sanitize_title($matches[1]);
+    if (get_query_var('produkt_slug')) {
         return PRODUKT_PLUGIN_PATH . 'templates/product-page.php';
     }
 
-    if (!preg_match('#^/shop/produkt/#', $uri) && preg_match('#^/shop/([^/]+)/?$#', $uri, $matches)) {
-        $_GET['produkt_category'] = sanitize_title($matches[1]);
+    if (get_query_var('produkt_category_slug')) {
         return PRODUKT_PLUGIN_PATH . 'templates/product-archive.php';
     }
 

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -577,3 +577,14 @@ class Plugin {
         return null;
     }
 }
+
+add_action('template_redirect', function () {
+    if (isset($_SERVER['REQUEST_URI']) && preg_match('#^/shop(?:/([^/]+))?/?$#', $_SERVER['REQUEST_URI'], $matches)) {
+        $_GET['produkt_category'] = isset($matches[1]) ? sanitize_title($matches[1]) : '';
+        global $wpdb;
+        $categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_categories WHERE active = 1 ORDER BY sort_order");
+        status_header(200);
+        include PRODUKT_PLUGIN_PATH . 'templates/product-archive.php';
+        exit;
+    }
+});

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -33,7 +33,7 @@ class Plugin {
 
         add_rewrite_rule('^shop/produkt/([^/]+)/?$', 'index.php?produkt_slug=$matches[1]', 'top');
         add_rewrite_rule(
-            '^shop/kategorie/([^/]+)/?$',
+            '^shop/([^/]+)/?$',
             'index.php?produkt_category=$matches[1]',
             'top'
         );
@@ -89,7 +89,7 @@ class Plugin {
         update_option('produkt_version', PRODUKT_VERSION);
         add_rewrite_rule('^shop/produkt/([^/]+)/?$', 'index.php?produkt_slug=$matches[1]', 'top');
         add_rewrite_rule(
-            '^shop/kategorie/([^/]+)/?$',
+            '^shop/([^/]+)/?$',
             'index.php?produkt_category=$matches[1]',
             'top'
         );
@@ -193,7 +193,11 @@ class Plugin {
 
     public function render_product_grid() {
         global $wpdb;
-        if (isset($_SERVER['REQUEST_URI']) && preg_match('#^/shop/kategorie/([^/]+)/?$#', $_SERVER['REQUEST_URI'], $matches)) {
+        if (
+            isset($_SERVER['REQUEST_URI']) &&
+            !preg_match('#^/shop/produkt/#', $_SERVER['REQUEST_URI']) &&
+            preg_match('#^/shop/([^/]+)/?$#', $_SERVER['REQUEST_URI'], $matches)
+        ) {
             $_GET['produkt_category'] = sanitize_title($matches[1]);
         }
 
@@ -581,14 +585,14 @@ class Plugin {
 add_filter('template_include', function ($template) {
     $uri = $_SERVER['REQUEST_URI'];
 
-    if (preg_match('#^/shop/kategorie/([^/]+)/?$#', $uri, $matches)) {
-        $_GET['produkt_category'] = sanitize_title($matches[1]);
-        return PRODUKT_PLUGIN_PATH . 'templates/product-archive.php';
-    }
-
     if (preg_match('#^/shop/produkt/([^/]+)/?$#', $uri, $matches)) {
         $_GET['produkt_slug'] = sanitize_title($matches[1]);
         return PRODUKT_PLUGIN_PATH . 'templates/product-page.php';
+    }
+
+    if (!preg_match('#^/shop/produkt/#', $uri) && preg_match('#^/shop/([^/]+)/?$#', $uri, $matches)) {
+        $_GET['produkt_category'] = sanitize_title($matches[1]);
+        return PRODUKT_PLUGIN_PATH . 'templates/product-archive.php';
     }
 
     return $template;

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -193,6 +193,10 @@ class Plugin {
 
     public function render_product_grid() {
         global $wpdb;
+        if (isset($_SERVER['REQUEST_URI']) && preg_match('#^/shop/([^/]+)/?$#', $_SERVER['REQUEST_URI'], $matches)) {
+            $_GET['produkt_category'] = sanitize_title($matches[1]);
+        }
+
         $categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_categories WHERE active = 1 ORDER BY sort_order");
         ob_start();
         include PRODUKT_PLUGIN_PATH . 'templates/product-archive.php';

--- a/templates/product-archive.php
+++ b/templates/product-archive.php
@@ -8,6 +8,11 @@ get_header();
 use ProduktVerleih\Database;
 use ProduktVerleih\StripeService;
 
+$categories = Database::get_all_categories(true);
+if (!is_array($categories)) {
+    $categories = [];
+}
+
 $category_slug = isset($_GET['produkt_category']) ? sanitize_title($_GET['produkt_category']) : '';
 echo '<pre>DEBUG: Kategorie-Slug = ' . htmlspecialchars($category_slug) . '</pre>';
 $filtered_product_ids = [];
@@ -26,7 +31,7 @@ if (!empty($category_slug)) {
             "SELECT produkt_id FROM {$wpdb->prefix}produkt_product_to_category WHERE category_id = %d",
             $category->id
         ));
-        $categories = array_filter($categories, function ($product) use ($filtered_product_ids) {
+        $categories = array_filter($categories ?? [], function ($product) use ($filtered_product_ids) {
             return in_array($product->id, $filtered_product_ids);
         });
     } elseif (!empty($category_slug)) {
@@ -81,7 +86,7 @@ function get_lowest_stripe_price_by_category($category_id) {
         <p>Keine Produkte in dieser Kategorie gefunden.</p>
     <?php endif; ?>
     <div class="produkt-shop-grid">
-        <?php foreach ($categories as $cat): ?>
+        <?php foreach (($categories ?? []) as $cat): ?>
         <?php $url = home_url('/shop/' . sanitize_title($cat->product_title)); ?>
         <?php
             $price_data = get_lowest_stripe_price_by_category($cat->id);

--- a/templates/product-archive.php
+++ b/templates/product-archive.php
@@ -127,4 +127,8 @@ if (!function_exists('get_lowest_stripe_price_by_category')) {
         <?php endforeach; ?>
     </div>
 </div>
+
+</div><!-- .ast-container -->
+</div><!-- #content -->
+
 <?php get_footer(); ?>

--- a/templates/product-archive.php
+++ b/templates/product-archive.php
@@ -15,7 +15,7 @@ if (!is_array($categories)) {
     $categories = [];
 }
 
-$category_slug = isset($_GET['produkt_category']) ? sanitize_title($_GET['produkt_category']) : '';
+$category_slug = sanitize_title(get_query_var('produkt_category_slug'));
 $filtered_product_ids = [];
 $category = null;
 

--- a/templates/product-archive.php
+++ b/templates/product-archive.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Template: Produkt-Archiv mit Kategorie
+ * Template Name: Produkt-Archiv
  */
 if (!defined('ABSPATH')) {
     exit;

--- a/templates/product-archive.php
+++ b/templates/product-archive.php
@@ -82,14 +82,15 @@ if (!function_exists('get_lowest_stripe_price_by_category')) {
 
 ?>
 <div class="produkt-shop-archive produkt-container">
-    <?php if (!empty($category_slug)): ?>
-      <h2>Produkte in Kategorie: <?= esc_html(ucfirst($category_slug)) ?></h2>
-    <?php else: ?>
-      <h2>Alle Produkte</h2>
-    <?php endif; ?>
     <?php if ($category_slug && !$category): ?>
+        <h2>Produkte in Kategorie: <?= esc_html(ucfirst($category_slug)) ?></h2>
         <p>Kategorie nicht gefunden.</p>
-    <?php elseif (empty($categories)): ?>
+    <?php elseif (!empty($category_slug)): ?>
+        <h2>Produkte in Kategorie: <?= esc_html(ucfirst($category_slug)) ?></h2>
+    <?php else: ?>
+        <h2>Alle Produkte</h2>
+    <?php endif; ?>
+    <?php if (empty($categories)): ?>
         <p>Keine Produkte in dieser Kategorie gefunden.</p>
     <?php endif; ?>
     <div class="produkt-shop-grid">

--- a/templates/product-archive.php
+++ b/templates/product-archive.php
@@ -43,39 +43,41 @@ if (!empty($category_slug)) {
     }
 }
 
-function get_lowest_stripe_price_by_category($category_id) {
-    global $wpdb;
+if (!function_exists('get_lowest_stripe_price_by_category')) {
+    function get_lowest_stripe_price_by_category($category_id) {
+        global $wpdb;
 
-    $variant_ids  = $wpdb->get_col($wpdb->prepare(
-        "SELECT id FROM {$wpdb->prefix}produkt_variants WHERE category_id = %d",
-        $category_id
-    ));
-    $duration_ids = $wpdb->get_col($wpdb->prepare(
-        "SELECT id FROM {$wpdb->prefix}produkt_durations WHERE category_id = %d",
-        $category_id
-    ));
+        $variant_ids  = $wpdb->get_col($wpdb->prepare(
+            "SELECT id FROM {$wpdb->prefix}produkt_variants WHERE category_id = %d",
+            $category_id
+        ));
+        $duration_ids = $wpdb->get_col($wpdb->prepare(
+            "SELECT id FROM {$wpdb->prefix}produkt_durations WHERE category_id = %d",
+            $category_id
+        ));
 
-    $price_data = StripeService::get_lowest_price_with_durations($variant_ids, $duration_ids);
+        $price_data = StripeService::get_lowest_price_with_durations($variant_ids, $duration_ids);
 
-    // Zähle alle gültigen Preis-Kombinationen (für Anzeige von "ab")
-    $price_count = 0;
-    if (!empty($variant_ids) && !empty($duration_ids)) {
-        $placeholders_variant  = implode(',', array_fill(0, count($variant_ids), '%d'));
-        $placeholders_duration = implode(',', array_fill(0, count($duration_ids), '%d'));
-        $count_query = $wpdb->prepare(
-            "SELECT COUNT(*) FROM {$wpdb->prefix}produkt_duration_prices
-             WHERE variant_id IN ($placeholders_variant)
-               AND duration_id IN ($placeholders_duration)",
-            array_merge($variant_ids, $duration_ids)
-        );
-        $price_count = (int) $wpdb->get_var($count_query);
+        // Zähle alle gültigen Preis-Kombinationen (für Anzeige von "ab")
+        $price_count = 0;
+        if (!empty($variant_ids) && !empty($duration_ids)) {
+            $placeholders_variant  = implode(',', array_fill(0, count($variant_ids), '%d'));
+            $placeholders_duration = implode(',', array_fill(0, count($duration_ids), '%d'));
+            $count_query = $wpdb->prepare(
+                "SELECT COUNT(*) FROM {$wpdb->prefix}produkt_duration_prices
+                 WHERE variant_id IN ($placeholders_variant)
+                   AND duration_id IN ($placeholders_duration)",
+                array_merge($variant_ids, $duration_ids)
+            );
+            $price_count = (int) $wpdb->get_var($count_query);
+        }
+
+        return [
+            'amount'     => $price_data['amount'] ?? null,
+            'price_id'   => $price_data['price_id'] ?? null,
+            'count'      => $price_count
+        ];
     }
-
-    return [
-        'amount'     => $price_data['amount'] ?? null,
-        'price_id'   => $price_data['price_id'] ?? null,
-        'count'      => $price_count
-    ];
 }
 
 ?>

--- a/templates/product-archive.php
+++ b/templates/product-archive.php
@@ -15,6 +15,7 @@ if (!is_array($categories)) {
     $categories = [];
 }
 
+// retrieve the requested category and sanitize the slug immediately
 $category_slug = sanitize_title(get_query_var('produkt_category_slug'));
 $filtered_product_ids = [];
 $category = null;

--- a/templates/product-archive.php
+++ b/templates/product-archive.php
@@ -4,7 +4,8 @@ if (!defined('ABSPATH')) { exit; }
 use ProduktVerleih\Database;
 use ProduktVerleih\StripeService;
 
-$category_slug = get_query_var('produkt_category');
+$category_slug = isset($_GET['produkt_category']) ? sanitize_title($_GET['produkt_category']) : '';
+echo '<pre>DEBUG: Kategorie-Slug = ' . htmlspecialchars($category_slug) . '</pre>';
 $filtered_product_ids = [];
 
 if (!empty($category_slug)) {

--- a/templates/product-archive.php
+++ b/templates/product-archive.php
@@ -1,5 +1,7 @@
 <?php
-/* Template Name: Produkt-Archiv */
+/**
+ * Template: Produkt-Archiv mit Kategorie
+ */
 if (!defined('ABSPATH')) {
     exit;
 }
@@ -14,7 +16,6 @@ if (!is_array($categories)) {
 }
 
 $category_slug = isset($_GET['produkt_category']) ? sanitize_title($_GET['produkt_category']) : '';
-echo '<pre>DEBUG: Kategorie-Slug = ' . htmlspecialchars($category_slug) . '</pre>';
 $filtered_product_ids = [];
 
 if (!empty($category_slug)) {
@@ -87,7 +88,7 @@ function get_lowest_stripe_price_by_category($category_id) {
     <?php endif; ?>
     <div class="produkt-shop-grid">
         <?php foreach (($categories ?? []) as $cat): ?>
-        <?php $url = home_url('/shop/' . sanitize_title($cat->product_title)); ?>
+        <?php $url = home_url('/shop/produkt/' . sanitize_title($cat->product_title)); ?>
         <?php
             $price_data = get_lowest_stripe_price_by_category($cat->id);
         ?>

--- a/templates/product-archive.php
+++ b/templates/product-archive.php
@@ -1,5 +1,9 @@
 <?php
-if (!defined('ABSPATH')) { exit; }
+/* Template Name: Produkt-Archiv */
+if (!defined('ABSPATH')) {
+    exit;
+}
+get_header();
 
 use ProduktVerleih\Database;
 use ProduktVerleih\StripeService;
@@ -16,11 +20,18 @@ if (!empty($category_slug)) {
         $category_slug
     ));
 
-    if ($category) {
+    if (!empty($category)) {
+        // Gefundene Kategorie → filtern
         $filtered_product_ids = $wpdb->get_col($wpdb->prepare(
             "SELECT produkt_id FROM {$wpdb->prefix}produkt_product_to_category WHERE category_id = %d",
             $category->id
         ));
+        $categories = array_filter($categories, function ($product) use ($filtered_product_ids) {
+            return in_array($product->id, $filtered_product_ids);
+        });
+    } elseif (!empty($category_slug)) {
+        // Slug war angegeben, aber ungültig
+        $categories = [];
     }
 }
 
@@ -59,17 +70,15 @@ function get_lowest_stripe_price_by_category($category_id) {
     ];
 }
 
-if (!empty($filtered_product_ids)) {
-    $categories = array_filter($categories, function ($product) use ($filtered_product_ids) {
-        return in_array($product->id, $filtered_product_ids);
-    });
-}
 ?>
 <div class="produkt-shop-archive produkt-container">
     <?php if (!empty($category_slug)): ?>
       <h2>Produkte in Kategorie: <?= esc_html(ucfirst($category_slug)) ?></h2>
     <?php else: ?>
       <h2>Alle Produkte</h2>
+    <?php endif; ?>
+    <?php if (empty($categories)): ?>
+        <p>Keine Produkte in dieser Kategorie gefunden.</p>
     <?php endif; ?>
     <div class="produkt-shop-grid">
         <?php foreach ($categories as $cat): ?>
@@ -106,3 +115,4 @@ if (!empty($filtered_product_ids)) {
         <?php endforeach; ?>
     </div>
 </div>
+<?php get_footer(); ?>

--- a/templates/product-archive.php
+++ b/templates/product-archive.php
@@ -17,6 +17,7 @@ if (!is_array($categories)) {
 
 $category_slug = isset($_GET['produkt_category']) ? sanitize_title($_GET['produkt_category']) : '';
 $filtered_product_ids = [];
+$category = null;
 
 if (!empty($category_slug)) {
     global $wpdb;
@@ -83,7 +84,9 @@ function get_lowest_stripe_price_by_category($category_id) {
     <?php else: ?>
       <h2>Alle Produkte</h2>
     <?php endif; ?>
-    <?php if (empty($categories)): ?>
+    <?php if ($category_slug && !$category): ?>
+        <p>Kategorie nicht gefunden.</p>
+    <?php elseif (empty($categories)): ?>
         <p>Keine Produkte in dieser Kategorie gefunden.</p>
     <?php endif; ?>
     <div class="produkt-shop-grid">

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -1,6 +1,39 @@
 <?php
+/* Template Name: Produkt-Seite */
+if (!defined('ABSPATH')) {
+    exit;
+}
 
 global $wpdb;
+
+get_header();
+
+$slug = get_query_var('produkt_slug');
+if (empty($slug) && isset($_GET['produkt_slug'])) {
+    $slug = sanitize_title($_GET['produkt_slug']);
+}
+
+$categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_categories");
+$category = null;
+foreach ($categories as $cat) {
+    if (sanitize_title($cat->product_title) === sanitize_title($slug)) {
+        $category = $cat;
+        break;
+    }
+}
+
+if (!$category) {
+    global $wp_query;
+    $wp_query->set_404();
+    status_header(404);
+    include get_query_template('404');
+    get_footer();
+    return;
+}
+
+add_filter('pre_get_document_title', function () use ($category) {
+    return $category->page_title ?: $category->product_title;
+});
 
 function get_lowest_stripe_price_by_category($category_id) {
     global $wpdb;
@@ -556,3 +589,4 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
         <button id="produkt-exit-send" style="display:none;">Senden</button>
     </div>
 </div>
+<?php get_footer(); ?>

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -8,10 +8,7 @@ global $wpdb;
 
 get_header();
 
-$slug = get_query_var('produkt_slug');
-if (empty($slug) && isset($_GET['produkt_slug'])) {
-    $slug = sanitize_title($_GET['produkt_slug']);
-}
+$slug = sanitize_title(get_query_var('produkt_slug'));
 
 $categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_categories");
 $category = null;


### PR DESCRIPTION
## Summary
- support simple product categories via new `produkt_product_categories` table
- link products to these categories using `produkt_product_to_category`
- clean up on plugin uninstall by dropping the new tables

## Testing
- `php -l includes/Database.php` *(fails: `bash: php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_686ed821d57c8330bef5a02ee2e716ea