### PR TITLE
Add customer account page

### DIFF
--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -257,7 +257,7 @@ class Plugin {
                     'expires' => $expires,
                 ];
 
-                update_option('produkt_login_token_' . $token, $data);
+                set_transient('produkt_login_token_' . $token, $data, 15 * MINUTE_IN_SECONDS);
 
                 error_log('TOKEN gespeichert: ' . print_r(['key' => 'produkt_login_token_' . $token, 'data' => $data], true));
 
@@ -584,7 +584,7 @@ class Plugin {
     public function handle_magic_login() {
         if (isset($_GET['produkt_login_token'])) {
             $token = sanitize_text_field($_GET['produkt_login_token'] ?? '');
-            $data  = get_option('produkt_login_token_' . $token);
+            $data  = get_transient('produkt_login_token_' . $token);
 
             error_log('TOKEN geladen: ' . print_r(['key' => 'produkt_login_token_' . $token, 'data' => $data], true));
 
@@ -593,7 +593,7 @@ class Plugin {
             }
 
             $user_id = $data['user_id'];
-            delete_option('produkt_login_token_' . $token);
+            delete_transient('produkt_login_token_' . $token);
 
             wp_set_auth_cookie($user_id);
             wp_redirect(get_permalink(get_option(PRODUKT_CUSTOMER_PAGE_OPTION)));

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -28,6 +28,7 @@ class Plugin {
         add_action('admin_menu', [$this->admin, 'add_admin_menu']);
         add_shortcode('produkt_product', [$this, 'product_shortcode']);
         add_shortcode('produkt_shop_grid', [$this, 'render_product_grid']);
+        add_shortcode('produkt_account', [$this, 'render_customer_account']);
         add_action('wp_enqueue_scripts', [$this->admin, 'enqueue_frontend_assets']);
         add_action('admin_enqueue_scripts', [$this->admin, 'enqueue_admin_assets']);
 
@@ -102,6 +103,7 @@ class Plugin {
         add_rewrite_rule('^shop/produkt/([^/]+)/?$', 'index.php?produkt_slug=$matches[1]', 'top');
         add_rewrite_rule('^shop/([^/]+)/?$', 'index.php?produkt_category_slug=$matches[1]', 'top');
         $this->create_shop_page();
+        $this->create_customer_page();
         flush_rewrite_rules();
     }
 
@@ -145,6 +147,7 @@ class Plugin {
             'produkt_ct_submit',
             'produkt_ct_after_submit',
             PRODUKT_SHOP_PAGE_OPTION,
+            PRODUKT_CUSTOMER_PAGE_OPTION,
         );
 
         foreach ($options as $opt) {
@@ -154,6 +157,10 @@ class Plugin {
         $page_id = get_option(PRODUKT_SHOP_PAGE_OPTION);
         if ($page_id) {
             wp_delete_post($page_id, true);
+        }
+        $customer_page_id = get_option(PRODUKT_CUSTOMER_PAGE_OPTION);
+        if ($customer_page_id) {
+            wp_delete_post($customer_page_id, true);
         }
     }
 
@@ -228,6 +235,12 @@ class Plugin {
 
         ob_start();
         include PRODUKT_PLUGIN_PATH . 'templates/product-archive.php';
+        return ob_get_clean();
+    }
+
+    public function render_customer_account() {
+        ob_start();
+        include PRODUKT_PLUGIN_PATH . 'templates/account-page.php';
         return ob_get_clean();
     }
 
@@ -577,10 +590,32 @@ class Plugin {
         update_option(PRODUKT_SHOP_PAGE_OPTION, $page_id);
     }
 
+    private function create_customer_page() {
+        $page = get_page_by_path('kundenkonto');
+        if (!$page) {
+            $page_data = [
+                'post_title'   => 'Kundenkonto',
+                'post_name'    => 'kundenkonto',
+                'post_content' => '[produkt_account]',
+                'post_status'  => 'publish',
+                'post_type'    => 'page'
+            ];
+            $page_id = wp_insert_post($page_data);
+        } else {
+            $page_id = $page->ID;
+        }
+
+        update_option(PRODUKT_CUSTOMER_PAGE_OPTION, $page_id);
+    }
+
     public function mark_shop_page($states, $post) {
         $shop_page_id = get_option(PRODUKT_SHOP_PAGE_OPTION);
         if ($post->ID == $shop_page_id) {
             $states[] = __('Shop-Seite', 'h2-concepts');
+        }
+        $customer_page_id = get_option(PRODUKT_CUSTOMER_PAGE_OPTION);
+        if ($post->ID == $customer_page_id) {
+            $states[] = __('Kundenkonto-Seite', 'h2-concepts');
         }
         return $states;
     }

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -252,13 +252,14 @@ class Plugin {
                 $token   = wp_generate_password(32, false);
                 $expires = current_time('timestamp') + 15 * MINUTE_IN_SECONDS;
 
-                update_option(
-                    'produkt_login_token_' . $token,
-                    [
-                        'user_id' => $user->ID,
-                        'expires' => $expires,
-                    ]
-                );
+                $data = [
+                    'user_id' => $user->ID,
+                    'expires' => $expires,
+                ];
+
+                update_option('produkt_login_token_' . $token, $data);
+
+                error_log('TOKEN gespeichert: ' . print_r(['key' => 'produkt_login_token_' . $token, 'data' => $data], true));
 
                 $login_url = add_query_arg([
                     'produkt_login_token' => $token,
@@ -584,6 +585,8 @@ class Plugin {
         if (isset($_GET['produkt_login_token'])) {
             $token = sanitize_text_field($_GET['produkt_login_token'] ?? '');
             $data  = get_option('produkt_login_token_' . $token);
+
+            error_log('TOKEN geladen: ' . print_r(['key' => 'produkt_login_token_' . $token, 'data' => $data], true));
 
             if (!$data || current_time('timestamp') > $data['expires']) {
                 wp_die('Der Login-Link ist ungültig oder abgelaufen.');

--- a/produkt-verleih.php
+++ b/produkt-verleih.php
@@ -81,3 +81,20 @@ function produkt_simple_checkout_button() {
     </script>
     <?php return ob_get_clean();
 }
+
+function produkt_set_login_token($user_id, $token, $expires) {
+    $data = [
+        'token'   => $token,
+        'expires' => $expires,
+    ];
+    update_user_meta($user_id, 'produkt_login_token', $data);
+}
+
+function produkt_get_login_token($user_id) {
+    $data = get_user_meta($user_id, 'produkt_login_token', true);
+    if (!is_array($data) || empty($data['token'])) {
+        error_log("TOKEN ABRUF FEHLGESCHLAGEN f\xC3\xBCr User {$user_id}");
+        return false;
+    }
+    return $data;
+}

--- a/produkt-verleih.php
+++ b/produkt-verleih.php
@@ -21,6 +21,7 @@ define('PRODUKT_PLUGIN_PATH', PRODUKT_PLUGIN_DIR);
 define('PRODUKT_VERSION', PRODUKT_PLUGIN_VERSION);
 define('PRODUKT_PLUGIN_FILE', __FILE__);
 define('PRODUKT_SHOP_PAGE_OPTION', 'produkt_shop_page_id');
+define('PRODUKT_CUSTOMER_PAGE_OPTION', 'produkt_customer_page_id');
 
 // Control whether default demo data is inserted on activation
 if (!defined('PRODUKT_LOAD_DEFAULT_DATA')) {

--- a/produkt-verleih.php
+++ b/produkt-verleih.php
@@ -86,6 +86,7 @@ function produkt_set_login_token($user_id, $token, $expires) {
     $data = [
         'token'   => $token,
         'expires' => $expires,
+        'used'    => false,
     ];
     update_user_meta($user_id, 'produkt_login_token', $data);
 }

--- a/templates/account-page.php
+++ b/templates/account-page.php
@@ -1,0 +1,6 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+?>
+<p>Hier entsteht Ihr persönlicher Kundenbereich.</p>

--- a/templates/account-page.php
+++ b/templates/account-page.php
@@ -3,4 +3,14 @@ if (!defined('ABSPATH')) {
     exit;
 }
 ?>
-<p>Hier entsteht Ihr persönlicher Kundenbereich.</p>
+<?php if (!is_user_logged_in()) : ?>
+    <h2>Login zum Kundenbereich</h2>
+    <form method="post">
+        <label for="produkt_email">Ihre E-Mail-Adresse:</label>
+        <input type="email" name="produkt_email" id="produkt_email" required>
+        <button type="submit" name="produkt_login_request">Login-Link anfordern</button>
+    </form>
+<?php else: ?>
+    <p>Willkommen zurück, <?php echo wp_get_current_user()->display_name; ?>!</p>
+    <!-- Hier kommen später die Kundendaten -->
+<?php endif; ?>


### PR DESCRIPTION
## Summary
- create `kundenkonto` page on plugin activation
- show admin post state for customer page
- register new `[produkt_account]` shortcode
- render a simple placeholder template
- remove customer page on uninstall

## Testing
- `find . -name '*.php' -print0 | xargs -0 -I {} php -l {}`

------
https://chatgpt.com/codex/tasks/task_b_6872d3f015048330a6f8e692d03315ae