### PR TITLE
Allow early cancellation 14 days before term end

### DIFF
--- a/assets/account-style.css
+++ b/assets/account-style.css
@@ -1,10 +1,5 @@
 .produkt-account-wrapper {
-    max-width: 1080px;
     margin: 0 auto;
-    padding: 40px 20px;
-    font-size: 16px;
-    line-height: 1.6;
-    background: #f9f9f9;
 }
 
 .abo-wrapper {
@@ -18,12 +13,18 @@
     border: 1px solid #ddd;
 }
 
-.abo-box, .order-box {
+.abo-box,
+.order-box {
     flex: 1 1 300px;
 }
 
+.order-box {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+}
+
 .abo-box h3 {
-    font-size: 20px;
     margin-bottom: 16px;
 }
 
@@ -52,10 +53,11 @@
 }
 
 .order-box img {
-    width: 100%;
+    width: 140px;
     height: auto;
-    margin-bottom: 12px;
+    margin: 0;
     border-radius: 8px;
+    flex-shrink: 0;
 }
 
 .produkt-account-email-form,

--- a/assets/account-style.css
+++ b/assets/account-style.css
@@ -1,0 +1,102 @@
+.produkt-account-wrapper {
+    max-width: 1080px;
+    margin: 0 auto;
+    padding: 40px 20px;
+    font-size: 16px;
+    line-height: 1.6;
+    background: #f9f9f9;
+}
+
+.abo-wrapper {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 24px;
+    margin-bottom: 40px;
+    padding: 24px;
+    background: #fff;
+    border-radius: 12px;
+    border: 1px solid #ddd;
+}
+
+.abo-box, .order-box {
+    flex: 1 1 300px;
+}
+
+.abo-box h3 {
+    font-size: 20px;
+    margin-bottom: 16px;
+}
+
+.abo-box p,
+.order-box p {
+    margin: 8px 0;
+}
+
+.abo-box form {
+    margin-top: 16px;
+}
+
+.abo-box button {
+    padding: 10px 20px;
+    font-size: 14px;
+    background-color: #dc3545;
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+}
+
+.abo-box button:hover {
+    background-color: #c82333;
+}
+
+.order-box img {
+    width: 100%;
+    height: auto;
+    margin-bottom: 12px;
+    border-radius: 8px;
+}
+
+.produkt-account-email-form,
+.produkt-account-code-form {
+    max-width: 400px;
+    margin: 0 auto 40px;
+    padding: 24px;
+    background: #fff;
+    border-radius: 8px;
+    border: 1px solid #ccc;
+}
+
+.produkt-account-email-form input,
+.produkt-account-code-form input {
+    width: 100%;
+    padding: 12px;
+    font-size: 16px;
+    margin-bottom: 12px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
+.produkt-account-email-form button,
+.produkt-account-code-form button {
+    width: 100%;
+    padding: 12px;
+    font-size: 16px;
+    background-color: #0073aa;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.produkt-account-email-form button:hover,
+.produkt-account-code-form button:hover {
+    background-color: #005d8f;
+}
+
+@media (max-width: 768px) {
+    .abo-wrapper {
+        flex-direction: column;
+    }
+}

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -131,14 +131,24 @@ class Admin {
     public function enqueue_frontend_assets() {
         global $post, $wpdb;
 
-        $slug = sanitize_title(get_query_var('produkt_slug'));
+        $slug          = sanitize_title(get_query_var('produkt_slug'));
         $category_slug = sanitize_title(get_query_var('produkt_category_slug'));
-        $content = $post->post_content ?? '';
+        $content       = $post->post_content ?? '';
 
-        if (!is_page('shop') && empty($slug) && empty($category_slug)) {
+        $customer_page_id = get_option(PRODUKT_CUSTOMER_PAGE_OPTION);
+        $is_account_page  = false;
+        if ($customer_page_id) {
+            $is_account_page = is_page($customer_page_id);
+        }
+        if (!$is_account_page) {
+            $is_account_page = has_shortcode($content, 'produkt_account');
+        }
+
+        if (!is_page('shop') && !$is_account_page && empty($slug) && empty($category_slug)) {
             if (!has_shortcode($content, 'produkt_product') &&
                 !has_shortcode($content, 'stripe_elements_form') &&
-                !has_shortcode($content, 'produkt_shop_grid')) {
+                !has_shortcode($content, 'produkt_shop_grid') &&
+                !has_shortcode($content, 'produkt_account')) {
                 return;
             }
         }
@@ -150,6 +160,15 @@ class Admin {
             [],
             PRODUKT_VERSION
         );
+
+        if ($is_account_page) {
+            wp_enqueue_style(
+                'produkt-account-style',
+                PRODUKT_PLUGIN_URL . 'assets/account-style.css',
+                [],
+                PRODUKT_VERSION
+            );
+        }
 
         $load_script = !empty($slug) || !empty($category_slug) || is_page('shop') ||
             has_shortcode($content, 'produkt_product') ||

--- a/includes/Database.php
+++ b/includes/Database.php
@@ -1251,4 +1251,24 @@ class Database {
     public static function clear_content_blocks_cache($category_id) {
         delete_transient('produkt_content_blocks_' . intval($category_id));
     }
+
+    /**
+     * Retrieve orders placed by a specific WordPress user.
+     *
+     * @param int $user_id User ID
+     * @return array List of order objects
+     */
+    public static function get_orders_for_user($user_id) {
+        $user = get_user_by('ID', $user_id);
+        if (!$user) {
+            return [];
+        }
+
+        global $wpdb;
+        $table = $wpdb->prefix . 'produkt_orders';
+        $email = sanitize_email($user->user_email);
+
+        $sql = "SELECT *, stripe_subscription_id AS subscription_id FROM $table WHERE customer_email = %s ORDER BY created_at";
+        return $wpdb->get_results($wpdb->prepare($sql, $email));
+    }
 }

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -68,6 +68,8 @@ class Plugin {
         add_action('admin_head', [$this->admin, 'custom_admin_styles']);
         add_filter('display_post_states', [$this, 'mark_shop_page'], 10, 2);
 
+        add_filter('show_admin_bar', [$this, 'hide_admin_bar_for_customers']);
+
         // Handle "Jetzt mieten" form submissions before headers are sent
         add_action('template_redirect', [$this, 'handle_rent_request']);
 
@@ -827,6 +829,13 @@ class Plugin {
         add_role('kunde', 'Kunde', [
             'read' => true,
         ]);
+    }
+
+    public function hide_admin_bar_for_customers($show) {
+        if (current_user_can('kunde')) {
+            return false;
+        }
+        return $show;
     }
 }
 

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -850,3 +850,10 @@ add_filter('template_include', function ($template) {
 
     return $template;
 });
+
+add_action('admin_init', function () {
+    if (current_user_can('kunde') && !wp_doing_ajax()) {
+        wp_redirect(home_url('/kundenkonto'));
+        exit;
+    }
+});

--- a/includes/StripeService.php
+++ b/includes/StripeService.php
@@ -257,4 +257,56 @@ class StripeService {
     public static function get_payment_method_configuration_id() {
         return get_option('produkt_stripe_pmc_id', '');
     }
+
+    /**
+     * Retrieve active subscriptions for a given customer.
+     *
+     * @param string $customer_id Stripe customer ID
+     * @return array|\WP_Error
+     */
+    public static function get_active_subscriptions_for_customer($customer_id) {
+        $init = self::init();
+        if (is_wp_error($init)) {
+            return $init;
+        }
+        try {
+            $subs = \Stripe\Subscription::all([
+                'customer' => $customer_id,
+                'status'   => 'all',
+                'limit'    => 100,
+            ]);
+            $result = [];
+            foreach ($subs->autoPagingIterator() as $sub) {
+                if (in_array($sub->status, ['active', 'trialing', 'past_due'], true)) {
+                    $result[] = [
+                        'subscription_id'   => $sub->id,
+                        'start_date'        => date('Y-m-d H:i:s', $sub->start_date),
+                        'cancel_at_period_end' => $sub->cancel_at_period_end,
+                    ];
+                }
+            }
+            return $result;
+        } catch (\Exception $e) {
+            return new \WP_Error('stripe_subscriptions', $e->getMessage());
+        }
+    }
+
+    /**
+     * Mark a subscription to cancel at the period end.
+     *
+     * @param string $subscription_id
+     * @return true|\WP_Error
+     */
+    public static function cancel_subscription_at_period_end($subscription_id) {
+        $init = self::init();
+        if (is_wp_error($init)) {
+            return $init;
+        }
+        try {
+            \Stripe\Subscription::update($subscription_id, ['cancel_at_period_end' => true]);
+            return true;
+        } catch (\Exception $e) {
+            return new \WP_Error('stripe_cancel', $e->getMessage());
+        }
+    }
 }

--- a/produkt-verleih.php
+++ b/produkt-verleih.php
@@ -21,6 +21,7 @@ define('PRODUKT_PLUGIN_PATH', PRODUKT_PLUGIN_DIR);
 define('PRODUKT_VERSION', PRODUKT_PLUGIN_VERSION);
 define('PRODUKT_PLUGIN_FILE', __FILE__);
 define('PRODUKT_SHOP_PAGE_OPTION', 'produkt_shop_page_id');
+define('PRODUKT_CUSTOMER_PAGE_OPTION', 'produkt_customer_page_id');
 
 // Control whether default demo data is inserted on activation
 if (!defined('PRODUKT_LOAD_DEFAULT_DATA')) {

--- a/templates/account-page.php
+++ b/templates/account-page.php
@@ -103,7 +103,7 @@ $db = new Database();
                     <?php if ($order) : ?>
                         <div class="order-box">
                             <?php if ($image_url) : ?>
-                                <img src="<?php echo esc_url($image_url); ?>" alt="" style="max-width:100%;height:auto;margin-bottom:8px;">
+                                <img src="<?php echo esc_url($image_url); ?>" alt="">
                             <?php endif; ?>
                             <p><strong>Name:</strong> <?php echo esc_html($order->customer_name); ?></p>
                             <p><strong>E-Mail:</strong> <?php echo esc_html($order->customer_email); ?></p>

--- a/templates/account-page.php
+++ b/templates/account-page.php
@@ -1,0 +1,162 @@
+<?php
+use ProduktVerleih\Database;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$db = new Database();
+
+?>
+<div class="produkt-account-wrapper">
+    <?php if (!is_user_logged_in()) : ?>
+        <form method="post" class="produkt-account-email-form">
+            <input type="email" name="email" placeholder="Ihre E-Mail" value="<?php echo esc_attr($email_value); ?>" required>
+            <button type="submit" name="request_login_code">Login-Code anfordern</button>
+        </form>
+        <?php if ($show_code_form) : ?>
+        <form method="post" class="produkt-account-code-form">
+            <input type="hidden" name="email" value="<?php echo esc_attr($email_value); ?>">
+            <input type="text" name="code" placeholder="6-stelliger Code" required>
+            <button type="submit" name="verify_login_code">Einloggen</button>
+        </form>
+        <?php endif; ?>
+    <?php else : ?>
+        <?php if (!empty($subscriptions)) : ?>
+            <h2>Ihre Abos</h2>
+            <?php
+            $orders = Database::get_orders_for_user(get_current_user_id());
+            $order_map = [];
+            foreach ($orders as $o) {
+                $order_map[$o->subscription_id] = $o;
+            }
+            ?>
+            <?php foreach ($subscriptions as $sub) : ?>
+                <?php
+                $order = $order_map[$sub['subscription_id']] ?? null;
+                $product_name = $order->produkt_name ?? $sub['subscription_id'];
+                $start_ts = strtotime($sub['start_date']);
+                $start_formatted = date_i18n('d.m.Y', $start_ts);
+                $laufzeit_in_monaten = 3;
+                if ($order && !empty($order->duration_id)) {
+                    global $wpdb;
+                    $laufzeit_in_monaten = (int) $wpdb->get_var(
+                        $wpdb->prepare(
+                            "SELECT months_minimum FROM {$wpdb->prefix}produkt_durations WHERE id = %d",
+                            $order->duration_id
+                        )
+                    );
+                    if (!$laufzeit_in_monaten) {
+                        $laufzeit_in_monaten = 3; // Fallback
+                    }
+                }
+                $cancelable_ts            = strtotime("+{$laufzeit_in_monaten} months", $start_ts);
+                $kuendigungsfenster_ts    = strtotime('-14 days', $cancelable_ts);
+                $kuendigbar_ab_date       = date_i18n('d.m.Y', $kuendigungsfenster_ts);
+                $cancelable               = time() >= $kuendigungsfenster_ts;
+
+                $image_url = '';
+                if ($order) {
+                    global $wpdb;
+                    if (!empty($order->variant_id)) {
+                        $image_url = $wpdb->get_var(
+                            $wpdb->prepare(
+                                "SELECT image_url_1 FROM {$wpdb->prefix}produkt_variants WHERE id = %d",
+                                $order->variant_id
+                            )
+                        );
+                    }
+
+                    if (empty($image_url) && !empty($order->category_id)) {
+                        $image_url = $wpdb->get_var(
+                            $wpdb->prepare(
+                                "SELECT default_image FROM {$wpdb->prefix}produkt_categories WHERE id = %d",
+                                $order->category_id
+                            )
+                        );
+                    }
+                }
+
+                $address = trim($order->customer_street . ', ' . $order->customer_postal . ' ' . $order->customer_city);
+                ?>
+                <div class="abo-wrapper">
+                    <div class="abo-box">
+                        <h3><?php echo esc_html($product_name); ?></h3>
+                        <p><strong>Gemietet seit:</strong> <?php echo esc_html($start_formatted); ?></p>
+                        <p><strong>Kündbar ab:</strong> <?php echo esc_html($kuendigbar_ab_date); ?></p>
+
+                        <?php if ($sub['cancel_at_period_end']) : ?>
+                            <p style="color:orange;"><strong>✅ Kündigung vorgemerkt.</strong></p>
+                        <?php elseif ($cancelable) : ?>
+                            <form method="post">
+                                <input type="hidden" name="cancel_subscription" value="<?php echo esc_attr($sub['subscription_id']); ?>">
+                                <p style="margin-bottom:8px;">Sie können jetzt kündigen – die Kündigung wird zum Ende der Mindestlaufzeit wirksam (<?php echo esc_html(date_i18n('d.m.Y', $cancelable_ts)); ?>).</p>
+                                <button type="submit" style="background:#dc3545;color:white;border:none;padding:10px 20px;border-radius:5px;">
+                                    Zum Laufzeitende kündigen
+                                </button>
+                            </form>
+                        <?php else : ?>
+                            <p style="color:#888;"><strong>⏳ Ihre Kündigung ist frühestens 14 Tage vor Ablauf der Mindestlaufzeit möglich (ab dem <?php echo esc_html($kuendigbar_ab_date); ?>).</strong></p>
+                        <?php endif; ?>
+                    </div>
+
+                    <?php if ($order) : ?>
+                        <div class="order-box">
+                            <?php if ($image_url) : ?>
+                                <img src="<?php echo esc_url($image_url); ?>" alt="" style="max-width:100%;height:auto;margin-bottom:8px;">
+                            <?php endif; ?>
+                            <p><strong>Name:</strong> <?php echo esc_html($order->customer_name); ?></p>
+                            <p><strong>E-Mail:</strong> <?php echo esc_html($order->customer_email); ?></p>
+                            <p><strong>Adresse:</strong> <?php echo esc_html($address); ?></p>
+                            <p><strong>Preis pro Monat:</strong> <?php echo esc_html(number_format((float) $order->final_price, 2, ',', '.')); ?>€</p>
+                            <?php if (!empty($order->extra_text)) : ?>
+                                <p><strong>Extras:</strong> <?php echo esc_html($order->extra_text); ?></p>
+                            <?php endif; ?>
+
+                            <?php if (!empty($order->produktfarbe_text)) : ?>
+                                <p><strong>Farbe:</strong> <?php echo esc_html($order->produktfarbe_text); ?></p>
+                            <?php endif; ?>
+
+                            <?php if (!empty($order->gestellfarbe_text)) : ?>
+                                <p><strong>Gestellfarbe:</strong> <?php echo esc_html($order->gestellfarbe_text); ?></p>
+                            <?php endif; ?>
+
+                            <?php if (!empty($order->zustand_text)) : ?>
+                                <p><strong>Zustand:</strong> <?php echo esc_html($order->zustand_text); ?></p>
+                            <?php endif; ?>
+                            <p><strong>Mietbeginn:</strong> <?php echo esc_html($start_formatted); ?></p>
+                        </div>
+                    <?php endif; ?>
+                </div>
+            <?php endforeach; ?>
+        <?php else : ?>
+            <p>Keine aktiven Abos.</p>
+        <?php endif; ?>
+    <?php endif; ?>
+</div>
+<style>
+.abo-box {
+    border: 1px solid #ddd;
+    padding: 16px;
+    border-radius: 8px;
+    margin-bottom: 24px;
+    background: #fff;
+}
+.abo-box h3 {
+    margin-top: 0;
+}
+.abo-wrapper {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    margin-bottom: 24px;
+}
+.order-box {
+    border: 1px solid #ddd;
+    padding: 16px;
+    border-radius: 8px;
+    background: #fff;
+    flex: 1;
+    min-width: 260px;
+}
+</style>

--- a/templates/account-page.php
+++ b/templates/account-page.php
@@ -134,29 +134,3 @@ $db = new Database();
         <?php endif; ?>
     <?php endif; ?>
 </div>
-<style>
-.abo-box {
-    border: 1px solid #ddd;
-    padding: 16px;
-    border-radius: 8px;
-    margin-bottom: 24px;
-    background: #fff;
-}
-.abo-box h3 {
-    margin-top: 0;
-}
-.abo-wrapper {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 20px;
-    margin-bottom: 24px;
-}
-.order-box {
-    border: 1px solid #ddd;
-    padding: 16px;
-    border-radius: 8px;
-    background: #fff;
-    flex: 1;
-    min-width: 260px;
-}
-</style>


### PR DESCRIPTION
## Summary
- update subscription section of account page
- allow cancellation within 14 days before term end
- show explanatory message and new button text
- add order details next to subscription information
- show default product image if variant has none and hide empty order fields
- redirect after verifying login code

## Testing
- `php -l templates/account-page.php`
- `php -l includes/Plugin.php`
- `php -l includes/Database.php`
- `php -l includes/StripeService.php`
- `php -l includes/Webhook.php`
- `php -l produkt-verleih.php`


------
https://chatgpt.com/codex/tasks/task_b_6873576f9cb88330a400f4e22328a1bc