### PR TITLE
Add customer account page and shortcode

### DIFF
--- a/includes/Database.php
+++ b/includes/Database.php
@@ -1251,4 +1251,24 @@ class Database {
     public static function clear_content_blocks_cache($category_id) {
         delete_transient('produkt_content_blocks_' . intval($category_id));
     }
+
+    /**
+     * Retrieve orders placed by a specific WordPress user.
+     *
+     * @param int $user_id User ID
+     * @return array List of order objects
+     */
+    public static function get_orders_for_user($user_id) {
+        $user = get_user_by('ID', $user_id);
+        if (!$user) {
+            return [];
+        }
+
+        global $wpdb;
+        $table = $wpdb->prefix . 'produkt_orders';
+        $email = sanitize_email($user->user_email);
+
+        $sql = "SELECT *, stripe_subscription_id AS subscription_id FROM $table WHERE customer_email = %s ORDER BY created_at";
+        return $wpdb->get_results($wpdb->prepare($sql, $email));
+    }
 }

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -331,12 +331,17 @@ class Plugin {
                                 }
                             }
 
-                            $laufzeit_in_monaten = 3; // Fallback
-
-                            if ($matching_order && !empty($matching_order->dauer_text)) {
-                                // Dauer auslesen, z.\xE2\x80\xAFB. \xE2\x80\x9EAb 2+ Monaten\xE2\x80\x9C \xE2\x86\x92 2
-                                if (preg_match('/(\d+)\+/', $matching_order->dauer_text, $matches)) {
-                                    $laufzeit_in_monaten = (int) $matches[1];
+                            $laufzeit_in_monaten = 3;
+                            if ($matching_order && !empty($matching_order->duration_id)) {
+                                global $wpdb;
+                                $laufzeit_in_monaten = (int) $wpdb->get_var(
+                                    $wpdb->prepare(
+                                        "SELECT months_minimum FROM {$wpdb->prefix}produkt_durations WHERE id = %d",
+                                        $matching_order->duration_id
+                                    )
+                                );
+                                if (!$laufzeit_in_monaten) {
+                                    $laufzeit_in_monaten = 3; // Fallback
                                 }
                             }
 

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -30,7 +30,6 @@ class Plugin {
         add_shortcode('produkt_shop_grid', [$this, 'render_product_grid']);
         add_shortcode('produkt_account', [$this, 'render_customer_account']);
         add_action('init', [$this, 'register_customer_role']);
-        add_action('template_redirect', [$this, 'maybe_handle_login_code']);
         add_action('wp_enqueue_scripts', [$this->admin, 'enqueue_frontend_assets']);
         add_action('admin_enqueue_scripts', [$this->admin, 'enqueue_admin_assets']);
 
@@ -656,28 +655,6 @@ class Plugin {
         }
     }
 
-    /**
-     * Process login code verification before any output is sent.
-     */
-    public function maybe_handle_login_code() {
-        if (empty($_POST['verify_login_code'])) {
-            return;
-        }
-
-        $email      = sanitize_email($_POST['email'] ?? '');
-        $input_code = sanitize_text_field($_POST['code'] ?? '');
-        $user       = get_user_by('email', $email);
-
-        if ($user) {
-            $data = get_user_meta($user->ID, 'produkt_login_code', true);
-            if ($data && $data['code'] == $input_code && time() <= $data['expires']) {
-                delete_user_meta($user->ID, 'produkt_login_code');
-                wp_set_auth_cookie($user->ID);
-                wp_redirect(get_permalink(get_option(PRODUKT_CUSTOMER_PAGE_OPTION)));
-                exit;
-            }
-        }
-    }
 
     public function maybe_display_product_page() {
         $slug = sanitize_title(get_query_var('produkt_slug'));

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -29,6 +29,7 @@ class Plugin {
         add_shortcode('produkt_product', [$this, 'product_shortcode']);
         add_shortcode('produkt_shop_grid', [$this, 'render_product_grid']);
         add_shortcode('produkt_account', [$this, 'render_customer_account']);
+        add_action('init', [$this, 'register_customer_role']);
         add_action('wp_enqueue_scripts', [$this->admin, 'enqueue_frontend_assets']);
         add_action('admin_enqueue_scripts', [$this->admin, 'enqueue_admin_assets']);
 
@@ -694,6 +695,12 @@ class Plugin {
         }
 
         return null;
+    }
+
+    public function register_customer_role() {
+        add_role('kunde', 'Kunde', [
+            'read' => true,
+        ]);
     }
 }
 

--- a/includes/StripeService.php
+++ b/includes/StripeService.php
@@ -257,4 +257,56 @@ class StripeService {
     public static function get_payment_method_configuration_id() {
         return get_option('produkt_stripe_pmc_id', '');
     }
+
+    /**
+     * Retrieve active subscriptions for a given customer.
+     *
+     * @param string $customer_id Stripe customer ID
+     * @return array|\WP_Error
+     */
+    public static function get_active_subscriptions_for_customer($customer_id) {
+        $init = self::init();
+        if (is_wp_error($init)) {
+            return $init;
+        }
+        try {
+            $subs = \Stripe\Subscription::all([
+                'customer' => $customer_id,
+                'status'   => 'all',
+                'limit'    => 100,
+            ]);
+            $result = [];
+            foreach ($subs->autoPagingIterator() as $sub) {
+                if (in_array($sub->status, ['active', 'trialing', 'past_due'], true)) {
+                    $result[] = [
+                        'subscription_id'   => $sub->id,
+                        'start_date'        => date('Y-m-d H:i:s', $sub->start_date),
+                        'cancel_at_period_end' => $sub->cancel_at_period_end,
+                    ];
+                }
+            }
+            return $result;
+        } catch (\Exception $e) {
+            return new \WP_Error('stripe_subscriptions', $e->getMessage());
+        }
+    }
+
+    /**
+     * Mark a subscription to cancel at the period end.
+     *
+     * @param string $subscription_id
+     * @return true|\WP_Error
+     */
+    public static function cancel_subscription_at_period_end($subscription_id) {
+        $init = self::init();
+        if (is_wp_error($init)) {
+            return $init;
+        }
+        try {
+            \Stripe\Subscription::update($subscription_id, ['cancel_at_period_end' => true]);
+            return true;
+        } catch (\Exception $e) {
+            return new \WP_Error('stripe_cancel', $e->getMessage());
+        }
+    }
 }

--- a/produkt-verleih.php
+++ b/produkt-verleih.php
@@ -21,6 +21,7 @@ define('PRODUKT_PLUGIN_PATH', PRODUKT_PLUGIN_DIR);
 define('PRODUKT_VERSION', PRODUKT_PLUGIN_VERSION);
 define('PRODUKT_PLUGIN_FILE', __FILE__);
 define('PRODUKT_SHOP_PAGE_OPTION', 'produkt_shop_page_id');
+define('PRODUKT_CUSTOMER_PAGE_OPTION', 'produkt_customer_page_id');
 
 // Control whether default demo data is inserted on activation
 if (!defined('PRODUKT_LOAD_DEFAULT_DATA')) {

--- a/templates/account-page.php
+++ b/templates/account-page.php
@@ -38,8 +38,17 @@ $db = new Database();
                 $start_ts = strtotime($sub['start_date']);
                 $start_formatted = date_i18n('d.m.Y', $start_ts);
                 $laufzeit_in_monaten = 3;
-                if ($order && !empty($order->dauer_text) && preg_match('/(\d+)\+/', $order->dauer_text, $m)) {
-                    $laufzeit_in_monaten = (int) $m[1];
+                if ($order && !empty($order->duration_id)) {
+                    global $wpdb;
+                    $laufzeit_in_monaten = (int) $wpdb->get_var(
+                        $wpdb->prepare(
+                            "SELECT months_minimum FROM {$wpdb->prefix}produkt_durations WHERE id = %d",
+                            $order->duration_id
+                        )
+                    );
+                    if (!$laufzeit_in_monaten) {
+                        $laufzeit_in_monaten = 3; // Fallback
+                    }
                 }
                 $cancelable_ts = strtotime("+{$laufzeit_in_monaten} months", $start_ts);
                 $cancelable_date = date_i18n('d.m.Y', $cancelable_ts);

--- a/templates/account-page.php
+++ b/templates/account-page.php
@@ -17,7 +17,26 @@ if (!defined('ABSPATH')) {
         </form>
         <?php endif; ?>
     <?php else : ?>
-        <p>Hier entsteht Ihr persönlicher Kundenbereich.</p>
+        <?php if (!empty($subscriptions)) : ?>
+            <h2>Ihre Abos</h2>
+            <ul class="produkt-subscriptions">
+                <?php foreach ($subscriptions as $s) : ?>
+                    <li>
+                        <?php echo esc_html($s['subscription_id']); ?>
+                        <?php if (empty($s['cancel_at_period_end'])) : ?>
+                            <form method="post" style="display:inline;margin-left:10px;">
+                                <input type="hidden" name="cancel_subscription" value="<?php echo esc_attr($s['subscription_id']); ?>">
+                                <button type="submit">Jetzt kündigen</button>
+                            </form>
+                        <?php else : ?>
+                            <span style="margin-left:10px;">Kündigung vorgemerkt</span>
+                        <?php endif; ?>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+        <?php else : ?>
+            <p>Keine aktiven Abos.</p>
+        <?php endif; ?>
     <?php endif; ?>
 </div>
 

--- a/templates/account-page.php
+++ b/templates/account-page.php
@@ -1,7 +1,11 @@
 <?php
+use ProduktVerleih\Database;
+
 if (!defined('ABSPATH')) {
     exit;
 }
+
+$db = new Database();
 
 ?>
 <div class="produkt-account-wrapper">

--- a/templates/account-page.php
+++ b/templates/account-page.php
@@ -1,4 +1,23 @@
 <?php
-// Kundenbereich Placeholder
+if (!defined('ABSPATH')) {
+    exit;
+}
 ?>
-<p>Hier entsteht Ihr persönlicher Kundenbereich.</p>
+<div class="produkt-account-wrapper">
+    <?php if (!is_user_logged_in()) : ?>
+        <form method="post" class="produkt-account-email-form">
+            <input type="email" name="email" placeholder="Ihre E-Mail" value="<?php echo esc_attr($email_value); ?>" required>
+            <button type="submit" name="request_login_code">Login-Code anfordern</button>
+        </form>
+        <?php if ($show_code_form) : ?>
+        <form method="post" class="produkt-account-code-form">
+            <input type="hidden" name="email" value="<?php echo esc_attr($email_value); ?>">
+            <input type="text" name="code" placeholder="6-stelliger Code" required>
+            <button type="submit" name="verify_login_code">Einloggen</button>
+        </form>
+        <?php endif; ?>
+    <?php else : ?>
+        <p>Hier entsteht Ihr persönlicher Kundenbereich.</p>
+    <?php endif; ?>
+</div>
+

--- a/templates/account-page.php
+++ b/templates/account-page.php
@@ -54,24 +54,56 @@ $db = new Database();
                 $kuendigungsfenster_ts    = strtotime('-14 days', $cancelable_ts);
                 $kuendigbar_ab_date       = date_i18n('d.m.Y', $kuendigungsfenster_ts);
                 $cancelable               = time() >= $kuendigungsfenster_ts;
-                ?>
-                <div class="abo-box">
-                    <h3><?php echo esc_html($product_name); ?></h3>
-                    <p><strong>Gemietet seit:</strong> <?php echo esc_html($start_formatted); ?></p>
-                    <p><strong>Kündbar ab:</strong> <?php echo esc_html($kuendigbar_ab_date); ?></p>
 
-                    <?php if ($sub['cancel_at_period_end']) : ?>
-                        <p style="color:orange;"><strong>✅ Kündigung vorgemerkt.</strong></p>
-                    <?php elseif ($cancelable) : ?>
-                        <form method="post">
-                            <input type="hidden" name="cancel_subscription" value="<?php echo esc_attr($sub['subscription_id']); ?>">
-                            <p style="margin-bottom:8px;">Sie können jetzt kündigen – die Kündigung wird zum Ende der Mindestlaufzeit wirksam (<?php echo esc_html(date_i18n('d.m.Y', $cancelable_ts)); ?>).</p>
-                            <button type="submit" style="background:#dc3545;color:white;border:none;padding:10px 20px;border-radius:5px;">
-                                Zum Laufzeitende kündigen
-                            </button>
-                        </form>
-                    <?php else : ?>
-                        <p style="color:#888;"><strong>⏳ Ihre Kündigung ist frühestens 14 Tage vor Ablauf der Mindestlaufzeit möglich (ab dem <?php echo esc_html($kuendigbar_ab_date); ?>).</strong></p>
+                $image_url = '';
+                if ($order && !empty($order->variant_id)) {
+                    global $wpdb;
+                    $image_url = $wpdb->get_var(
+                        $wpdb->prepare(
+                            "SELECT image_url_1 FROM {$wpdb->prefix}produkt_variants WHERE id = %d",
+                            $order->variant_id
+                        )
+                    );
+                }
+
+                $address = trim($order->customer_street . ', ' . $order->customer_postal . ' ' . $order->customer_city);
+                ?>
+                <div class="abo-wrapper">
+                    <div class="abo-box">
+                        <h3><?php echo esc_html($product_name); ?></h3>
+                        <p><strong>Gemietet seit:</strong> <?php echo esc_html($start_formatted); ?></p>
+                        <p><strong>Kündbar ab:</strong> <?php echo esc_html($kuendigbar_ab_date); ?></p>
+
+                        <?php if ($sub['cancel_at_period_end']) : ?>
+                            <p style="color:orange;"><strong>✅ Kündigung vorgemerkt.</strong></p>
+                        <?php elseif ($cancelable) : ?>
+                            <form method="post">
+                                <input type="hidden" name="cancel_subscription" value="<?php echo esc_attr($sub['subscription_id']); ?>">
+                                <p style="margin-bottom:8px;">Sie können jetzt kündigen – die Kündigung wird zum Ende der Mindestlaufzeit wirksam (<?php echo esc_html(date_i18n('d.m.Y', $cancelable_ts)); ?>).</p>
+                                <button type="submit" style="background:#dc3545;color:white;border:none;padding:10px 20px;border-radius:5px;">
+                                    Zum Laufzeitende kündigen
+                                </button>
+                            </form>
+                        <?php else : ?>
+                            <p style="color:#888;"><strong>⏳ Ihre Kündigung ist frühestens 14 Tage vor Ablauf der Mindestlaufzeit möglich (ab dem <?php echo esc_html($kuendigbar_ab_date); ?>).</strong></p>
+                        <?php endif; ?>
+                    </div>
+
+                    <?php if ($order) : ?>
+                        <div class="order-box">
+                            <?php if ($image_url) : ?>
+                                <img src="<?php echo esc_url($image_url); ?>" alt="" style="max-width:100%;height:auto;margin-bottom:8px;">
+                            <?php endif; ?>
+                            <p><strong>Name:</strong> <?php echo esc_html($order->customer_name); ?></p>
+                            <p><strong>E-Mail:</strong> <?php echo esc_html($order->customer_email); ?></p>
+                            <p><strong>Adresse:</strong> <?php echo esc_html($address); ?></p>
+                            <p><strong>Preis pro Monat:</strong> <?php echo esc_html(number_format((float) $order->final_price, 2, ',', '.')); ?>€</p>
+                            <p><strong>Extras:</strong> <?php echo esc_html($order->extra_text); ?></p>
+                            <p><strong>Farbe:</strong> <?php echo esc_html($order->produktfarbe_text); ?></p>
+                            <p><strong>Gestellfarbe:</strong> <?php echo esc_html($order->gestellfarbe_text); ?></p>
+                            <p><strong>Zustand:</strong> <?php echo esc_html($order->zustand_text); ?></p>
+                            <p><strong>Mietbeginn:</strong> <?php echo esc_html($start_formatted); ?></p>
+                        </div>
                     <?php endif; ?>
                 </div>
             <?php endforeach; ?>
@@ -90,5 +122,19 @@ $db = new Database();
 }
 .abo-box h3 {
     margin-top: 0;
+}
+.abo-wrapper {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    margin-bottom: 24px;
+}
+.order-box {
+    border: 1px solid #ddd;
+    padding: 16px;
+    border-radius: 8px;
+    background: #fff;
+    flex: 1;
+    min-width: 260px;
 }
 </style>

--- a/templates/account-page.php
+++ b/templates/account-page.php
@@ -1,0 +1,4 @@
+<?php
+// Kundenbereich Placeholder
+?>
+<p>Hier entsteht Ihr persönlicher Kundenbereich.</p>

--- a/templates/account-page.php
+++ b/templates/account-page.php
@@ -2,6 +2,24 @@
 if (!defined('ABSPATH')) {
     exit;
 }
+
+if (isset($_POST['verify_login_code'])) {
+    $email      = sanitize_email($_POST['email'] ?? '');
+    $input_code = sanitize_text_field($_POST['code'] ?? '');
+    $user       = get_user_by('email', $email);
+
+    if ($user) {
+        $data = get_user_meta($user->ID, 'produkt_login_code', true);
+        if ($data && $data['code'] == $input_code && time() <= $data['expires']) {
+            delete_user_meta($user->ID, 'produkt_login_code');
+            delete_user_meta($user->ID, 'login_code');
+            delete_user_meta($user->ID, 'login_code_time');
+            wp_set_auth_cookie($user->ID, true);
+            wp_safe_redirect(get_permalink());
+            exit;
+        }
+    }
+}
 ?>
 <div class="produkt-account-wrapper">
     <?php if (!is_user_logged_in()) : ?>

--- a/templates/account-page.php
+++ b/templates/account-page.php
@@ -3,23 +3,6 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-if (isset($_POST['verify_login_code'])) {
-    $email      = sanitize_email($_POST['email'] ?? '');
-    $input_code = sanitize_text_field($_POST['code'] ?? '');
-    $user       = get_user_by('email', $email);
-
-    if ($user) {
-        $data = get_user_meta($user->ID, 'produkt_login_code', true);
-        if ($data && $data['code'] == $input_code && time() <= $data['expires']) {
-            delete_user_meta($user->ID, 'produkt_login_code');
-            delete_user_meta($user->ID, 'login_code');
-            delete_user_meta($user->ID, 'login_code_time');
-            wp_set_auth_cookie($user->ID, true);
-            wp_safe_redirect(get_permalink());
-            exit;
-        }
-    }
-}
 ?>
 <div class="produkt-account-wrapper">
     <?php if (!is_user_logged_in()) : ?>

--- a/templates/account-page.php
+++ b/templates/account-page.php
@@ -50,9 +50,10 @@ $db = new Database();
                         $laufzeit_in_monaten = 3; // Fallback
                     }
                 }
-                $cancelable_ts = strtotime("+{$laufzeit_in_monaten} months", $start_ts);
-                $cancelable_date = date_i18n('d.m.Y', $cancelable_ts);
-                $cancelable = time() > $cancelable_ts;
+                $cancelable_ts       = strtotime("+{$laufzeit_in_monaten} months", $start_ts);
+                $cancelable_date       = date_i18n('d.m.Y', $cancelable_ts);
+                $kuendigungsfenster_ts = strtotime('-14 days', $cancelable_ts);
+                $cancelable            = time() >= $kuendigungsfenster_ts;
                 ?>
                 <div class="abo-box">
                     <h3><?php echo esc_html($product_name); ?></h3>
@@ -64,7 +65,10 @@ $db = new Database();
                     <?php elseif ($cancelable) : ?>
                         <form method="post">
                             <input type="hidden" name="cancel_subscription" value="<?php echo esc_attr($sub['subscription_id']); ?>">
-                            <button type="submit" style="background:#dc3545;color:white;border:none;padding:10px 20px;border-radius:5px;">Jetzt kündigen</button>
+                            <p style="margin-bottom:8px;"> Sie können jetzt kündigen – die Kündigung wird zum Ende der Mindestlaufzeit wirksam (<?php echo esc_html($cancelable_date); ?>).</p>
+                            <button type="submit" style="background:#dc3545;color:white;border:none;padding:10px 20px;border-radius:5px;">
+                                Zum Laufzeitende kündigen
+                            </button>
                         </form>
                     <?php else : ?>
                         <p style="color:#888;"><strong>⏳ Mindestlaufzeit noch aktiv.</strong></p>

--- a/templates/account-page.php
+++ b/templates/account-page.php
@@ -50,28 +50,28 @@ $db = new Database();
                         $laufzeit_in_monaten = 3; // Fallback
                     }
                 }
-                $cancelable_ts       = strtotime("+{$laufzeit_in_monaten} months", $start_ts);
-                $cancelable_date       = date_i18n('d.m.Y', $cancelable_ts);
-                $kuendigungsfenster_ts = strtotime('-14 days', $cancelable_ts);
-                $cancelable            = time() >= $kuendigungsfenster_ts;
+                $cancelable_ts            = strtotime("+{$laufzeit_in_monaten} months", $start_ts);
+                $kuendigungsfenster_ts    = strtotime('-14 days', $cancelable_ts);
+                $kuendigbar_ab_date       = date_i18n('d.m.Y', $kuendigungsfenster_ts);
+                $cancelable               = time() >= $kuendigungsfenster_ts;
                 ?>
                 <div class="abo-box">
                     <h3><?php echo esc_html($product_name); ?></h3>
                     <p><strong>Gemietet seit:</strong> <?php echo esc_html($start_formatted); ?></p>
-                    <p><strong>Kündbar ab:</strong> <?php echo esc_html($cancelable_date); ?></p>
+                    <p><strong>Kündbar ab:</strong> <?php echo esc_html($kuendigbar_ab_date); ?></p>
 
                     <?php if ($sub['cancel_at_period_end']) : ?>
                         <p style="color:orange;"><strong>✅ Kündigung vorgemerkt.</strong></p>
                     <?php elseif ($cancelable) : ?>
                         <form method="post">
                             <input type="hidden" name="cancel_subscription" value="<?php echo esc_attr($sub['subscription_id']); ?>">
-                            <p style="margin-bottom:8px;"> Sie können jetzt kündigen – die Kündigung wird zum Ende der Mindestlaufzeit wirksam (<?php echo esc_html($cancelable_date); ?>).</p>
+                            <p style="margin-bottom:8px;">Sie können jetzt kündigen – die Kündigung wird zum Ende der Mindestlaufzeit wirksam (<?php echo esc_html(date_i18n('d.m.Y', $cancelable_ts)); ?>).</p>
                             <button type="submit" style="background:#dc3545;color:white;border:none;padding:10px 20px;border-radius:5px;">
                                 Zum Laufzeitende kündigen
                             </button>
                         </form>
                     <?php else : ?>
-                        <p style="color:#888;"><strong>⏳ Mindestlaufzeit noch aktiv.</strong></p>
+                        <p style="color:#888;"><strong>⏳ Ihre Kündigung ist frühestens 14 Tage vor Ablauf der Mindestlaufzeit möglich (ab dem <?php echo esc_html($kuendigbar_ab_date); ?>).</strong></p>
                     <?php endif; ?>
                 </div>
             <?php endforeach; ?>

--- a/templates/account-page.php
+++ b/templates/account-page.php
@@ -56,14 +56,25 @@ $db = new Database();
                 $cancelable               = time() >= $kuendigungsfenster_ts;
 
                 $image_url = '';
-                if ($order && !empty($order->variant_id)) {
+                if ($order) {
                     global $wpdb;
-                    $image_url = $wpdb->get_var(
-                        $wpdb->prepare(
-                            "SELECT image_url_1 FROM {$wpdb->prefix}produkt_variants WHERE id = %d",
-                            $order->variant_id
-                        )
-                    );
+                    if (!empty($order->variant_id)) {
+                        $image_url = $wpdb->get_var(
+                            $wpdb->prepare(
+                                "SELECT image_url_1 FROM {$wpdb->prefix}produkt_variants WHERE id = %d",
+                                $order->variant_id
+                            )
+                        );
+                    }
+
+                    if (empty($image_url) && !empty($order->category_id)) {
+                        $image_url = $wpdb->get_var(
+                            $wpdb->prepare(
+                                "SELECT default_image FROM {$wpdb->prefix}produkt_categories WHERE id = %d",
+                                $order->category_id
+                            )
+                        );
+                    }
                 }
 
                 $address = trim($order->customer_street . ', ' . $order->customer_postal . ' ' . $order->customer_city);
@@ -98,10 +109,21 @@ $db = new Database();
                             <p><strong>E-Mail:</strong> <?php echo esc_html($order->customer_email); ?></p>
                             <p><strong>Adresse:</strong> <?php echo esc_html($address); ?></p>
                             <p><strong>Preis pro Monat:</strong> <?php echo esc_html(number_format((float) $order->final_price, 2, ',', '.')); ?>€</p>
-                            <p><strong>Extras:</strong> <?php echo esc_html($order->extra_text); ?></p>
-                            <p><strong>Farbe:</strong> <?php echo esc_html($order->produktfarbe_text); ?></p>
-                            <p><strong>Gestellfarbe:</strong> <?php echo esc_html($order->gestellfarbe_text); ?></p>
-                            <p><strong>Zustand:</strong> <?php echo esc_html($order->zustand_text); ?></p>
+                            <?php if (!empty($order->extra_text)) : ?>
+                                <p><strong>Extras:</strong> <?php echo esc_html($order->extra_text); ?></p>
+                            <?php endif; ?>
+
+                            <?php if (!empty($order->produktfarbe_text)) : ?>
+                                <p><strong>Farbe:</strong> <?php echo esc_html($order->produktfarbe_text); ?></p>
+                            <?php endif; ?>
+
+                            <?php if (!empty($order->gestellfarbe_text)) : ?>
+                                <p><strong>Gestellfarbe:</strong> <?php echo esc_html($order->gestellfarbe_text); ?></p>
+                            <?php endif; ?>
+
+                            <?php if (!empty($order->zustand_text)) : ?>
+                                <p><strong>Zustand:</strong> <?php echo esc_html($order->zustand_text); ?></p>
+                            <?php endif; ?>
                             <p><strong>Mietbeginn:</strong> <?php echo esc_html($start_formatted); ?></p>
                         </div>
                     <?php endif; ?>


### PR DESCRIPTION
## Summary
- create `Kundenkonto` page during activation
- show post state for the customer page in admin
- add `[produkt_account]` shortcode that renders a new template
- install template placeholder for the customer account
- clean up options and pages on uninstall

## Testing
- `php -l includes/Plugin.php`
- `php -l produkt-verleih.php`
- `php -l templates/account-page.php`


------
https://chatgpt.com/codex/tasks/task_b_6873576f9cb88330a400f4e22328a1bc