### PR TITLE
Handle login code before output

### DIFF
--- a/assets/account-style.css
+++ b/assets/account-style.css
@@ -1,5 +1,9 @@
 .produkt-account-wrapper {
-    margin: 0 auto;
+    max-width: 100%;
+    margin: 0;
+    padding: 50px 0;
+    background: transparent;
+    border-radius: 1rem;
 }
 
 /* Layout with sidebar similar to the shop pages */

--- a/assets/account-style.css
+++ b/assets/account-style.css
@@ -1,0 +1,104 @@
+.produkt-account-wrapper {
+    margin: 0 auto;
+}
+
+.abo-wrapper {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 24px;
+    margin-bottom: 40px;
+    padding: 24px;
+    background: #fff;
+    border-radius: 12px;
+    border: 1px solid #ddd;
+}
+
+.abo-box,
+.order-box {
+    flex: 1 1 300px;
+}
+
+.order-box {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+}
+
+.abo-box h3 {
+    margin-bottom: 16px;
+}
+
+.abo-box p,
+.order-box p {
+    margin: 8px 0;
+}
+
+.abo-box form {
+    margin-top: 16px;
+}
+
+.abo-box button {
+    padding: 10px 20px;
+    font-size: 14px;
+    background-color: #dc3545;
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+}
+
+.abo-box button:hover {
+    background-color: #c82333;
+}
+
+.order-box img {
+    width: 140px;
+    height: auto;
+    margin: 0;
+    border-radius: 8px;
+    flex-shrink: 0;
+}
+
+.produkt-account-email-form,
+.produkt-account-code-form {
+    max-width: 400px;
+    margin: 0 auto 40px;
+    padding: 24px;
+    background: #fff;
+    border-radius: 8px;
+    border: 1px solid #ccc;
+}
+
+.produkt-account-email-form input,
+.produkt-account-code-form input {
+    width: 100%;
+    padding: 12px;
+    font-size: 16px;
+    margin-bottom: 12px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
+.produkt-account-email-form button,
+.produkt-account-code-form button {
+    width: 100%;
+    padding: 12px;
+    font-size: 16px;
+    background-color: #0073aa;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.produkt-account-email-form button:hover,
+.produkt-account-code-form button:hover {
+    background-color: #005d8f;
+}
+
+@media (max-width: 768px) {
+    .abo-wrapper {
+        flex-direction: column;
+    }
+}

--- a/assets/account-style.css
+++ b/assets/account-style.css
@@ -2,26 +2,68 @@
     margin: 0 auto;
 }
 
-.abo-wrapper {
+/* Layout with sidebar similar to the shop pages */
+.account-layout {
+    display: grid;
+    grid-template-columns: 200px 1fr;
+    gap: 2rem;
+}
+
+.account-sidebar h2 {
+    margin-top: 0;
+    font-size: 1.1rem;
+}
+
+.account-sidebar ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.account-sidebar li {
+    margin-bottom: 0.5rem;
     display: flex;
-    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+}
+
+.account-sidebar a {
+    color: #000;
+    text-decoration: none !important;
+}
+
+.account-sidebar a.active {
+    font-weight: bold;
+}
+
+/* Grid with three cards per subscription */
+.abo-row {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
     gap: 24px;
     margin-bottom: 40px;
-    padding: 24px;
-    background: #fff;
-    border-radius: 12px;
-    border: 1px solid #ddd;
 }
 
 .abo-box,
-.order-box {
-    flex: 1 1 300px;
+.order-box,
+.image-box {
+    background: #fff;
+    border-radius: 12px;
+    border: 1px solid #ddd;
+    padding: 24px;
 }
 
-.order-box {
+.image-box {
     display: flex;
-    align-items: flex-start;
-    gap: 12px;
+    align-items: center;
+    justify-content: center;
+}
+
+.order-box img,
+.image-box img {
+    width: 100%;
+    height: auto;
+    border-radius: 8px;
 }
 
 .abo-box h3 {
@@ -52,13 +94,7 @@
     background-color: #c82333;
 }
 
-.order-box img {
-    width: 140px;
-    height: auto;
-    margin: 0;
-    border-radius: 8px;
-    flex-shrink: 0;
-}
+
 
 .produkt-account-email-form,
 .produkt-account-code-form {
@@ -98,7 +134,10 @@
 }
 
 @media (max-width: 768px) {
-    .abo-wrapper {
-        flex-direction: column;
+    .account-layout {
+        grid-template-columns: 1fr;
+    }
+    .abo-row {
+        grid-template-columns: 1fr;
     }
 }

--- a/assets/account-style.css
+++ b/assets/account-style.css
@@ -73,6 +73,39 @@
     margin-bottom: 16px;
 }
 
+.abo-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 12px;
+}
+
+.status-badge {
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 12px;
+    font-weight: 600;
+    color: #fff;
+}
+
+.status-badge.active {
+    background-color: #28a745;
+}
+
+.status-badge.scheduled {
+    background-color: #fd7e14;
+}
+
+.status-badge.cancelled {
+    background-color: #dc3545;
+}
+
+.abo-info {
+    font-size: 0.875rem;
+    color: #666;
+    margin-top: 12px;
+}
+
 .abo-box p,
 .order-box p {
     margin: 8px 0;

--- a/assets/account-style.css
+++ b/assets/account-style.css
@@ -47,9 +47,8 @@
 .abo-box,
 .order-box,
 .image-box {
-    background: #fff;
+    background: #f4f4f4;
     border-radius: 12px;
-    border: 1px solid #ddd;
     padding: 24px;
 }
 

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -131,14 +131,24 @@ class Admin {
     public function enqueue_frontend_assets() {
         global $post, $wpdb;
 
-        $slug = sanitize_title(get_query_var('produkt_slug'));
+        $slug          = sanitize_title(get_query_var('produkt_slug'));
         $category_slug = sanitize_title(get_query_var('produkt_category_slug'));
-        $content = $post->post_content ?? '';
+        $content       = $post->post_content ?? '';
 
-        if (!is_page('shop') && empty($slug) && empty($category_slug)) {
+        $customer_page_id = get_option(PRODUKT_CUSTOMER_PAGE_OPTION);
+        $is_account_page  = false;
+        if ($customer_page_id) {
+            $is_account_page = is_page($customer_page_id);
+        }
+        if (!$is_account_page) {
+            $is_account_page = has_shortcode($content, 'produkt_account');
+        }
+
+        if (!is_page('shop') && !$is_account_page && empty($slug) && empty($category_slug)) {
             if (!has_shortcode($content, 'produkt_product') &&
                 !has_shortcode($content, 'stripe_elements_form') &&
-                !has_shortcode($content, 'produkt_shop_grid')) {
+                !has_shortcode($content, 'produkt_shop_grid') &&
+                !has_shortcode($content, 'produkt_account')) {
                 return;
             }
         }
@@ -150,6 +160,15 @@ class Admin {
             [],
             PRODUKT_VERSION
         );
+
+        if ($is_account_page) {
+            wp_enqueue_style(
+                'produkt-account-style',
+                PRODUKT_PLUGIN_URL . 'assets/account-style.css',
+                [],
+                PRODUKT_VERSION
+            );
+        }
 
         $load_script = !empty($slug) || !empty($category_slug) || is_page('shop') ||
             has_shortcode($content, 'produkt_product') ||

--- a/includes/Database.php
+++ b/includes/Database.php
@@ -1251,4 +1251,24 @@ class Database {
     public static function clear_content_blocks_cache($category_id) {
         delete_transient('produkt_content_blocks_' . intval($category_id));
     }
+
+    /**
+     * Retrieve orders placed by a specific WordPress user.
+     *
+     * @param int $user_id User ID
+     * @return array List of order objects
+     */
+    public static function get_orders_for_user($user_id) {
+        $user = get_user_by('ID', $user_id);
+        if (!$user) {
+            return [];
+        }
+
+        global $wpdb;
+        $table = $wpdb->prefix . 'produkt_orders';
+        $email = sanitize_email($user->user_email);
+
+        $sql = "SELECT *, stripe_subscription_id AS subscription_id FROM $table WHERE customer_email = %s ORDER BY created_at";
+        return $wpdb->get_results($wpdb->prepare($sql, $email));
+    }
 }

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -5,6 +5,12 @@ class Plugin {
     private $db;
     private $ajax;
     private $admin;
+    /**
+     * Stores an error message when login code verification fails.
+     * Displayed on the account page after template_redirect processing.
+     * @var string
+     */
+    private $login_error = '';
 
     public function __construct() {
         $this->db = new Database();
@@ -28,6 +34,8 @@ class Plugin {
         add_action('admin_menu', [$this->admin, 'add_admin_menu']);
         add_shortcode('produkt_product', [$this, 'product_shortcode']);
         add_shortcode('produkt_shop_grid', [$this, 'render_product_grid']);
+        add_shortcode('produkt_account', [$this, 'render_customer_account']);
+        add_action('init', [$this, 'register_customer_role']);
         add_action('wp_enqueue_scripts', [$this->admin, 'enqueue_frontend_assets']);
         add_action('admin_enqueue_scripts', [$this->admin, 'enqueue_admin_assets']);
 
@@ -60,8 +68,13 @@ class Plugin {
         add_action('admin_head', [$this->admin, 'custom_admin_styles']);
         add_filter('display_post_states', [$this, 'mark_shop_page'], 10, 2);
 
+        add_filter('show_admin_bar', [$this, 'hide_admin_bar_for_customers']);
+
         // Handle "Jetzt mieten" form submissions before headers are sent
         add_action('template_redirect', [$this, 'handle_rent_request']);
+
+        // Process login code submissions as early as possible to avoid header issues
+        add_action('template_redirect', [$this, 'maybe_handle_login_code'], 1);
 
         // Ensure Astra page wrappers for plugin templates
         add_filter('body_class', function ($classes) {
@@ -102,6 +115,7 @@ class Plugin {
         add_rewrite_rule('^shop/produkt/([^/]+)/?$', 'index.php?produkt_slug=$matches[1]', 'top');
         add_rewrite_rule('^shop/([^/]+)/?$', 'index.php?produkt_category_slug=$matches[1]', 'top');
         $this->create_shop_page();
+        $this->create_customer_page();
         flush_rewrite_rules();
     }
 
@@ -145,6 +159,7 @@ class Plugin {
             'produkt_ct_submit',
             'produkt_ct_after_submit',
             PRODUKT_SHOP_PAGE_OPTION,
+            PRODUKT_CUSTOMER_PAGE_OPTION,
         );
 
         foreach ($options as $opt) {
@@ -154,6 +169,11 @@ class Plugin {
         $page_id = get_option(PRODUKT_SHOP_PAGE_OPTION);
         if ($page_id) {
             wp_delete_post($page_id, true);
+        }
+
+        $cust_page_id = get_option(PRODUKT_CUSTOMER_PAGE_OPTION);
+        if ($cust_page_id) {
+            wp_delete_post($cust_page_id, true);
         }
     }
 
@@ -228,6 +248,147 @@ class Plugin {
 
         ob_start();
         include PRODUKT_PLUGIN_PATH . 'templates/product-archive.php';
+        return ob_get_clean();
+    }
+
+    public function render_customer_account() {
+        $message        = $this->login_error;
+        $show_code_form = isset($_POST['verify_login_code']);
+        $email_value    = '';
+
+        if (
+            isset($_POST['verify_login_code']) &&
+            !empty($_POST['email']) &&
+            !empty($_POST['code'])
+        ) {
+            $email       = sanitize_email($_POST['email']);
+            $input_code  = trim($_POST['code']);
+            $email_value = $email;
+            $user        = get_user_by('email', $email);
+
+            if ($user) {
+                $data = get_user_meta($user->ID, 'produkt_login_code', true);
+                if (
+                    !(
+                        isset($data['code'], $data['expires']) &&
+                        $data['code'] == $input_code &&
+                        time() <= $data['expires']
+                    )
+                ) {
+                    $message        = '<p style="color:red;">Der Code ist ungültig oder abgelaufen.</p>';
+                    $show_code_form = true;
+                }
+            } else {
+                $message        = '<p style="color:red;">Benutzer wurde nicht gefunden.</p>';
+                $show_code_form = true;
+            }
+
+        } elseif (isset($_POST['request_login_code']) && !empty($_POST['email'])) {
+            $email       = sanitize_email($_POST['email']);
+            $email_value = $email;
+            $user        = get_user_by('email', $email);
+
+            if (!$user) {
+                $user_id = wp_create_user($email, wp_generate_password(), $email);
+                if (!is_wp_error($user_id)) {
+                    wp_update_user(['ID' => $user_id, 'role' => 'kunde']);
+                    $user = get_user_by('ID', $user_id);
+                }
+            }
+
+            if ($user) {
+                $code    = random_int(100000, 999999);
+                $expires = time() + 15 * MINUTE_IN_SECONDS;
+                update_user_meta(
+                    $user->ID,
+                    'produkt_login_code',
+                    ['code' => $code, 'expires' => $expires]
+                );
+
+                wp_mail(
+                    $email,
+                    'Ihr Login-Code',
+                    "Ihr Login-Code lautet: $code\nGültig für 15 Minuten."
+                );
+                $message        = '<p>Login-Code gesendet.</p>';
+                $show_code_form = true;
+            }
+
+        }
+
+        ob_start();
+        $subscriptions  = [];
+        $current_user_id = get_current_user_id();
+        if ($current_user_id) {
+            $customer_id = get_user_meta($current_user_id, 'stripe_customer_id', true);
+
+            if ($customer_id && isset($_POST['cancel_subscription'])) {
+                $sub_id = sanitize_text_field($_POST['cancel_subscription']);
+                $subs   = StripeService::get_active_subscriptions_for_customer($customer_id);
+                $orders = Database::get_orders_for_user($current_user_id);
+
+                if (!is_wp_error($subs)) {
+                    foreach ($subs as $sub) {
+                        if ($sub['subscription_id'] === $sub_id) {
+                            $matching_order = null;
+
+                            // passende Bestellung zur Subscription suchen
+                            foreach ($orders as $order) {
+                                if ($order->subscription_id === $sub_id) {
+                                    $matching_order = $order;
+                                    break;
+                                }
+                            }
+
+                            $laufzeit_in_monaten = 3;
+                            if ($matching_order && !empty($matching_order->duration_id)) {
+                                global $wpdb;
+                                $laufzeit_in_monaten = (int) $wpdb->get_var(
+                                    $wpdb->prepare(
+                                        "SELECT months_minimum FROM {$wpdb->prefix}produkt_durations WHERE id = %d",
+                                        $matching_order->duration_id
+                                    )
+                                );
+                                if (!$laufzeit_in_monaten) {
+                                    $laufzeit_in_monaten = 3; // Fallback
+                                }
+                            }
+
+                            $start_ts      = strtotime($sub['start_date']);
+                            $cancelable_ts = strtotime("+{$laufzeit_in_monaten} months", $start_ts);
+                            $cancelable    = time() > $cancelable_ts;
+                            $period_end_ts = strtotime($sub['current_period_end']);
+                            $period_end_date = date_i18n('d.m.Y', $period_end_ts);
+
+                            if ($cancelable && empty($sub['cancel_at_period_end'])) {
+                                $res = StripeService::cancel_subscription_at_period_end($sub_id);
+                                if (is_wp_error($res)) {
+                                    $message = '<p style="color:red;">' . esc_html($res->get_error_message()) . '</p>';
+                                } else {
+                                    $message = '<p>K\xFCndigung vorgemerkt. Laufzeit endet am ' . esc_html($period_end_date) . '.</p>';
+                                }
+                            } else {
+                                $message = '<p style="color:red;">Dieses Abo kann noch nicht gek\xC3\xBCndigt werden.</p>';
+                            }
+
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if ($customer_id) {
+                $subs = StripeService::get_active_subscriptions_for_customer($customer_id);
+                if (!is_wp_error($subs)) {
+                    $subscriptions = $subs;
+                } else {
+                    $message = '<p style="color:red;">' . esc_html($subs->get_error_message()) . '</p>';
+                }
+            }
+        }
+
+        echo $message;
+        include PRODUKT_PLUGIN_PATH . 'templates/account-page.php';
         return ob_get_clean();
     }
 
@@ -526,6 +687,45 @@ class Plugin {
         }
     }
 
+    /**
+     * Verify a login code before any output is sent and log the user in.
+     * Redirects to the customer account page on success.
+     */
+    public function maybe_handle_login_code() {
+        if (
+            !isset($_POST['verify_login_code']) ||
+            empty($_POST['email']) ||
+            empty($_POST['code'])
+        ) {
+            return;
+        }
+
+        $email      = sanitize_email($_POST['email']);
+        $input_code = trim($_POST['code']);
+        $user       = get_user_by('email', $email);
+
+        if ($user) {
+            $data = get_user_meta($user->ID, 'produkt_login_code', true);
+            if (
+                isset($data['code'], $data['expires']) &&
+                $data['code'] == $input_code &&
+                time() <= $data['expires']
+            ) {
+                delete_user_meta($user->ID, 'produkt_login_code');
+
+                wp_set_current_user($user->ID);
+                wp_set_auth_cookie($user->ID, true);
+                $page_id = get_option(PRODUKT_CUSTOMER_PAGE_OPTION);
+                wp_safe_redirect(get_permalink($page_id));
+                exit;
+            }
+        }
+
+        // Invalid code – store message for later display
+        $this->login_error = '<p style="color:red;">Der Code ist ungültig oder abgelaufen.</p>';
+    }
+
+
     public function maybe_display_product_page() {
         $slug = sanitize_title(get_query_var('produkt_slug'));
         if (empty($slug)) {
@@ -577,10 +777,32 @@ class Plugin {
         update_option(PRODUKT_SHOP_PAGE_OPTION, $page_id);
     }
 
+    private function create_customer_page() {
+        $page = get_page_by_path('kundenkonto');
+        if (!$page) {
+            $page_data = [
+                'post_title'   => 'Kundenkonto',
+                'post_name'    => 'kundenkonto',
+                'post_content' => '[produkt_account]',
+                'post_status'  => 'publish',
+                'post_type'    => 'page'
+            ];
+            $page_id = wp_insert_post($page_data);
+        } else {
+            $page_id = $page->ID;
+        }
+
+        update_option(PRODUKT_CUSTOMER_PAGE_OPTION, $page_id);
+    }
+
     public function mark_shop_page($states, $post) {
         $shop_page_id = get_option(PRODUKT_SHOP_PAGE_OPTION);
         if ($post->ID == $shop_page_id) {
             $states[] = __('Shop-Seite', 'h2-concepts');
+        }
+        $customer_page_id = get_option(PRODUKT_CUSTOMER_PAGE_OPTION);
+        if ($post->ID == $customer_page_id) {
+            $states[] = __('Kundenkonto-Seite', 'h2-concepts');
         }
         return $states;
     }
@@ -604,6 +826,19 @@ class Plugin {
 
         return null;
     }
+
+    public function register_customer_role() {
+        add_role('kunde', 'Kunde', [
+            'read' => true,
+        ]);
+    }
+
+    public function hide_admin_bar_for_customers($show) {
+        if (current_user_can('kunde')) {
+            return false;
+        }
+        return $show;
+    }
 }
 
 add_filter('template_include', function ($template) {
@@ -616,4 +851,11 @@ add_filter('template_include', function ($template) {
     }
 
     return $template;
+});
+
+add_action('admin_init', function () {
+    if (current_user_can('kunde') && !wp_doing_ajax()) {
+        wp_redirect(home_url('/kundenkonto'));
+        exit;
+    }
 });

--- a/includes/StripeService.php
+++ b/includes/StripeService.php
@@ -282,8 +282,8 @@ class StripeService {
                         'subscription_id'      => $sub->id,
                         'start_date'           => date('Y-m-d H:i:s', $sub->start_date),
                         'cancel_at_period_end' => $sub->cancel_at_period_end,
-                        'current_period_start' => date('Y-m-d H:i:s', $sub->current_period_start),
-                        'current_period_end'   => date('Y-m-d H:i:s', $sub->current_period_end),
+                        'current_period_start' => isset($sub->current_period_start) ? date('Y-m-d H:i:s', $sub->current_period_start) : null,
+                        'current_period_end'   => isset($sub->current_period_end) ? date('Y-m-d H:i:s', $sub->current_period_end) : null,
                         'status'               => $sub->status,
                     ];
                 }

--- a/produkt-verleih.php
+++ b/produkt-verleih.php
@@ -21,6 +21,7 @@ define('PRODUKT_PLUGIN_PATH', PRODUKT_PLUGIN_DIR);
 define('PRODUKT_VERSION', PRODUKT_PLUGIN_VERSION);
 define('PRODUKT_PLUGIN_FILE', __FILE__);
 define('PRODUKT_SHOP_PAGE_OPTION', 'produkt_shop_page_id');
+define('PRODUKT_CUSTOMER_PAGE_OPTION', 'produkt_customer_page_id');
 
 // Control whether default demo data is inserted on activation
 if (!defined('PRODUKT_LOAD_DEFAULT_DATA')) {

--- a/templates/account-page.php
+++ b/templates/account-page.php
@@ -8,7 +8,8 @@ if (!defined('ABSPATH')) {
 $db = new Database();
 
 ?>
-<div class="produkt-account-wrapper">
+<div class="produkt-account-wrapper produkt-container shop-overview-container">
+    <h1>Kundenkonto</h1>
     <?php if (!is_user_logged_in()) : ?>
         <form method="post" class="produkt-account-email-form">
             <input type="email" name="email" placeholder="Ihre E-Mail" value="<?php echo esc_attr($email_value); ?>" required>

--- a/templates/account-page.php
+++ b/templates/account-page.php
@@ -1,0 +1,148 @@
+<?php
+use ProduktVerleih\Database;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$db = new Database();
+
+?>
+<div class="produkt-account-wrapper">
+    <?php if (!is_user_logged_in()) : ?>
+        <form method="post" class="produkt-account-email-form">
+            <input type="email" name="email" placeholder="Ihre E-Mail" value="<?php echo esc_attr($email_value); ?>" required>
+            <button type="submit" name="request_login_code">Login-Code anfordern</button>
+        </form>
+        <?php if ($show_code_form) : ?>
+        <form method="post" class="produkt-account-code-form">
+            <input type="hidden" name="email" value="<?php echo esc_attr($email_value); ?>">
+            <input type="text" name="code" placeholder="6-stelliger Code" required>
+            <button type="submit" name="verify_login_code">Einloggen</button>
+        </form>
+        <?php endif; ?>
+    <?php else : ?>
+        <?php if (!empty($subscriptions)) : ?>
+            <h2>Ihre Abos</h2>
+            <?php
+            $orders = Database::get_orders_for_user(get_current_user_id());
+            $order_map = [];
+            foreach ($orders as $o) {
+                $order_map[$o->subscription_id] = $o;
+            }
+            ?>
+            <?php foreach ($subscriptions as $sub) : ?>
+                <?php
+                $order = $order_map[$sub['subscription_id']] ?? null;
+                $product_name = $order->produkt_name ?? $sub['subscription_id'];
+                $start_ts = strtotime($sub['start_date']);
+                $start_formatted = date_i18n('d.m.Y', $start_ts);
+                $laufzeit_in_monaten = 3;
+                if ($order && !empty($order->duration_id)) {
+                    global $wpdb;
+                    $laufzeit_in_monaten = (int) $wpdb->get_var(
+                        $wpdb->prepare(
+                            "SELECT months_minimum FROM {$wpdb->prefix}produkt_durations WHERE id = %d",
+                            $order->duration_id
+                        )
+                    );
+                    if (!$laufzeit_in_monaten) {
+                        $laufzeit_in_monaten = 3; // Fallback
+                    }
+                }
+                $cancelable_ts            = strtotime("+{$laufzeit_in_monaten} months", $start_ts);
+                $kuendigungsfenster_ts    = strtotime('-14 days', $cancelable_ts);
+                $kuendigbar_ab_date       = date_i18n('d.m.Y', $kuendigungsfenster_ts);
+                $cancelable               = time() >= $kuendigungsfenster_ts;
+                $is_extended              = time() > $cancelable_ts;
+
+                $period_end_ts   = strtotime($sub['current_period_end']);
+                $period_end_date = date_i18n('d.m.Y', $period_end_ts);
+
+                $image_url = '';
+                if ($order) {
+                    global $wpdb;
+                    if (!empty($order->variant_id)) {
+                        $image_url = $wpdb->get_var(
+                            $wpdb->prepare(
+                                "SELECT image_url_1 FROM {$wpdb->prefix}produkt_variants WHERE id = %d",
+                                $order->variant_id
+                            )
+                        );
+                    }
+
+                    if (empty($image_url) && !empty($order->category_id)) {
+                        $image_url = $wpdb->get_var(
+                            $wpdb->prepare(
+                                "SELECT default_image FROM {$wpdb->prefix}produkt_categories WHERE id = %d",
+                                $order->category_id
+                            )
+                        );
+                    }
+                }
+
+                $address = trim($order->customer_street . ', ' . $order->customer_postal . ' ' . $order->customer_city);
+                ?>
+                <div class="abo-wrapper">
+                    <div class="abo-box">
+                        <h3><?php echo esc_html($product_name); ?></h3>
+                        <p><strong>Gemietet seit:</strong> <?php echo esc_html($start_formatted); ?></p>
+                        <p><strong>Kündbar ab:</strong> <?php echo esc_html($kuendigbar_ab_date); ?></p>
+
+                        <?php if ($sub['cancel_at_period_end']) : ?>
+                            <p style="color:orange;"><strong>✅ Kündigung vorgemerkt zum <?php echo esc_html($period_end_date); ?>.</strong></p>
+                        <?php elseif ($is_extended) : ?>
+                            <p>📦 Abo läuft weiter. Nächster Abrechnungszeitraum bis: <?php echo esc_html($period_end_date); ?></p>
+                            <form method="post">
+                                <input type="hidden" name="cancel_subscription" value="<?php echo esc_attr($sub['subscription_id']); ?>">
+                                <button type="submit" style="background:#dc3545;color:white;border:none;padding:10px 20px;border-radius:5px;">
+                                    Zum nächsten Laufzeitende kündigen
+                                </button>
+                            </form>
+                        <?php elseif ($cancelable) : ?>
+                            <form method="post">
+                                <input type="hidden" name="cancel_subscription" value="<?php echo esc_attr($sub['subscription_id']); ?>">
+                                <p style="margin-bottom:8px;">Sie können jetzt kündigen – die Kündigung wird zum Ende der Mindestlaufzeit wirksam (<?php echo esc_html(date_i18n('d.m.Y', $cancelable_ts)); ?>).</p>
+                                <button type="submit" style="background:#dc3545;color:white;border:none;padding:10px 20px;border-radius:5px;">
+                                    Zum Laufzeitende kündigen
+                                </button>
+                            </form>
+                        <?php else : ?>
+                            <p style="color:#888;"><strong>⏳ Ihre Kündigung ist frühestens 14 Tage vor Ablauf der Mindestlaufzeit möglich (ab dem <?php echo esc_html($kuendigbar_ab_date); ?>).</strong></p>
+                        <?php endif; ?>
+                    </div>
+
+                    <?php if ($order) : ?>
+                        <div class="order-box">
+                            <?php if ($image_url) : ?>
+                                <img src="<?php echo esc_url($image_url); ?>" alt="">
+                            <?php endif; ?>
+                            <p><strong>Name:</strong> <?php echo esc_html($order->customer_name); ?></p>
+                            <p><strong>E-Mail:</strong> <?php echo esc_html($order->customer_email); ?></p>
+                            <p><strong>Adresse:</strong> <?php echo esc_html($address); ?></p>
+                            <p><strong>Preis pro Monat:</strong> <?php echo esc_html(number_format((float) $order->final_price, 2, ',', '.')); ?>€</p>
+                            <?php if (!empty($order->extra_text)) : ?>
+                                <p><strong>Extras:</strong> <?php echo esc_html($order->extra_text); ?></p>
+                            <?php endif; ?>
+
+                            <?php if (!empty($order->produktfarbe_text)) : ?>
+                                <p><strong>Farbe:</strong> <?php echo esc_html($order->produktfarbe_text); ?></p>
+                            <?php endif; ?>
+
+                            <?php if (!empty($order->gestellfarbe_text)) : ?>
+                                <p><strong>Gestellfarbe:</strong> <?php echo esc_html($order->gestellfarbe_text); ?></p>
+                            <?php endif; ?>
+
+                            <?php if (!empty($order->zustand_text)) : ?>
+                                <p><strong>Zustand:</strong> <?php echo esc_html($order->zustand_text); ?></p>
+                            <?php endif; ?>
+                            <p><strong>Mietbeginn:</strong> <?php echo esc_html($start_formatted); ?></p>
+                        </div>
+                    <?php endif; ?>
+                </div>
+            <?php endforeach; ?>
+        <?php else : ?>
+            <p>Keine aktiven Abos.</p>
+        <?php endif; ?>
+    <?php endif; ?>
+</div>

--- a/templates/account-page.php
+++ b/templates/account-page.php
@@ -22,8 +22,15 @@ $db = new Database();
         </form>
         <?php endif; ?>
     <?php else : ?>
+        <div class="account-layout">
+            <aside class="account-sidebar">
+                <h2>Hallo <?php echo esc_html(wp_get_current_user()->display_name); ?></h2>
+                <ul>
+                    <li class="active"><span class="menu-icon">📦</span> Abos</li>
+                </ul>
+            </aside>
+            <div>
         <?php if (!empty($subscriptions)) : ?>
-            <h2>Ihre Abos</h2>
             <?php
             $orders = Database::get_orders_for_user(get_current_user_id());
             $order_map = [];
@@ -87,9 +94,10 @@ $db = new Database();
 
                 $address = trim($order->customer_street . ', ' . $order->customer_postal . ' ' . $order->customer_city);
                 ?>
-                <div class="abo-wrapper">
+                <div class="abo-row">
                     <div class="abo-box">
-                        <h3><?php echo esc_html($product_name); ?></h3>
+                        <h3>Abo-Übersicht</h3>
+                        <p><strong>Produkt:</strong> <?php echo esc_html($product_name); ?></p>
                         <p><strong>Gemietet seit:</strong> <?php echo esc_html($start_formatted); ?></p>
                         <p><strong>Kündbar ab:</strong> <?php echo esc_html($kuendigbar_ab_date); ?></p>
                         <?php if (!empty($sub['current_period_end'])) : ?>
@@ -120,10 +128,13 @@ $db = new Database();
                     </div>
 
                     <?php if ($order) : ?>
-                        <div class="order-box">
+                        <div class="image-box">
                             <?php if ($image_url) : ?>
                                 <img src="<?php echo esc_url($image_url); ?>" alt="">
                             <?php endif; ?>
+                        </div>
+                        <div class="order-box">
+                            <h3>Abo-Details</h3>
                             <p><strong>Name:</strong> <?php echo esc_html($order->customer_name); ?></p>
                             <p><strong>E-Mail:</strong> <?php echo esc_html($order->customer_email); ?></p>
                             <p><strong>Adresse:</strong> <?php echo esc_html($address); ?></p>
@@ -151,5 +162,7 @@ $db = new Database();
         <?php else : ?>
             <p>Keine aktiven Abos.</p>
         <?php endif; ?>
+            </div>
+        </div>
     <?php endif; ?>
 </div>

--- a/templates/account-page.php
+++ b/templates/account-page.php
@@ -92,6 +92,9 @@ $db = new Database();
                         <h3><?php echo esc_html($product_name); ?></h3>
                         <p><strong>Gemietet seit:</strong> <?php echo esc_html($start_formatted); ?></p>
                         <p><strong>Kündbar ab:</strong> <?php echo esc_html($kuendigbar_ab_date); ?></p>
+                        <?php if (!empty($sub['current_period_end'])) : ?>
+                            <p><strong>Läuft aktuell bis:</strong> <?php echo esc_html(date_i18n('d.m.Y', strtotime($sub['current_period_end']))); ?></p>
+                        <?php endif; ?>
 
                         <?php if ($sub['cancel_at_period_end']) : ?>
                             <p style="color:orange;"><strong>✅ Kündigung vorgemerkt zum <?php echo esc_html($period_end_date); ?>.</strong></p>

--- a/templates/account-page.php
+++ b/templates/account-page.php
@@ -37,10 +37,17 @@ $db = new Database();
         }
         ?>
         <div class="account-layout">
-            <aside class="account-sidebar">
+            <aside class="account-sidebar shop-category-list">
                 <h2>Hallo <?php echo esc_html($full_name); ?></h2>
                 <ul>
-                    <li class="active"><span class="menu-icon">📦</span> Abos</li>
+                    <li>
+                        <a href="#" class="active"><span class="menu-icon">📦</span> Abos</a>
+                    </li>
+                    <li>
+                        <a href="<?php echo esc_url(wp_logout_url(get_permalink())); ?>">
+                            <span class="menu-icon">🚪</span> Logout
+                        </a>
+                    </li>
                 </ul>
             </aside>
             <div>

--- a/templates/account-page.php
+++ b/templates/account-page.php
@@ -22,9 +22,22 @@ $db = new Database();
         </form>
         <?php endif; ?>
     <?php else : ?>
+        <?php
+        $orders = Database::get_orders_for_user(get_current_user_id());
+        $full_name = '';
+        foreach ($orders as $o) {
+            if (!empty($o->customer_name)) {
+                $full_name = $o->customer_name;
+                break;
+            }
+        }
+        if (!$full_name) {
+            $full_name = wp_get_current_user()->display_name;
+        }
+        ?>
         <div class="account-layout">
             <aside class="account-sidebar">
-                <h2>Hallo <?php echo esc_html(wp_get_current_user()->display_name); ?></h2>
+                <h2>Hallo <?php echo esc_html($full_name); ?></h2>
                 <ul>
                     <li class="active"><span class="menu-icon">📦</span> Abos</li>
                 </ul>
@@ -32,7 +45,6 @@ $db = new Database();
             <div>
         <?php if (!empty($subscriptions)) : ?>
             <?php
-            $orders = Database::get_orders_for_user(get_current_user_id());
             $order_map = [];
             foreach ($orders as $o) {
                 $order_map[$o->subscription_id] = $o;

--- a/templates/account-page.php
+++ b/templates/account-page.php
@@ -116,7 +116,23 @@ $db = new Database();
                 ?>
                 <div class="abo-row">
                     <div class="abo-box">
-                        <h3>Abo-Übersicht</h3>
+                        <?php
+                        $badge_text  = 'Aktiv';
+                        $badge_class = 'active';
+                        if ($sub['status'] === 'canceled') {
+                            $badge_text  = 'Gekündigt';
+                            $badge_class = 'cancelled';
+                        } elseif ($sub['cancel_at_period_end']) {
+                            $badge_text  = 'Kündigung vorgemerkt';
+                            $badge_class = 'scheduled';
+                        }
+                        ?>
+                        <div class="abo-header">
+                            <h3>Abo-Übersicht</h3>
+                            <span class="status-badge <?php echo esc_attr($badge_class); ?>">
+                                <?php echo esc_html($badge_text); ?>
+                            </span>
+                        </div>
                         <p><strong>Produkt:</strong> <?php echo esc_html($product_name); ?></p>
                         <p><strong>Gemietet seit:</strong> <?php echo esc_html($start_formatted); ?></p>
                         <p><strong>Kündbar ab:</strong> <?php echo esc_html($kuendigbar_ab_date); ?></p>
@@ -145,6 +161,7 @@ $db = new Database();
                         <?php else : ?>
                             <p style="color:#888;"><strong>⏳ Ihre Kündigung ist frühestens 14 Tage vor Ablauf der Mindestlaufzeit möglich (ab dem <?php echo esc_html($kuendigbar_ab_date); ?>).</strong></p>
                         <?php endif; ?>
+                        <p class="abo-info">Nach Ablauf der Mindestlaufzeit verlängert sich das Abo automatisch monatlich. Sie können jederzeit zum Ende des laufenden Abrechnungszeitraums kündigen.</p>
                     </div>
 
                     <?php if ($order) : ?>

--- a/templates/account-page.php
+++ b/templates/account-page.php
@@ -56,8 +56,12 @@ $db = new Database();
                 $cancelable               = time() >= $kuendigungsfenster_ts;
                 $is_extended              = time() > $cancelable_ts;
 
-                $period_end_ts   = strtotime($sub['current_period_end']);
-                $period_end_date = date_i18n('d.m.Y', $period_end_ts);
+                $period_end_ts   = null;
+                $period_end_date = '';
+                if (!empty($sub['current_period_end'])) {
+                    $period_end_ts   = strtotime($sub['current_period_end']);
+                    $period_end_date = date_i18n('d.m.Y', $period_end_ts);
+                }
 
                 $image_url = '';
                 if ($order) {


### PR DESCRIPTION
## Summary
- process login code via `template_redirect` to avoid header warnings
- store invalid login errors for later display
- show login form again when code verification fails
- hide admin bar for the "kunde" role
- block backend access for customers
- load new account styles from a dedicated stylesheet
- tweak account style and reduce order image size
- show subscription extension information and period end dates

## Testing
- `php -l templates/account-page.php`
- `php -l includes/Plugin.php`
- `php -l includes/Database.php`
- `php -l includes/StripeService.php`
- `php -l includes/Webhook.php`
- `php -l produkt-verleih.php`
- `php -l includes/Admin.php`


------
https://chatgpt.com/codex/tasks/task_b_6873576f9cb88330a400f4e22328a1bc