### PR TITLE
Add dynamic content blocks

### DIFF
--- a/admin/content-blocks-page.php
+++ b/admin/content-blocks-page.php
@@ -1,0 +1,140 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+
+global $wpdb;
+$table_name = $wpdb->prefix . 'produkt_content_blocks';
+
+$categories = $wpdb->get_results("SELECT id, name FROM {$wpdb->prefix}produkt_product_categories ORDER BY name");
+$selected_category = isset($_GET['category']) ? intval($_GET['category']) : ($categories[0]->id ?? 0);
+$action = isset($_GET['action']) ? sanitize_text_field($_GET['action']) : 'list';
+$edit_id = isset($_GET['edit']) ? intval($_GET['edit']) : 0;
+
+if (isset($_POST['save_block'])) {
+    \ProduktVerleih\Admin::verify_admin_action();
+    $data = [
+        'category_id' => $selected_category,
+        'position'     => intval($_POST['position']),
+        'title'        => sanitize_text_field($_POST['title']),
+        'content'      => wp_kses_post($_POST['content']),
+        'image_url'    => esc_url_raw($_POST['image_url']),
+        'button_text'  => sanitize_text_field($_POST['button_text']),
+        'button_url'   => esc_url_raw($_POST['button_url']),
+    ];
+    if (!empty($_POST['id'])) {
+        $wpdb->update($table_name, $data, ['id' => intval($_POST['id'])]);
+    } else {
+        $wpdb->insert($table_name, $data);
+    }
+    \ProduktVerleih\Database::clear_content_blocks_cache($selected_category);
+    $action = 'list';
+}
+
+if (isset($_GET['delete']) && isset($_GET['fw_nonce']) && wp_verify_nonce($_GET['fw_nonce'], 'produkt_admin_action')) {
+    $wpdb->delete($table_name, ['id' => intval($_GET['delete'])]);
+    \ProduktVerleih\Database::clear_content_blocks_cache($selected_category);
+}
+
+$block = null;
+if ($action === 'edit' && $edit_id) {
+    $block = $wpdb->get_row($wpdb->prepare("SELECT * FROM $table_name WHERE id = %d", $edit_id));
+    if (!$block) { $action = 'list'; }
+}
+
+$blocks = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE category_id = %d ORDER BY position", $selected_category));
+?>
+<div class="wrap">
+    <h1>Content-Blöcke</h1>
+
+    <form method="get" action="">
+        <input type="hidden" name="page" value="produkt-content-blocks">
+        <label for="cb-category-select"><strong>Kategorie:</strong></label>
+        <select id="cb-category-select" name="category" onchange="this.form.submit()">
+            <?php foreach ($categories as $cat): ?>
+                <option value="<?php echo $cat->id; ?>" <?php selected($selected_category, $cat->id); ?>><?php echo esc_html($cat->name); ?></option>
+            <?php endforeach; ?>
+        </select>
+        <noscript><input type="submit" value="Wechseln" class="button"></noscript>
+    </form>
+
+    <?php if ($action === 'add' || $action === 'edit'): ?>
+        <h2><?php echo $action === 'edit' ? 'Block bearbeiten' : 'Neuen Block hinzufügen'; ?></h2>
+        <form method="post" action="" class="produkt-compact-form">
+            <?php wp_nonce_field('produkt_admin_action', 'produkt_admin_nonce'); ?>
+            <input type="hidden" name="id" value="<?php echo esc_attr($block->id ?? ''); ?>">
+            <input type="hidden" name="category_id" value="<?php echo $selected_category; ?>">
+            <table class="form-table">
+                <tr>
+                    <th><label>Position *</label></th>
+                    <td><input type="number" name="position" required value="<?php echo esc_attr($block->position ?? 9); ?>"></td>
+                </tr>
+                <tr>
+                    <th><label>Überschrift *</label></th>
+                    <td><input type="text" name="title" required value="<?php echo esc_attr($block->title ?? ''); ?>"></td>
+                </tr>
+                <tr>
+                    <th><label>Text *</label></th>
+                    <td><textarea name="content" rows="4" required><?php echo esc_textarea($block->content ?? ''); ?></textarea></td>
+                </tr>
+                <tr>
+                    <th><label>Bild</label></th>
+                    <td>
+                        <input type="url" name="image_url" id="image_url" value="<?php echo esc_attr($block->image_url ?? ''); ?>">
+                        <button type="button" class="button produkt-media-button" data-target="image_url">📁</button>
+                    </td>
+                </tr>
+                <tr>
+                    <th><label>Button-Text</label></th>
+                    <td><input type="text" name="button_text" value="<?php echo esc_attr($block->button_text ?? ''); ?>"></td>
+                </tr>
+                <tr>
+                    <th><label>Button-Link</label></th>
+                    <td><input type="url" name="button_url" value="<?php echo esc_attr($block->button_url ?? ''); ?>"></td>
+                </tr>
+            </table>
+            <p>
+                <button type="submit" name="save_block" class="button button-primary">Speichern</button>
+                <a href="<?php echo admin_url('admin.php?page=produkt-content-blocks&category=' . $selected_category); ?>" class="button">Abbrechen</a>
+            </p>
+        </form>
+        <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.produkt-media-button').forEach(function(btn) {
+                btn.addEventListener('click', function(e) {
+                    e.preventDefault();
+                    const targetId = this.getAttribute('data-target');
+                    const field = document.getElementById(targetId);
+                    if (!field) return;
+                    const frame = wp.media({ title: 'Bild auswählen', button: { text: 'Bild verwenden' }, multiple: false });
+                    frame.on('select', function() {
+                        const att = frame.state().get('selection').first().toJSON();
+                        field.value = att.url;
+                    });
+                    frame.open();
+                });
+            });
+        });
+        </script>
+    <?php else: ?>
+        <h2>Blöcke</h2>
+        <p><a href="<?php echo admin_url('admin.php?page=produkt-content-blocks&category=' . $selected_category . '&action=add'); ?>" class="button button-primary">Neuen Block hinzufügen</a></p>
+        <?php if (empty($blocks)): ?>
+            <p>Noch keine Blöcke definiert.</p>
+        <?php else: ?>
+            <table class="widefat striped">
+                <thead><tr><th>Position</th><th>Titel</th><th>Aktionen</th></tr></thead>
+                <tbody>
+                    <?php foreach ($blocks as $b): ?>
+                        <tr>
+                            <td><?php echo intval($b->position); ?></td>
+                            <td><?php echo esc_html($b->title); ?></td>
+                            <td>
+                                <a href="<?php echo admin_url('admin.php?page=produkt-content-blocks&category=' . $selected_category . '&action=edit&edit=' . $b->id); ?>" class="button">Bearbeiten</a>
+                                <a href="<?php echo admin_url('admin.php?page=produkt-content-blocks&category=' . $selected_category . '&delete=' . $b->id . '&fw_nonce=' . wp_create_nonce('produkt_admin_action')); ?>" class="button button-danger" onclick="return confirm('Wirklich löschen?')">Löschen</a>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        <?php endif; ?>
+    <?php endif; ?>
+</div>

--- a/admin/content-blocks-page.php
+++ b/admin/content-blocks-page.php
@@ -5,6 +5,7 @@ global $wpdb;
 $table_name = $wpdb->prefix . 'produkt_content_blocks';
 
 $categories = $wpdb->get_results("SELECT id, name FROM {$wpdb->prefix}produkt_product_categories ORDER BY name");
+array_unshift($categories, (object)['id' => 0, 'name' => 'Alle Kategorien']);
 $selected_category = isset($_GET['category']) ? intval($_GET['category']) : ($categories[0]->id ?? 0);
 $action = isset($_GET['action']) ? sanitize_text_field($_GET['action']) : 'list';
 $edit_id = isset($_GET['edit']) ? intval($_GET['edit']) : 0;

--- a/admin/content-blocks-page.php
+++ b/admin/content-blocks-page.php
@@ -15,6 +15,7 @@ if (isset($_POST['save_block'])) {
     $data = [
         'category_id' => $selected_category,
         'position'     => intval($_POST['position']),
+        'position_mobile' => intval($_POST['position_mobile']),
         'title'        => sanitize_text_field($_POST['title']),
         'content'      => wp_kses_post($_POST['content']),
         'image_url'    => esc_url_raw($_POST['image_url']),
@@ -65,8 +66,12 @@ $blocks = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE cat
             <input type="hidden" name="category_id" value="<?php echo $selected_category; ?>">
             <table class="form-table">
                 <tr>
-                    <th><label>Position *</label></th>
+                    <th><label>Position Desktop *</label></th>
                     <td><input type="number" name="position" required value="<?php echo esc_attr($block->position ?? 9); ?>"></td>
+                </tr>
+                <tr>
+                    <th><label>Position Mobil *</label></th>
+                    <td><input type="number" name="position_mobile" required value="<?php echo esc_attr($block->position_mobile ?? 6); ?>"></td>
                 </tr>
                 <tr>
                     <th><label>Überschrift *</label></th>
@@ -122,11 +127,12 @@ $blocks = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE cat
             <p>Noch keine Blöcke definiert.</p>
         <?php else: ?>
             <table class="widefat striped">
-                <thead><tr><th>Position</th><th>Titel</th><th>Aktionen</th></tr></thead>
+                <thead><tr><th>Desktop</th><th>Mobil</th><th>Titel</th><th>Aktionen</th></tr></thead>
                 <tbody>
                     <?php foreach ($blocks as $b): ?>
                         <tr>
                             <td><?php echo intval($b->position); ?></td>
+                            <td><?php echo intval($b->position_mobile); ?></td>
                             <td><?php echo esc_html($b->title); ?></td>
                             <td>
                                 <a href="<?php echo admin_url('admin.php?page=produkt-content-blocks&category=' . $selected_category . '&action=edit&edit=' . $b->id); ?>" class="button">Bearbeiten</a>

--- a/assets/style.css
+++ b/assets/style.css
@@ -1702,6 +1702,10 @@ body.shop-filter-open {
     background: #f5f5f5;
     padding: 1rem;
     border-radius: .5rem;
+    width: 100%;
+}
+.shop-product-grid .content-block {
+    grid-column: 1 / -1;
 }
 .content-block-text {
     flex: 0 0 70%;

--- a/assets/style.css
+++ b/assets/style.css
@@ -1695,6 +1695,40 @@ body.shop-filter-open {
     overflow: hidden;
 }
 
+.content-block {
+    display: flex;
+    gap: 1rem;
+    margin: 2rem 0;
+    background: #f5f5f5;
+    padding: 1rem;
+    border-radius: .5rem;
+}
+.content-block-text {
+    flex: 0 0 70%;
+}
+.content-block-image {
+    flex: 0 0 30%;
+}
+.content-block-image img {
+    width: 100%;
+    height: auto;
+    display: block;
+}
+.content-block-button {
+    margin-top: 1rem;
+    display: inline-block;
+}
+
+@media (max-width: 768px) {
+    .content-block {
+        flex-direction: column;
+    }
+    .content-block-text,
+    .content-block-image {
+        flex: 1 1 auto;
+    }
+}
+
 @media (max-width: 768px) {
     .shop-category-list {
         display: none;

--- a/assets/style.css
+++ b/assets/style.css
@@ -1717,6 +1717,8 @@ body.shop-filter-open {
     width: 100%;
     height: auto;
     display: block;
+    border-radius: 0.5rem;
+    margin-right: 1rem;
 }
 .content-block-button {
     margin-top: 1rem;

--- a/assets/style.css
+++ b/assets/style.css
@@ -1725,6 +1725,13 @@ body.shop-filter-open {
     display: inline-block;
 }
 
+.desktop-only {
+    display: block;
+}
+.mobile-only {
+    display: none;
+}
+
 @media (max-width: 768px) {
     .content-block {
         flex-direction: column;
@@ -1732,6 +1739,12 @@ body.shop-filter-open {
     .content-block-text,
     .content-block-image {
         flex: 1 1 auto;
+    }
+    .desktop-only {
+        display: none;
+    }
+    .mobile-only {
+        display: block;
     }
 }
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -1730,7 +1730,7 @@ body.shop-filter-open {
 
 /* Show blocks based on screen size without overriding flex layout */
 .desktop-only {
-    display: flex;
+    display: flex ;
 }
 .mobile-only {
     display: none;

--- a/assets/style.css
+++ b/assets/style.css
@@ -1697,6 +1697,7 @@ body.shop-filter-open {
 
 .content-block {
     display: flex;
+    flex-direction: row;
     gap: 1rem;
     margin: 2rem 0;
     background: #f5f5f5;
@@ -1712,13 +1713,13 @@ body.shop-filter-open {
 }
 .content-block-image {
     flex: 0 0 30%;
+    padding-right: 1rem;
 }
 .content-block-image img {
     width: 100%;
     height: auto;
     display: block;
     border-radius: 0.5rem;
-    margin-right: 1rem;
 }
 .content-block-button {
     margin-top: 1rem;

--- a/assets/style.css
+++ b/assets/style.css
@@ -1744,6 +1744,9 @@ body.shop-filter-open {
     .content-block-image {
         flex: 1 1 auto;
     }
+    .content-block-image {
+        padding-right: 0;
+    }
     .desktop-only {
         display: none;
     }

--- a/assets/style.css
+++ b/assets/style.css
@@ -1728,8 +1728,9 @@ body.shop-filter-open {
     display: inline-block;
 }
 
+/* Show blocks based on screen size without overriding flex layout */
 .desktop-only {
-    display: block;
+    display: flex;
 }
 .mobile-only {
     display: none;
@@ -1747,7 +1748,7 @@ body.shop-filter-open {
         display: none;
     }
     .mobile-only {
-        display: block;
+        display: flex;
     }
 }
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -1715,7 +1715,7 @@ body.shop-filter-open {
 }
 .content-block-image {
     flex: 0 0 30%;
-    margin-right: 1rem;
+    padding-right: 16px;
 }
 .content-block-image img {
     width: 100%;

--- a/assets/style.css
+++ b/assets/style.css
@@ -1698,6 +1698,8 @@ body.shop-filter-open {
 .content-block {
     display: flex;
     flex-direction: row;
+    flex-wrap: nowrap;
+    align-items: flex-start;
     gap: 1rem;
     margin: 2rem 0;
     background: #f5f5f5;
@@ -1713,7 +1715,7 @@ body.shop-filter-open {
 }
 .content-block-image {
     flex: 0 0 30%;
-    padding-right: 1rem;
+    margin-right: 1rem;
 }
 .content-block-image img {
     width: 100%;

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -95,6 +95,15 @@ class Admin {
             'produkt-colors',
             array($this, 'colors_page')
         );
+
+        add_submenu_page(
+            'produkt-verleih',
+            'Content-Blöcke',
+            'Content-Blöcke',
+            'manage_options',
+            'produkt-content-blocks',
+            array($this, 'content_blocks_page')
+        );
         
         
         
@@ -571,6 +580,10 @@ class Admin {
     
     public function colors_page() {
         include PRODUKT_PLUGIN_PATH . 'admin/colors-page.php';
+    }
+
+    public function content_blocks_page() {
+        include PRODUKT_PLUGIN_PATH . 'admin/content-blocks-page.php';
     }
     
     public function orders_page() {

--- a/includes/Database.php
+++ b/includes/Database.php
@@ -567,6 +567,28 @@ class Database {
             require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
             dbDelta($sql);
         }
+
+        // Create content blocks table if it doesn't exist
+        $table_blocks = $wpdb->prefix . 'produkt_content_blocks';
+        $blocks_exists = $wpdb->get_var("SHOW TABLES LIKE '$table_blocks'");
+        if (!$blocks_exists) {
+            $charset_collate = $wpdb->get_charset_collate();
+            $sql = "CREATE TABLE $table_blocks (
+                id INT NOT NULL AUTO_INCREMENT,
+                category_id INT NOT NULL,
+                position INT NOT NULL,
+                title TEXT NOT NULL,
+                content TEXT NOT NULL,
+                image_url TEXT,
+                button_text TEXT,
+                button_url TEXT,
+                PRIMARY KEY (id),
+                KEY category_id (category_id)
+            ) $charset_collate;";
+
+            require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
+            dbDelta($sql);
+        }
     }
     
     public function create_tables() {
@@ -856,6 +878,21 @@ class Database {
         dbDelta($sql_variant_options);
         dbDelta($sql_variant_durations);
         dbDelta($sql_duration_prices);
+        // Content blocks table
+        $table_content_blocks = $wpdb->prefix . 'produkt_content_blocks';
+        $sql_content_blocks = "CREATE TABLE $table_content_blocks (
+            id INT NOT NULL AUTO_INCREMENT,
+            category_id INT NOT NULL,
+            position INT NOT NULL,
+            title TEXT NOT NULL,
+            content TEXT NOT NULL,
+            image_url TEXT,
+            button_text TEXT,
+            button_url TEXT,
+            PRIMARY KEY (id),
+            KEY category_id (category_id)
+        ) $charset_collate;";
+        dbDelta($sql_content_blocks);
         dbDelta($sql_orders);
 
         // Metadata table for storing Stripe session details
@@ -1097,6 +1134,7 @@ class Database {
             'produkt_analytics',
             'produkt_branding',
             'produkt_notifications',
+            'produkt_content_blocks',
             'produkt_stripe_metadata'
         );
 
@@ -1158,5 +1196,40 @@ class Database {
         $sql .= " ORDER BY sort_order";
 
         return $wpdb->get_results($sql);
+    }
+
+    /**
+     * Retrieve content blocks for a product category.
+     *
+     * @param int $category_id
+     * @return array
+     */
+    public static function get_content_blocks_for_category($category_id) {
+        $cache_key = 'produkt_content_blocks_' . intval($category_id);
+        $blocks = get_transient($cache_key);
+        if ($blocks !== false) {
+            return $blocks;
+        }
+
+        global $wpdb;
+        $table = $wpdb->prefix . 'produkt_content_blocks';
+        $blocks = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT * FROM $table WHERE category_id = %d ORDER BY position",
+                $category_id
+            )
+        );
+
+        set_transient($cache_key, $blocks, HOUR_IN_SECONDS);
+        return $blocks;
+    }
+
+    /**
+     * Clear cached content blocks for a category.
+     *
+     * @param int $category_id
+     */
+    public static function clear_content_blocks_cache($category_id) {
+        delete_transient('produkt_content_blocks_' . intval($category_id));
     }
 }

--- a/includes/Database.php
+++ b/includes/Database.php
@@ -577,6 +577,7 @@ class Database {
                 id INT NOT NULL AUTO_INCREMENT,
                 category_id INT NOT NULL,
                 position INT NOT NULL,
+                position_mobile INT NOT NULL DEFAULT 6,
                 title TEXT NOT NULL,
                 content TEXT NOT NULL,
                 image_url TEXT,
@@ -588,6 +589,12 @@ class Database {
 
             require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
             dbDelta($sql);
+        } else {
+            // Add missing columns for desktop/mobile positions
+            $mobile_exists = $wpdb->get_results("SHOW COLUMNS FROM $table_blocks LIKE 'position_mobile'");
+            if (empty($mobile_exists)) {
+                $wpdb->query("ALTER TABLE $table_blocks ADD COLUMN position_mobile INT NOT NULL DEFAULT 6 AFTER position");
+            }
         }
     }
     
@@ -884,6 +891,7 @@ class Database {
             id INT NOT NULL AUTO_INCREMENT,
             category_id INT NOT NULL,
             position INT NOT NULL,
+            position_mobile INT NOT NULL DEFAULT 6,
             title TEXT NOT NULL,
             content TEXT NOT NULL,
             image_url TEXT,

--- a/templates/product-archive.php
+++ b/templates/product-archive.php
@@ -51,10 +51,6 @@ $content_blocks = Database::get_content_blocks_for_category($content_category_id
 $blocks_by_position = [];
 foreach ($content_blocks as $b) {
     $blocks_by_position[$b->position][] = $b;
-    $mobile_pos = intval(($b->position / 9) * 6);
-    if ($mobile_pos > 0) {
-        $blocks_by_position[$mobile_pos][] = $b;
-    }
 }
 
 if (!function_exists('get_lowest_stripe_price_by_category')) {
@@ -169,8 +165,9 @@ if (!function_exists('get_lowest_stripe_price_by_category')) {
             </a>
         </div>
         <?php
-            if (isset($blocks_by_position[$produkt_index])) {
-                foreach ($blocks_by_position[$produkt_index] as $block) {
+            $next_index = $produkt_index + 1;
+            if (isset($blocks_by_position[$next_index])) {
+                foreach ($blocks_by_position[$next_index] as $block) {
                     ?>
                     <div class="content-block">
                         <div class="content-block-text">

--- a/templates/product-archive.php
+++ b/templates/product-archive.php
@@ -48,9 +48,11 @@ if (!empty($category_slug)) {
 
 $content_category_id = $category->id ?? 0;
 $content_blocks = Database::get_content_blocks_for_category($content_category_id);
-$blocks_by_position = [];
+$blocks_by_position_desktop = [];
+$blocks_by_position_mobile  = [];
 foreach ($content_blocks as $b) {
-    $blocks_by_position[$b->position][] = $b;
+    $blocks_by_position_desktop[$b->position][] = $b;
+    $blocks_by_position_mobile[$b->position_mobile][] = $b;
 }
 
 if (!function_exists('get_lowest_stripe_price_by_category')) {
@@ -166,10 +168,30 @@ if (!function_exists('get_lowest_stripe_price_by_category')) {
         </div>
         <?php
             $next_index = $produkt_index + 1;
-            if (isset($blocks_by_position[$next_index])) {
-                foreach ($blocks_by_position[$next_index] as $block) {
+            if (isset($blocks_by_position_desktop[$next_index])) {
+                foreach ($blocks_by_position_desktop[$next_index] as $block) {
                     ?>
-                    <div class="content-block">
+                    <div class="content-block desktop-only">
+                        <div class="content-block-text">
+                            <h3><?php echo esc_html($block->title); ?></h3>
+                            <?php echo wpautop($block->content); ?>
+                            <?php if (!empty($block->button_text) && !empty($block->button_url)): ?>
+                                <a class="content-block-button" href="<?php echo esc_url($block->button_url); ?>"><?php echo esc_html($block->button_text); ?></a>
+                            <?php endif; ?>
+                        </div>
+                        <div class="content-block-image">
+                            <?php if (!empty($block->image_url)): ?>
+                                <img src="<?php echo esc_url($block->image_url); ?>" alt="">
+                            <?php endif; ?>
+                        </div>
+                    </div>
+                    <?php
+                }
+            }
+            if (isset($blocks_by_position_mobile[$next_index])) {
+                foreach ($blocks_by_position_mobile[$next_index] as $block) {
+                    ?>
+                    <div class="content-block mobile-only">
                         <div class="content-block-text">
                             <h3><?php echo esc_html($block->title); ?></h3>
                             <?php echo wpautop($block->content); ?>

--- a/templates/product-archive.php
+++ b/templates/product-archive.php
@@ -46,10 +46,8 @@ if (!empty($category_slug)) {
     }
 }
 
-$content_blocks = [];
-if (!empty($category)) {
-    $content_blocks = Database::get_content_blocks_for_category($category->id);
-}
+$content_category_id = $category->id ?? 0;
+$content_blocks = Database::get_content_blocks_for_category($content_category_id);
 $blocks_by_position = [];
 foreach ($content_blocks as $b) {
     $blocks_by_position[$b->position][] = $b;

--- a/templates/product-archive.php
+++ b/templates/product-archive.php
@@ -46,6 +46,19 @@ if (!empty($category_slug)) {
     }
 }
 
+$content_blocks = [];
+if (!empty($category)) {
+    $content_blocks = Database::get_content_blocks_for_category($category->id);
+}
+$blocks_by_position = [];
+foreach ($content_blocks as $b) {
+    $blocks_by_position[$b->position][] = $b;
+    $mobile_pos = intval(($b->position / 9) * 6);
+    if ($mobile_pos > 0) {
+        $blocks_by_position[$mobile_pos][] = $b;
+    }
+}
+
 if (!function_exists('get_lowest_stripe_price_by_category')) {
     function get_lowest_stripe_price_by_category($category_id) {
         global $wpdb;
@@ -120,7 +133,7 @@ if (!function_exists('get_lowest_stripe_price_by_category')) {
             <?php endif; ?>
 
             <div class="shop-product-grid">
-        <?php foreach (($categories ?? []) as $cat): ?>
+        <?php $produkt_index = 0; foreach (($categories ?? []) as $cat): $produkt_index++; ?>
         <?php $url = home_url('/shop/produkt/' . sanitize_title($cat->product_title)); ?>
         <?php $price_data = get_lowest_stripe_price_by_category($cat->id); ?>
         <div class="shop-product-item">
@@ -157,6 +170,28 @@ if (!function_exists('get_lowest_stripe_price_by_category')) {
                 </div>
             </a>
         </div>
+        <?php
+            if (isset($blocks_by_position[$produkt_index])) {
+                foreach ($blocks_by_position[$produkt_index] as $block) {
+                    ?>
+                    <div class="content-block">
+                        <div class="content-block-text">
+                            <h3><?php echo esc_html($block->title); ?></h3>
+                            <?php echo wpautop($block->content); ?>
+                            <?php if (!empty($block->button_text) && !empty($block->button_url)): ?>
+                                <a class="content-block-button" href="<?php echo esc_url($block->button_url); ?>"><?php echo esc_html($block->button_text); ?></a>
+                            <?php endif; ?>
+                        </div>
+                        <div class="content-block-image">
+                            <?php if (!empty($block->image_url)): ?>
+                                <img src="<?php echo esc_url($block->image_url); ?>" alt="">
+                            <?php endif; ?>
+                        </div>
+                    </div>
+                    <?php
+                }
+            }
+        ?>
         <?php endforeach; ?>
 
         </div>


### PR DESCRIPTION
## Summary
- add new `produkt_content_blocks` table and helper methods
- expose new admin page "Content-Blöcke" to manage blocks
- render blocks in the product archive after configured positions
- basic styling for content block layout

## Testing
- `php -l admin/content-blocks-page.php`
- `php -l includes/Admin.php`
- `php -l includes/Database.php`
- `php -l templates/product-archive.php`


------
https://chatgpt.com/codex/tasks/task_b_6870c9a68e048330b9f939b5163814bc