### PR TITLE
Fix desktop-only padding on content block image

### DIFF
--- a/admin/content-blocks-page.php
+++ b/admin/content-blocks-page.php
@@ -1,0 +1,147 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+
+global $wpdb;
+$table_name = $wpdb->prefix . 'produkt_content_blocks';
+
+$categories = $wpdb->get_results("SELECT id, name FROM {$wpdb->prefix}produkt_product_categories ORDER BY name");
+array_unshift($categories, (object)['id' => 0, 'name' => 'Alle Kategorien']);
+$selected_category = isset($_GET['category']) ? intval($_GET['category']) : ($categories[0]->id ?? 0);
+$action = isset($_GET['action']) ? sanitize_text_field($_GET['action']) : 'list';
+$edit_id = isset($_GET['edit']) ? intval($_GET['edit']) : 0;
+
+if (isset($_POST['save_block'])) {
+    \ProduktVerleih\Admin::verify_admin_action();
+    $data = [
+        'category_id' => $selected_category,
+        'position'     => intval($_POST['position']),
+        'position_mobile' => intval($_POST['position_mobile']),
+        'title'        => sanitize_text_field($_POST['title']),
+        'content'      => wp_kses_post($_POST['content']),
+        'image_url'    => esc_url_raw($_POST['image_url']),
+        'button_text'  => sanitize_text_field($_POST['button_text']),
+        'button_url'   => esc_url_raw($_POST['button_url']),
+    ];
+    if (!empty($_POST['id'])) {
+        $wpdb->update($table_name, $data, ['id' => intval($_POST['id'])]);
+    } else {
+        $wpdb->insert($table_name, $data);
+    }
+    \ProduktVerleih\Database::clear_content_blocks_cache($selected_category);
+    $action = 'list';
+}
+
+if (isset($_GET['delete']) && isset($_GET['fw_nonce']) && wp_verify_nonce($_GET['fw_nonce'], 'produkt_admin_action')) {
+    $wpdb->delete($table_name, ['id' => intval($_GET['delete'])]);
+    \ProduktVerleih\Database::clear_content_blocks_cache($selected_category);
+}
+
+$block = null;
+if ($action === 'edit' && $edit_id) {
+    $block = $wpdb->get_row($wpdb->prepare("SELECT * FROM $table_name WHERE id = %d", $edit_id));
+    if (!$block) { $action = 'list'; }
+}
+
+$blocks = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE category_id = %d ORDER BY position", $selected_category));
+?>
+<div class="wrap">
+    <h1>Content-Blöcke</h1>
+
+    <form method="get" action="">
+        <input type="hidden" name="page" value="produkt-content-blocks">
+        <label for="cb-category-select"><strong>Kategorie:</strong></label>
+        <select id="cb-category-select" name="category" onchange="this.form.submit()">
+            <?php foreach ($categories as $cat): ?>
+                <option value="<?php echo $cat->id; ?>" <?php selected($selected_category, $cat->id); ?>><?php echo esc_html($cat->name); ?></option>
+            <?php endforeach; ?>
+        </select>
+        <noscript><input type="submit" value="Wechseln" class="button"></noscript>
+    </form>
+
+    <?php if ($action === 'add' || $action === 'edit'): ?>
+        <h2><?php echo $action === 'edit' ? 'Block bearbeiten' : 'Neuen Block hinzufügen'; ?></h2>
+        <form method="post" action="" class="produkt-compact-form">
+            <?php wp_nonce_field('produkt_admin_action', 'produkt_admin_nonce'); ?>
+            <input type="hidden" name="id" value="<?php echo esc_attr($block->id ?? ''); ?>">
+            <input type="hidden" name="category_id" value="<?php echo $selected_category; ?>">
+            <table class="form-table">
+                <tr>
+                    <th><label>Position Desktop *</label></th>
+                    <td><input type="number" name="position" required value="<?php echo esc_attr($block->position ?? 9); ?>"></td>
+                </tr>
+                <tr>
+                    <th><label>Position Mobil *</label></th>
+                    <td><input type="number" name="position_mobile" required value="<?php echo esc_attr($block->position_mobile ?? 6); ?>"></td>
+                </tr>
+                <tr>
+                    <th><label>Überschrift *</label></th>
+                    <td><input type="text" name="title" required value="<?php echo esc_attr($block->title ?? ''); ?>"></td>
+                </tr>
+                <tr>
+                    <th><label>Text *</label></th>
+                    <td><textarea name="content" rows="4" required><?php echo esc_textarea($block->content ?? ''); ?></textarea></td>
+                </tr>
+                <tr>
+                    <th><label>Bild</label></th>
+                    <td>
+                        <input type="url" name="image_url" id="image_url" value="<?php echo esc_attr($block->image_url ?? ''); ?>">
+                        <button type="button" class="button produkt-media-button" data-target="image_url">📁</button>
+                    </td>
+                </tr>
+                <tr>
+                    <th><label>Button-Text</label></th>
+                    <td><input type="text" name="button_text" value="<?php echo esc_attr($block->button_text ?? ''); ?>"></td>
+                </tr>
+                <tr>
+                    <th><label>Button-Link</label></th>
+                    <td><input type="url" name="button_url" value="<?php echo esc_attr($block->button_url ?? ''); ?>"></td>
+                </tr>
+            </table>
+            <p>
+                <button type="submit" name="save_block" class="button button-primary">Speichern</button>
+                <a href="<?php echo admin_url('admin.php?page=produkt-content-blocks&category=' . $selected_category); ?>" class="button">Abbrechen</a>
+            </p>
+        </form>
+        <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.produkt-media-button').forEach(function(btn) {
+                btn.addEventListener('click', function(e) {
+                    e.preventDefault();
+                    const targetId = this.getAttribute('data-target');
+                    const field = document.getElementById(targetId);
+                    if (!field) return;
+                    const frame = wp.media({ title: 'Bild auswählen', button: { text: 'Bild verwenden' }, multiple: false });
+                    frame.on('select', function() {
+                        const att = frame.state().get('selection').first().toJSON();
+                        field.value = att.url;
+                    });
+                    frame.open();
+                });
+            });
+        });
+        </script>
+    <?php else: ?>
+        <h2>Blöcke</h2>
+        <p><a href="<?php echo admin_url('admin.php?page=produkt-content-blocks&category=' . $selected_category . '&action=add'); ?>" class="button button-primary">Neuen Block hinzufügen</a></p>
+        <?php if (empty($blocks)): ?>
+            <p>Noch keine Blöcke definiert.</p>
+        <?php else: ?>
+            <table class="widefat striped">
+                <thead><tr><th>Desktop</th><th>Mobil</th><th>Titel</th><th>Aktionen</th></tr></thead>
+                <tbody>
+                    <?php foreach ($blocks as $b): ?>
+                        <tr>
+                            <td><?php echo intval($b->position); ?></td>
+                            <td><?php echo intval($b->position_mobile); ?></td>
+                            <td><?php echo esc_html($b->title); ?></td>
+                            <td>
+                                <a href="<?php echo admin_url('admin.php?page=produkt-content-blocks&category=' . $selected_category . '&action=edit&edit=' . $b->id); ?>" class="button">Bearbeiten</a>
+                                <a href="<?php echo admin_url('admin.php?page=produkt-content-blocks&category=' . $selected_category . '&delete=' . $b->id . '&fw_nonce=' . wp_create_nonce('produkt_admin_action')); ?>" class="button button-danger" onclick="return confirm('Wirklich löschen?')">Löschen</a>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        <?php endif; ?>
+    <?php endif; ?>
+</div>

--- a/admin/content-blocks-page.php
+++ b/admin/content-blocks-page.php
@@ -21,6 +21,8 @@ if (isset($_POST['save_block'])) {
         'image_url'    => esc_url_raw($_POST['image_url']),
         'button_text'  => sanitize_text_field($_POST['button_text']),
         'button_url'   => esc_url_raw($_POST['button_url']),
+        'background_color' => sanitize_hex_color($_POST['background_color']),
+        'badge_text'  => sanitize_text_field($_POST['badge_text']),
     ];
     if (!empty($_POST['id'])) {
         $wpdb->update($table_name, $data, ['id' => intval($_POST['id'])]);
@@ -95,6 +97,14 @@ $blocks = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE cat
                 <tr>
                     <th><label>Button-Link</label></th>
                     <td><input type="url" name="button_url" value="<?php echo esc_attr($block->button_url ?? ''); ?>"></td>
+                </tr>
+                <tr>
+                    <th><label>Hintergrundfarbe</label></th>
+                    <td><input type="color" name="background_color" value="<?php echo esc_attr($block->background_color ?? '#ffffff'); ?>"></td>
+                </tr>
+                <tr>
+                    <th><label>Badge-Text</label></th>
+                    <td><input type="text" name="badge_text" value="<?php echo esc_attr($block->badge_text ?? ''); ?>"></td>
                 </tr>
             </table>
             <p>

--- a/assets/style.css
+++ b/assets/style.css
@@ -1718,17 +1718,21 @@ body.shop-filter-open {
     background-size: cover;
     background-position: center;
     border-radius: 0 .5rem .5rem 0;
-    position: relative;
-    display: flex;
-    justify-content: center;
-    align-items: flex-end;
+    margin-right: 16px;
     overflow: hidden;
 }
 .content-block-button {
-    display: inline-block;
-    margin-top: 0;
-    margin-bottom: 1rem;
-    z-index: 2;
+    width: 100%;
+    padding: 1.3rem 1.5rem;
+    border-radius: 999px;
+    font-weight: 700;
+    font-size: 1.125rem;
+    transition: all 0.2s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+    border: none;
 }
 
 /* Show blocks based on screen size without overriding flex layout */
@@ -1751,13 +1755,14 @@ body.shop-filter-open {
     .content-block-image {
         padding-right: 0;
         min-height: 400px;
-        border-radius: 0 0 .5rem .5rem;
+        border-radius: .5rem .5rem 0 0;
     }
     .desktop-only {
         display: none;
     }
     .mobile-only {
         display: flex;
+        flex-direction: column-reverse;
     }
 }
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -1713,12 +1713,15 @@ body.shop-filter-open {
     flex: 0 0 70%;
     padding: 2rem;
 }
+.content-block-description {
+    margin-bottom: 2em;
+}
 .content-block-badge {
     background: #ffc107;
     text-transform: uppercase;
     font-size: 13px;
     border-radius: 999px;
-    padding: 0.125rem 0.75rem;
+    padding: 0.25rem 1rem;
     margin-bottom: 1.5rem;
     display: inline-block;
 }
@@ -1732,16 +1735,15 @@ body.shop-filter-open {
 }
 .content-block-button {
     width: 100%;
-    padding: 1rem 2rem;
+    padding: 0.9rem 2rem;
     border-radius: 999px;
-    font-weight: 700;
-    font-size: 1.125rem;
+    font-weight: 400;
+    font-size: 16px;
     transition: all 0.2s ease;
     border: none;
     text-decoration: none !important;
     background: var(--produkt-button-bg);
     color: var(--produkt-button-text);
-    margin-top: 20px;
 }
 .content-block-button:hover {
     color: #ffffff;
@@ -1765,8 +1767,7 @@ body.shop-filter-open {
         flex: 1 1 auto;
     }
     .content-block-image {
-        padding-right: 0;
-        min-height: 400px;
+        min-height: 350px;
         border-radius: .5rem .5rem 0 0;
     }
     .content-block-text h3 {

--- a/assets/style.css
+++ b/assets/style.css
@@ -1713,6 +1713,15 @@ body.shop-filter-open {
     flex: 0 0 70%;
     padding: 2rem;
 }
+.content-block-badge {
+    background: #ffc107;
+    text-transform: uppercase;
+    font-size: 13px;
+    border-radius: 999px;
+    padding: 0.125rem 0.75rem;
+    margin-bottom: 1.5rem;
+    display: inline-block;
+}
 .content-block-image {
     flex: 0 0 30%;
     background-size: cover;
@@ -1723,16 +1732,19 @@ body.shop-filter-open {
 }
 .content-block-button {
     width: 100%;
-    padding: 1.3rem 1.5rem;
+    padding: 1rem 2rem;
     border-radius: 999px;
     font-weight: 700;
     font-size: 1.125rem;
     transition: all 0.2s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.75rem;
     border: none;
+    text-decoration: none !important;
+    background: var(--produkt-button-bg);
+    color: var(--produkt-button-text);
+    margin-top: 20px;
+}
+.content-block-button:hover {
+    color: #ffffff;
 }
 
 /* Show blocks based on screen size without overriding flex layout */
@@ -1756,6 +1768,9 @@ body.shop-filter-open {
         padding-right: 0;
         min-height: 400px;
         border-radius: .5rem .5rem 0 0;
+    }
+    .content-block-text h3 {
+        font-size: 28px;
     }
     .desktop-only {
         display: none;

--- a/assets/style.css
+++ b/assets/style.css
@@ -1695,6 +1695,71 @@ body.shop-filter-open {
     overflow: hidden;
 }
 
+.content-block {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    align-items: flex-start;
+    gap: 1rem;
+    margin: 2rem 0;
+    background: #f5f5f5;
+    padding: 1rem;
+    border-radius: .5rem;
+    width: 100%;
+}
+.shop-product-grid .content-block {
+    grid-column: 1 / -1;
+}
+.content-block-text {
+    flex: 0 0 70%;
+}
+.content-block-image {
+    flex: 0 0 30%;
+    padding-right: 16px;
+    background-size: cover;
+    background-position: center;
+    min-height: 400px;
+    border-radius: 0.5rem;
+    position: relative;
+    display: flex;
+    justify-content: center;
+    align-items: flex-end;
+    overflow: hidden;
+}
+.content-block-button {
+    display: inline-block;
+    margin-top: 0;
+    margin-bottom: 1rem;
+    z-index: 2;
+}
+
+/* Show blocks based on screen size without overriding flex layout */
+.desktop-only {
+    display: flex ;
+}
+.mobile-only {
+    display: none;
+}
+
+@media (max-width: 768px) {
+    .content-block {
+        flex-direction: column;
+    }
+    .content-block-text,
+    .content-block-image {
+        flex: 1 1 auto;
+    }
+    .content-block-image {
+        padding-right: 0;
+    }
+    .desktop-only {
+        display: none;
+    }
+    .mobile-only {
+        display: flex;
+    }
+}
+
 @media (max-width: 768px) {
     .shop-category-list {
         display: none;

--- a/assets/style.css
+++ b/assets/style.css
@@ -1703,7 +1703,6 @@ body.shop-filter-open {
     gap: 1rem;
     margin: 2rem 0;
     background: #f5f5f5;
-    padding: 1rem;
     border-radius: .5rem;
     width: 100%;
 }
@@ -1712,6 +1711,7 @@ body.shop-filter-open {
 }
 .content-block-text {
     flex: 0 0 70%;
+    padding: 2rem;
 }
 .content-block-image {
     flex: 0 0 30%;
@@ -1750,6 +1750,8 @@ body.shop-filter-open {
     }
     .content-block-image {
         padding-right: 0;
+        min-height: 400px;
+        border-radius: 0 0 .5rem .5rem;
     }
     .desktop-only {
         display: none;

--- a/assets/style.css
+++ b/assets/style.css
@@ -1769,6 +1769,7 @@ body.shop-filter-open {
     .content-block-image {
         min-height: 350px;
         border-radius: .5rem .5rem 0 0;
+        margin: 0;
     }
     .content-block-text h3 {
         font-size: 28px;

--- a/assets/style.css
+++ b/assets/style.css
@@ -1715,11 +1715,9 @@ body.shop-filter-open {
 }
 .content-block-image {
     flex: 0 0 30%;
-    padding-right: 16px;
     background-size: cover;
     background-position: center;
-    min-height: 400px;
-    border-radius: 0.5rem;
+    border-radius: 0 .5rem .5rem 0;
     position: relative;
     display: flex;
     justify-content: center;
@@ -1736,6 +1734,7 @@ body.shop-filter-open {
 /* Show blocks based on screen size without overriding flex layout */
 .desktop-only {
     display: flex ;
+    align-items: stretch;
 }
 .mobile-only {
     display: none;

--- a/assets/style.css
+++ b/assets/style.css
@@ -1699,7 +1699,7 @@ body.shop-filter-open {
     display: flex;
     flex-direction: row;
     flex-wrap: nowrap;
-    align-items: flex-start;
+    align-items: stretch;
     gap: 1rem;
     margin: 2rem 0;
     background: #f5f5f5;

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -95,6 +95,15 @@ class Admin {
             'produkt-colors',
             array($this, 'colors_page')
         );
+
+        add_submenu_page(
+            'produkt-verleih',
+            'Content-Blöcke',
+            'Content-Blöcke',
+            'manage_options',
+            'produkt-content-blocks',
+            array($this, 'content_blocks_page')
+        );
         
         
         
@@ -571,6 +580,10 @@ class Admin {
     
     public function colors_page() {
         include PRODUKT_PLUGIN_PATH . 'admin/colors-page.php';
+    }
+
+    public function content_blocks_page() {
+        include PRODUKT_PLUGIN_PATH . 'admin/content-blocks-page.php';
     }
     
     public function orders_page() {

--- a/includes/Database.php
+++ b/includes/Database.php
@@ -595,6 +595,15 @@ class Database {
             if (empty($mobile_exists)) {
                 $wpdb->query("ALTER TABLE $table_blocks ADD COLUMN position_mobile INT NOT NULL DEFAULT 6 AFTER position");
             }
+
+            $color_exists = $wpdb->get_results("SHOW COLUMNS FROM $table_blocks LIKE 'background_color'");
+            if (empty($color_exists)) {
+                $wpdb->query("ALTER TABLE $table_blocks ADD COLUMN background_color VARCHAR(20) DEFAULT '' AFTER button_url");
+            }
+            $badge_exists = $wpdb->get_results("SHOW COLUMNS FROM $table_blocks LIKE 'badge_text'");
+            if (empty($badge_exists)) {
+                $wpdb->query("ALTER TABLE $table_blocks ADD COLUMN badge_text TEXT AFTER background_color");
+            }
         }
     }
     
@@ -897,6 +906,8 @@ class Database {
             image_url TEXT,
             button_text TEXT,
             button_url TEXT,
+            background_color VARCHAR(20) DEFAULT '',
+            badge_text TEXT,
             PRIMARY KEY (id),
             KEY category_id (category_id)
         ) $charset_collate;";

--- a/includes/Database.php
+++ b/includes/Database.php
@@ -567,6 +567,35 @@ class Database {
             require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
             dbDelta($sql);
         }
+
+        // Create content blocks table if it doesn't exist
+        $table_blocks = $wpdb->prefix . 'produkt_content_blocks';
+        $blocks_exists = $wpdb->get_var("SHOW TABLES LIKE '$table_blocks'");
+        if (!$blocks_exists) {
+            $charset_collate = $wpdb->get_charset_collate();
+            $sql = "CREATE TABLE $table_blocks (
+                id INT NOT NULL AUTO_INCREMENT,
+                category_id INT NOT NULL,
+                position INT NOT NULL,
+                position_mobile INT NOT NULL DEFAULT 6,
+                title TEXT NOT NULL,
+                content TEXT NOT NULL,
+                image_url TEXT,
+                button_text TEXT,
+                button_url TEXT,
+                PRIMARY KEY (id),
+                KEY category_id (category_id)
+            ) $charset_collate;";
+
+            require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
+            dbDelta($sql);
+        } else {
+            // Add missing columns for desktop/mobile positions
+            $mobile_exists = $wpdb->get_results("SHOW COLUMNS FROM $table_blocks LIKE 'position_mobile'");
+            if (empty($mobile_exists)) {
+                $wpdb->query("ALTER TABLE $table_blocks ADD COLUMN position_mobile INT NOT NULL DEFAULT 6 AFTER position");
+            }
+        }
     }
     
     public function create_tables() {
@@ -856,6 +885,22 @@ class Database {
         dbDelta($sql_variant_options);
         dbDelta($sql_variant_durations);
         dbDelta($sql_duration_prices);
+        // Content blocks table
+        $table_content_blocks = $wpdb->prefix . 'produkt_content_blocks';
+        $sql_content_blocks = "CREATE TABLE $table_content_blocks (
+            id INT NOT NULL AUTO_INCREMENT,
+            category_id INT NOT NULL,
+            position INT NOT NULL,
+            position_mobile INT NOT NULL DEFAULT 6,
+            title TEXT NOT NULL,
+            content TEXT NOT NULL,
+            image_url TEXT,
+            button_text TEXT,
+            button_url TEXT,
+            PRIMARY KEY (id),
+            KEY category_id (category_id)
+        ) $charset_collate;";
+        dbDelta($sql_content_blocks);
         dbDelta($sql_orders);
 
         // Metadata table for storing Stripe session details
@@ -1097,6 +1142,7 @@ class Database {
             'produkt_analytics',
             'produkt_branding',
             'produkt_notifications',
+            'produkt_content_blocks',
             'produkt_stripe_metadata'
         );
 
@@ -1158,5 +1204,40 @@ class Database {
         $sql .= " ORDER BY sort_order";
 
         return $wpdb->get_results($sql);
+    }
+
+    /**
+     * Retrieve content blocks for a product category.
+     *
+     * @param int $category_id
+     * @return array
+     */
+    public static function get_content_blocks_for_category($category_id) {
+        $cache_key = 'produkt_content_blocks_' . intval($category_id);
+        $blocks = get_transient($cache_key);
+        if ($blocks !== false) {
+            return $blocks;
+        }
+
+        global $wpdb;
+        $table = $wpdb->prefix . 'produkt_content_blocks';
+        $blocks = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT * FROM $table WHERE category_id = %d ORDER BY position",
+                $category_id
+            )
+        );
+
+        set_transient($cache_key, $blocks, HOUR_IN_SECONDS);
+        return $blocks;
+    }
+
+    /**
+     * Clear cached content blocks for a category.
+     *
+     * @param int $category_id
+     */
+    public static function clear_content_blocks_cache($category_id) {
+        delete_transient('produkt_content_blocks_' . intval($category_id));
     }
 }

--- a/templates/product-archive.php
+++ b/templates/product-archive.php
@@ -46,6 +46,15 @@ if (!empty($category_slug)) {
     }
 }
 
+$content_category_id = $category->id ?? 0;
+$content_blocks = Database::get_content_blocks_for_category($content_category_id);
+$blocks_by_position_desktop = [];
+$blocks_by_position_mobile  = [];
+foreach ($content_blocks as $b) {
+    $blocks_by_position_desktop[$b->position][] = $b;
+    $blocks_by_position_mobile[$b->position_mobile][] = $b;
+}
+
 if (!function_exists('get_lowest_stripe_price_by_category')) {
     function get_lowest_stripe_price_by_category($category_id) {
         global $wpdb;
@@ -120,7 +129,7 @@ if (!function_exists('get_lowest_stripe_price_by_category')) {
             <?php endif; ?>
 
             <div class="shop-product-grid">
-        <?php foreach (($categories ?? []) as $cat): ?>
+        <?php $produkt_index = 0; foreach (($categories ?? []) as $cat): $produkt_index++; ?>
         <?php $url = home_url('/shop/produkt/' . sanitize_title($cat->product_title)); ?>
         <?php $price_data = get_lowest_stripe_price_by_category($cat->id); ?>
         <div class="shop-product-item">
@@ -157,6 +166,43 @@ if (!function_exists('get_lowest_stripe_price_by_category')) {
                 </div>
             </a>
         </div>
+        <?php
+            $next_index = $produkt_index + 1;
+            if (isset($blocks_by_position_desktop[$next_index])) {
+                foreach ($blocks_by_position_desktop[$next_index] as $block) {
+                    ?>
+                    <div class="content-block desktop-only">
+                        <div class="content-block-text">
+                            <h3><?php echo esc_html($block->title); ?></h3>
+                            <?php echo wpautop($block->content); ?>
+                        </div>
+                        <div class="content-block-image"<?php if (!empty($block->image_url)): ?> style="background-image:url('<?php echo esc_url($block->image_url); ?>')"<?php endif; ?>>
+                            <?php if (!empty($block->button_text) && !empty($block->button_url)): ?>
+                                <a class="content-block-button" href="<?php echo esc_url($block->button_url); ?>"><?php echo esc_html($block->button_text); ?></a>
+                            <?php endif; ?>
+                        </div>
+                    </div>
+                    <?php
+                }
+            }
+            if (isset($blocks_by_position_mobile[$next_index])) {
+                foreach ($blocks_by_position_mobile[$next_index] as $block) {
+                    ?>
+                    <div class="content-block mobile-only">
+                        <div class="content-block-text">
+                            <h3><?php echo esc_html($block->title); ?></h3>
+                            <?php echo wpautop($block->content); ?>
+                        </div>
+                        <div class="content-block-image"<?php if (!empty($block->image_url)): ?> style="background-image:url('<?php echo esc_url($block->image_url); ?>')"<?php endif; ?>>
+                            <?php if (!empty($block->button_text) && !empty($block->button_url)): ?>
+                                <a class="content-block-button" href="<?php echo esc_url($block->button_url); ?>"><?php echo esc_html($block->button_text); ?></a>
+                            <?php endif; ?>
+                        </div>
+                    </div>
+                    <?php
+                }
+            }
+        ?>
         <?php endforeach; ?>
 
         </div>

--- a/templates/product-archive.php
+++ b/templates/product-archive.php
@@ -175,11 +175,11 @@ if (!function_exists('get_lowest_stripe_price_by_category')) {
                         <div class="content-block-text">
                             <h3><?php echo esc_html($block->title); ?></h3>
                             <?php echo wpautop($block->content); ?>
-                        </div>
-                        <div class="content-block-image"<?php if (!empty($block->image_url)): ?> style="background-image:url('<?php echo esc_url($block->image_url); ?>')"<?php endif; ?>>
                             <?php if (!empty($block->button_text) && !empty($block->button_url)): ?>
                                 <a class="content-block-button" href="<?php echo esc_url($block->button_url); ?>"><?php echo esc_html($block->button_text); ?></a>
                             <?php endif; ?>
+                        </div>
+                        <div class="content-block-image"<?php if (!empty($block->image_url)): ?> style="background-image:url('<?php echo esc_url($block->image_url); ?>')"<?php endif; ?>>
                         </div>
                     </div>
                     <?php
@@ -192,11 +192,11 @@ if (!function_exists('get_lowest_stripe_price_by_category')) {
                         <div class="content-block-text">
                             <h3><?php echo esc_html($block->title); ?></h3>
                             <?php echo wpautop($block->content); ?>
-                        </div>
-                        <div class="content-block-image"<?php if (!empty($block->image_url)): ?> style="background-image:url('<?php echo esc_url($block->image_url); ?>')"<?php endif; ?>>
                             <?php if (!empty($block->button_text) && !empty($block->button_url)): ?>
                                 <a class="content-block-button" href="<?php echo esc_url($block->button_url); ?>"><?php echo esc_html($block->button_text); ?></a>
                             <?php endif; ?>
+                        </div>
+                        <div class="content-block-image"<?php if (!empty($block->image_url)): ?> style="background-image:url('<?php echo esc_url($block->image_url); ?>')"<?php endif; ?>>
                         </div>
                     </div>
                     <?php

--- a/templates/product-archive.php
+++ b/templates/product-archive.php
@@ -171,8 +171,11 @@ if (!function_exists('get_lowest_stripe_price_by_category')) {
             if (isset($blocks_by_position_desktop[$next_index])) {
                 foreach ($blocks_by_position_desktop[$next_index] as $block) {
                     ?>
-                    <div class="content-block desktop-only">
+                    <div class="content-block desktop-only"<?php if (!empty($block->background_color)): ?> style="background-color: <?php echo esc_attr($block->background_color); ?>"<?php endif; ?>>
                         <div class="content-block-text">
+                            <?php if (!empty($block->badge_text)): ?>
+                                <span class="content-block-badge"><?php echo esc_html($block->badge_text); ?></span>
+                            <?php endif; ?>
                             <h3><?php echo esc_html($block->title); ?></h3>
                             <?php echo wpautop($block->content); ?>
                             <?php if (!empty($block->button_text) && !empty($block->button_url)): ?>
@@ -188,8 +191,11 @@ if (!function_exists('get_lowest_stripe_price_by_category')) {
             if (isset($blocks_by_position_mobile[$next_index])) {
                 foreach ($blocks_by_position_mobile[$next_index] as $block) {
                     ?>
-                    <div class="content-block mobile-only">
+                    <div class="content-block mobile-only"<?php if (!empty($block->background_color)): ?> style="background-color: <?php echo esc_attr($block->background_color); ?>"<?php endif; ?>>
                         <div class="content-block-text">
+                            <?php if (!empty($block->badge_text)): ?>
+                                <span class="content-block-badge"><?php echo esc_html($block->badge_text); ?></span>
+                            <?php endif; ?>
                             <h3><?php echo esc_html($block->title); ?></h3>
                             <?php echo wpautop($block->content); ?>
                             <?php if (!empty($block->button_text) && !empty($block->button_url)): ?>

--- a/templates/product-archive.php
+++ b/templates/product-archive.php
@@ -177,7 +177,9 @@ if (!function_exists('get_lowest_stripe_price_by_category')) {
                                 <span class="content-block-badge"><?php echo esc_html($block->badge_text); ?></span>
                             <?php endif; ?>
                             <h3><?php echo esc_html($block->title); ?></h3>
-                            <?php echo wpautop($block->content); ?>
+                            <div class="content-block-description">
+                                <?php echo wpautop($block->content); ?>
+                            </div>
                             <?php if (!empty($block->button_text) && !empty($block->button_url)): ?>
                                 <a class="content-block-button" href="<?php echo esc_url($block->button_url); ?>"><?php echo esc_html($block->button_text); ?></a>
                             <?php endif; ?>
@@ -197,7 +199,9 @@ if (!function_exists('get_lowest_stripe_price_by_category')) {
                                 <span class="content-block-badge"><?php echo esc_html($block->badge_text); ?></span>
                             <?php endif; ?>
                             <h3><?php echo esc_html($block->title); ?></h3>
-                            <?php echo wpautop($block->content); ?>
+                            <div class="content-block-description">
+                                <?php echo wpautop($block->content); ?>
+                            </div>
                             <?php if (!empty($block->button_text) && !empty($block->button_url)): ?>
                                 <a class="content-block-button" href="<?php echo esc_url($block->button_url); ?>"><?php echo esc_html($block->button_text); ?></a>
                             <?php endif; ?>


### PR DESCRIPTION
## Summary
- keep `.content-block-image` padding-right on desktop
- remove that padding in the mobile breakpoint
- overlay the button on the block image and use the image as a background

## Testing
- `php -l admin/content-blocks-page.php`
- `php -l includes/Admin.php`
- `php -l includes/Database.php`
- `php -l templates/product-archive.php`


------
https://chatgpt.com/codex/tasks/task_b_6870c9a68e048330b9f939b5163814bc