### PR TITLE
Globalize button settings and improve product form UX

### DIFF
--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -47,6 +47,10 @@ foreach ($branding_results as $result) {
            class="produkt-tab <?php echo $active_tab === 'stripe' ? 'active' : ''; ?>">
             💳 Stripe Integration
         </a>
+        <a href="<?php echo admin_url('admin.php?page=produkt-settings&tab=buttons'); ?>"
+           class="produkt-tab <?php echo $active_tab === 'buttons' ? 'active' : ''; ?>">
+            🔘 Buttons & Tooltips
+        </a>
         <a href="<?php echo admin_url('admin.php?page=produkt-settings&tab=debug'); ?>"
            class="produkt-tab <?php echo $active_tab === 'debug' ? 'active' : ''; ?>">
             🔧 Debug
@@ -69,6 +73,9 @@ foreach ($branding_results as $result) {
                 break;
             case 'stripe':
                 include PRODUKT_PLUGIN_PATH . 'admin/tabs/stripe-tab.php';
+                break;
+            case 'buttons':
+                include PRODUKT_PLUGIN_PATH . 'admin/tabs/buttons-tab.php';
                 break;
             case 'debug':
                 include PRODUKT_PLUGIN_PATH . 'admin/tabs/debug-tab.php';

--- a/admin/tabs/buttons-tab.php
+++ b/admin/tabs/buttons-tab.php
@@ -1,0 +1,127 @@
+<?php
+// Buttons & Tooltips Tab Content
+
+if (isset($_POST['submit_buttons'])) {
+    \ProduktVerleih\Admin::verify_admin_action();
+    $settings = [
+        'button_text'       => sanitize_text_field($_POST['button_text'] ?? ''),
+        'button_icon'       => esc_url_raw($_POST['button_icon'] ?? ''),
+        'payment_icons'     => isset($_POST['payment_icons']) ? array_map('sanitize_text_field', (array) $_POST['payment_icons']) : [],
+        'price_label'       => sanitize_text_field($_POST['price_label'] ?? ''),
+        'price_period'      => sanitize_text_field($_POST['price_period'] ?? 'month'),
+        'vat_included'      => isset($_POST['vat_included']) ? 1 : 0,
+        'duration_tooltip'  => sanitize_textarea_field($_POST['duration_tooltip'] ?? ''),
+        'condition_tooltip' => sanitize_textarea_field($_POST['condition_tooltip'] ?? ''),
+        'show_tooltips'     => isset($_POST['show_tooltips']) ? 1 : 0,
+    ];
+    update_option('produkt_ui_settings', $settings);
+    echo '<div class="notice notice-success"><p>✅ Einstellungen gespeichert!</p></div>';
+}
+
+$ui = get_option('produkt_ui_settings', [
+    'button_text' => '',
+    'button_icon' => '',
+    'payment_icons' => [],
+    'price_label' => '',
+    'price_period' => 'month',
+    'vat_included' => 0,
+    'duration_tooltip' => '',
+    'condition_tooltip' => '',
+    'show_tooltips' => 1,
+]);
+?>
+<div class="produkt-branding-tab">
+    <form method="post" action="">
+        <?php wp_nonce_field('produkt_admin_action', 'produkt_admin_nonce'); ?>
+        <div class="produkt-form-section">
+            <h4>🔘 Button & Tooltips</h4>
+            <div class="produkt-form-row">
+                <div class="produkt-form-group">
+                    <label>Button-Text</label>
+                    <input type="text" name="button_text" value="<?php echo esc_attr($ui['button_text']); ?>">
+                </div>
+                <div class="produkt-form-group">
+                    <label>Button-Icon</label>
+                    <div class="produkt-upload-area">
+                        <input type="url" name="button_icon" id="ui_button_icon" value="<?php echo esc_attr($ui['button_icon']); ?>">
+                        <button type="button" class="button produkt-media-button" data-target="ui_button_icon">📁</button>
+                    </div>
+                    <?php if (!empty($ui['button_icon'])): ?>
+                    <div class="produkt-icon-preview">
+                        <img src="<?php echo esc_url($ui['button_icon']); ?>" alt="Button Icon">
+                    </div>
+                    <?php endif; ?>
+                </div>
+            </div>
+            <div class="produkt-form-row">
+                <div class="produkt-form-group">
+                    <label>Preis-Label</label>
+                    <input type="text" name="price_label" value="<?php echo esc_attr($ui['price_label']); ?>" placeholder="Monatlicher Mietpreis">
+                </div>
+                <div class="produkt-form-group">
+                    <label>Preiszeitraum</label>
+                    <select name="price_period">
+                        <option value="month" <?php selected($ui['price_period'], 'month'); ?>>pro Monat</option>
+                        <option value="one-time" <?php selected($ui['price_period'], 'one-time'); ?>>einmalig</option>
+                    </select>
+                </div>
+                <div class="produkt-form-group">
+                    <label><input type="checkbox" name="vat_included" value="1" <?php checked($ui['vat_included'], 1); ?>> Mit MwSt.</label>
+                </div>
+            </div>
+            <div class="produkt-form-group">
+                <label>Bezahlmethoden</label>
+                <div class="produkt-payment-checkboxes">
+                    <?php $payment_methods = [
+                        'american-express' => 'American Express',
+                        'apple-pay' => 'Apple Pay',
+                        'google-pay' => 'Google Pay',
+                        'klarna' => 'Klarna',
+                        'maestro' => 'Maestro',
+                        'mastercard' => 'Mastercard',
+                        'paypal' => 'Paypal',
+                        'shop' => 'Shop',
+                        'union-pay' => 'Union Pay',
+                        'visa' => 'Visa'
+                    ]; ?>
+                    <?php foreach ($payment_methods as $key => $label): ?>
+                        <label>
+                            <input type="checkbox" name="payment_icons[]" value="<?php echo esc_attr($key); ?>" <?php checked(in_array($key, (array)$ui['payment_icons'])); ?>>
+                            <img src="<?php echo esc_url(PRODUKT_PLUGIN_URL . 'assets/payment-icons/' . $key . '.svg'); ?>" alt="<?php echo esc_attr($label); ?>">
+                        </label>
+                    <?php endforeach; ?>
+                </div>
+            </div>
+            <div class="produkt-form-group">
+                <label>Mietdauer-Tooltip</label>
+                <textarea name="duration_tooltip" rows="3"><?php echo esc_textarea($ui['duration_tooltip']); ?></textarea>
+            </div>
+            <div class="produkt-form-group">
+                <label>Zustand-Tooltip</label>
+                <textarea name="condition_tooltip" rows="4"><?php echo esc_textarea($ui['condition_tooltip']); ?></textarea>
+            </div>
+            <div class="produkt-form-group">
+                <label><input type="checkbox" name="show_tooltips" value="1" <?php checked($ui['show_tooltips'], 1); ?>> Tooltips auf Produktseite anzeigen</label>
+            </div>
+        </div>
+        <?php submit_button('💾 Einstellungen speichern', 'primary', 'submit_buttons'); ?>
+    </form>
+</div>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    document.querySelectorAll('.produkt-media-button').forEach(function(button){
+        button.addEventListener('click', function(e){
+            e.preventDefault();
+            const targetId = this.getAttribute('data-target');
+            const targetInput = document.getElementById(targetId);
+            if(!targetInput) return;
+            const mediaUploader = wp.media({title:'Bild auswählen',button:{text:'Bild verwenden'},multiple:false});
+            mediaUploader.on('select', function(){
+                const attachment = mediaUploader.state().get('selection').first().toJSON();
+                targetInput.value = attachment.url;
+            });
+            mediaUploader.open();
+        });
+    });
+});
+</script>

--- a/admin/tabs/categories-add-tab.php
+++ b/admin/tabs/categories-add-tab.php
@@ -5,7 +5,7 @@
 <div class="produkt-add-category">
     <div class="produkt-form-header">
         <h3>➕ Neues Produkt hinzufügen</h3>
-        <p>Erstellen Sie ein neues Produkt mit SEO-Einstellungen und individueller Konfiguration.</p>
+        <p>Erstellen Sie eine Produkt und Produktseite individuellen Einstellungen und Konfigurationen.</p>
     </div>
     
     <form method="post" action="" class="produkt-compact-form">
@@ -38,6 +38,7 @@
                     <label>SEO-Titel</label>
                     <input type="text" name="meta_title" maxlength="60" placeholder="Optimiert für Suchmaschinen">
                     <small>Max. 60 Zeichen für Google</small>
+                    <div id="meta_title_counter" class="produkt-char-counter"></div>
                 </div>
                 <div class="produkt-form-group">
                     <label>Layout-Stil</label>
@@ -52,22 +53,16 @@
             <div class="produkt-form-group">
                 <label>SEO-Beschreibung</label>
                 <textarea name="meta_description" rows="3" maxlength="160" placeholder="Beschreibung für Suchmaschinen (max. 160 Zeichen)"></textarea>
+                <div id="meta_description_counter" class="produkt-char-counter"></div>
             </div>
         </div>
         
         <!-- Seiteninhalte -->
         <div class="produkt-form-section">
             <h4>📄 Seiteninhalte</h4>
-            
-            <div class="produkt-form-row">
-                <div class="produkt-form-group">
-                    <label>Produkttitel *</label>
-                    <input type="text" name="product_title" required placeholder="Titel unter dem Produktbild">
-                </div>
-            </div>
 
             <div class="produkt-form-group">
-                <label>Kurzbeschreibung</label>
+                <label>Kurzbeschreibung <small>für Produktübersichtsseite</small></label>
                 <textarea name="short_description" rows="2" placeholder="Kurzer Text unter dem Titel"></textarea>
             </div>
 
@@ -155,78 +150,7 @@
             <button type="button" id="add-accordion" class="button">+ Accordion hinzufügen</button>
         </div>
         
-        <!-- Button & Tooltips -->
-        <div class="produkt-form-section">
-            <h4>🔘 Button & Tooltips</h4>
-            <div class="produkt-form-row">
-                <div class="produkt-form-group">
-                    <label>Button-Text</label>
-                    <input type="text" name="button_text" placeholder="z.B. Jetzt Mieten">
-                </div>
-                <div class="produkt-form-group">
-                    <label>Button-Icon</label>
-                    <div class="produkt-upload-area">
-                        <input type="url" name="button_icon" id="button_icon" placeholder="https://example.com/button-icon.png">
-                        <button type="button" class="button produkt-media-button" data-target="button_icon">📁</button>
-                    </div>
-                </div>
-            </div>
 
-            <div class="produkt-form-row">
-                <div class="produkt-form-group">
-                    <label>Preis-Label</label>
-                    <input type="text" name="price_label" placeholder="Monatlicher Mietpreis">
-                </div>
-                <div class="produkt-form-group">
-                    <label>Preiszeitraum</label>
-                    <select name="price_period">
-                        <option value="month">pro Monat</option>
-                        <option value="one-time">einmalig</option>
-                    </select>
-                </div>
-                <div class="produkt-form-group">
-                    <label><input type="checkbox" name="vat_included" value="1"> Mit MwSt.</label>
-                </div>
-            </div>
-
-            <div class="produkt-form-group">
-                <label>Bezahlmethoden</label>
-                <div class="produkt-payment-checkboxes">
-                    <?php $payment_methods = [
-                        'american-express' => 'American Express',
-                        'apple-pay' => 'Apple Pay',
-                        'google-pay' => 'Google Pay',
-                        'klarna' => 'Klarna',
-                        'maestro' => 'Maestro',
-                        'mastercard' => 'Mastercard',
-                        'paypal' => 'Paypal',
-                        'shop' => 'Shop',
-                        'union-pay' => 'Union Pay',
-                        'visa' => 'Visa'
-                    ]; ?>
-                    <?php foreach ($payment_methods as $key => $label): ?>
-                        <label>
-                            <input type="checkbox" name="payment_icons[]" value="<?php echo esc_attr($key); ?>">
-                            <img src="<?php echo esc_url(PRODUKT_PLUGIN_URL . 'assets/payment-icons/' . $key . '.svg'); ?>" alt="<?php echo esc_attr($label); ?>">
-                        </label>
-                    <?php endforeach; ?>
-                </div>
-            </div>
-
-            
-            <div class="produkt-form-group">
-                <label>Mietdauer-Tooltip</label>
-                <textarea name="duration_tooltip" rows="3" placeholder="Text der bei 'Wählen Sie Ihre Mietdauer' angezeigt wird"></textarea>
-            </div>
-            
-            <div class="produkt-form-group">
-                <label>Zustand-Tooltip</label>
-                <textarea name="condition_tooltip" rows="4" placeholder="Text der bei 'Zustand' angezeigt wird"></textarea>
-            </div>
-        <div class="produkt-form-group">
-            <label><input type="checkbox" name="show_tooltips" value="1" checked> Tooltips auf Produktseite anzeigen</label>
-        </div>
-    </div>
 
     <!-- Produktbewertung -->
     <div class="produkt-form-section">
@@ -313,10 +237,13 @@ document.addEventListener('DOMContentLoaded', function() {
     // Auto-generate shortcode from name
     const nameInput = document.querySelector('input[name="name"]');
     const shortcodeInput = document.querySelector('input[name="shortcode"]');
-    
+    let manualShortcode = false;
+    if (shortcodeInput) {
+        shortcodeInput.addEventListener('input', function() { manualShortcode = true; });
+    }
     if (nameInput && shortcodeInput) {
         nameInput.addEventListener('input', function() {
-            if (!shortcodeInput.value) {
+            if (!manualShortcode) {
                 const shortcode = this.value
                     .toLowerCase()
                     .replace(/[^a-z0-9\s-]/g, '')
@@ -326,6 +253,28 @@ document.addEventListener('DOMContentLoaded', function() {
                 shortcodeInput.value = shortcode;
             }
         });
+    }
+
+    function updateCharCounter(input, counter, min, max) {
+        const len = input.value.length;
+        counter.textContent = len + ' Zeichen';
+        let cls = 'warning';
+        if (len > max) { cls = 'error'; }
+        else if (len >= min) { cls = 'ok'; }
+        counter.className = 'produkt-char-counter ' + cls;
+    }
+
+    const mtInput = document.querySelector('input[name="meta_title"]');
+    const mtCounter = document.getElementById('meta_title_counter');
+    if (mtInput && mtCounter) {
+        updateCharCounter(mtInput, mtCounter, 50, 60);
+        mtInput.addEventListener('input', () => updateCharCounter(mtInput, mtCounter, 50, 60));
+    }
+    const mdInput = document.querySelector('textarea[name="meta_description"]');
+    const mdCounter = document.getElementById('meta_description_counter');
+    if (mdInput && mdCounter) {
+        updateCharCounter(mdInput, mdCounter, 150, 160);
+        mdInput.addEventListener('input', () => updateCharCounter(mdInput, mdCounter, 150, 160));
     }
 
     // Accordion fields are handled in admin-script.js

--- a/admin/tabs/categories-edit-tab.php
+++ b/admin/tabs/categories-edit-tab.php
@@ -27,7 +27,6 @@
             <a href="#" class="produkt-subtab" data-tab="product">Produktseite</a>
             <a href="#" class="produkt-subtab" data-tab="shipping">Versand</a>
             <a href="#" class="produkt-subtab" data-tab="features">Features</a>
-            <a href="#" class="produkt-subtab" data-tab="tooltips">Tooltips</a>
             <a href="#" class="produkt-subtab" data-tab="pricing">Preis-Einstellungen</a>
         </div>
 
@@ -57,6 +56,7 @@
                     <label>SEO-Titel</label>
                     <input type="text" name="meta_title" value="<?php echo esc_attr($edit_item->meta_title ?? ''); ?>" maxlength="60">
                     <small>Max. 60 Zeichen für Google</small>
+                    <div id="meta_title_counter" class="produkt-char-counter"></div>
                 </div>
                 <div class="produkt-form-group">
                     <label>Layout-Stil</label>
@@ -71,6 +71,7 @@
             <div class="produkt-form-group">
                 <label>SEO-Beschreibung</label>
                 <textarea name="meta_description" rows="3" maxlength="160"><?php echo esc_textarea($edit_item->meta_description ?? ''); ?></textarea>
+                <div id="meta_description_counter" class="produkt-char-counter"></div>
             </div>
         </div>
 
@@ -103,15 +104,8 @@
         <div class="produkt-form-section">
             <h4>📄 Seiteninhalte</h4>
             
-            <div class="produkt-form-row">
-                <div class="produkt-form-group">
-                    <label>Produkttitel *</label>
-                    <input type="text" name="product_title" value="<?php echo esc_attr($edit_item->product_title); ?>" required>
-                </div>
-            </div>
-
             <div class="produkt-form-group">
-                <label>Kurzbeschreibung</label>
+                <label>Kurzbeschreibung <small>für Produktübersichtsseite</small></label>
                 <textarea name="short_description" rows="2"><?php echo esc_textarea($edit_item->short_description ?? ''); ?></textarea>
             </div>
 
@@ -150,58 +144,7 @@
             </div>
         </div>
         
-        <!-- Button -->
-        <div class="produkt-form-section">
-            <h4>🔘 Button</h4>
-            <div class="produkt-form-row">
-                <div class="produkt-form-group">
-                    <label>Button-Text</label>
-                    <input type="text" name="button_text" value="<?php echo esc_attr($edit_item->button_text); ?>">
-                </div>
-                <div class="produkt-form-group">
-                    <label>Button-Icon</label>
-                    <div class="produkt-upload-area">
-                        <input type="url" name="button_icon" id="button_icon" value="<?php echo esc_attr($edit_item->button_icon); ?>">
-                        <button type="button" class="button produkt-media-button" data-target="button_icon">📁</button>
-                    </div>
-                    <?php if (!empty($edit_item->button_icon)): ?>
-                    <div class="produkt-icon-preview">
-                        <img src="<?php echo esc_url($edit_item->button_icon); ?>" alt="Button Icon">
-                    </div>
-                    <?php endif; ?>
-                </div>
-            </div>
 
-            <div class="produkt-form-group">
-                <label>Bezahlmethoden</label>
-                <div class="produkt-payment-checkboxes">
-                    <?php $payment_methods = [
-                        'american-express' => 'American Express',
-                        'apple-pay' => 'Apple Pay',
-                        'google-pay' => 'Google Pay',
-                        'klarna' => 'Klarna',
-                        'maestro' => 'Maestro',
-                        'mastercard' => 'Mastercard',
-                        'paypal' => 'Paypal',
-                        'shop' => 'Shop',
-                        'union-pay' => 'Union Pay',
-                        'visa' => 'Visa'
-                    ];
-                    $selected_icons = [];
-                    if (isset($edit_item->payment_icons)) {
-                        $selected_icons = array_filter(array_map('trim', explode(',', $edit_item->payment_icons)));
-                    }
-                    ?>
-                    <?php foreach ($payment_methods as $key => $label): ?>
-                        <label>
-                            <input type="checkbox" name="payment_icons[]" value="<?php echo esc_attr($key); ?>" <?php checked(in_array($key, $selected_icons)); ?>>
-                            <img src="<?php echo esc_url(PRODUKT_PLUGIN_URL . 'assets/payment-icons/' . $key . '.svg'); ?>" alt="<?php echo esc_attr($label); ?>">
-                        </label>
-                    <?php endforeach; ?>
-                </div>
-            </div>
-
-        </div>
 
         <!-- Produktbewertung -->
         <div class="produkt-form-section">
@@ -303,22 +246,7 @@
 
         </div><!-- end tab-features -->
 
-        <div id="tab-tooltips" class="produkt-subtab-content">
-            <div class="produkt-form-section">
-                <h4>💬 Tooltips</h4>
-                <div class="produkt-form-group">
-                    <label>Mietdauer-Tooltip</label>
-                    <textarea name="duration_tooltip" rows="3"><?php echo esc_textarea($edit_item->duration_tooltip); ?></textarea>
-                </div>
-                <div class="produkt-form-group">
-                    <label>Zustand-Tooltip</label>
-                    <textarea name="condition_tooltip" rows="4"><?php echo esc_textarea($edit_item->condition_tooltip); ?></textarea>
-                </div>
-                <div class="produkt-form-group">
-                    <label><input type="checkbox" name="show_tooltips" value="1" <?php checked($edit_item->show_tooltips ?? 1, 1); ?>> Tooltips auf Produktseite anzeigen</label>
-                </div>
-            </div>
-        </div><!-- end tab-tooltips -->
+
 
         <div id="tab-pricing" class="produkt-subtab-content">
             <div class="produkt-form-section">
@@ -418,6 +346,49 @@ document.addEventListener('DOMContentLoaded', function() {
             mediaUploader.open();
         });
     });
+
+    // Auto-generate shortcode from name
+    const nameInput = document.querySelector('input[name="name"]');
+    const shortcodeInput = document.querySelector('input[name="shortcode"]');
+    let manualShortcode = false;
+    if (shortcodeInput) {
+        shortcodeInput.addEventListener('input', function() { manualShortcode = true; });
+    }
+    if (nameInput && shortcodeInput) {
+        nameInput.addEventListener('input', function() {
+            if (!manualShortcode) {
+                const shortcode = this.value
+                    .toLowerCase()
+                    .replace(/[^a-z0-9\s-]/g, '')
+                    .replace(/\s+/g, '-')
+                    .replace(/-+/g, '-')
+                    .trim();
+                shortcodeInput.value = shortcode;
+            }
+        });
+    }
+
+    function updateCharCounter(input, counter, min, max) {
+        const len = input.value.length;
+        counter.textContent = len + ' Zeichen';
+        let cls = 'warning';
+        if (len > max) { cls = 'error'; }
+        else if (len >= min) { cls = 'ok'; }
+        counter.className = 'produkt-char-counter ' + cls;
+    }
+
+    const mtInput = document.querySelector('input[name="meta_title"]');
+    const mtCounter = document.getElementById('meta_title_counter');
+    if (mtInput && mtCounter) {
+        updateCharCounter(mtInput, mtCounter, 50, 60);
+        mtInput.addEventListener('input', () => updateCharCounter(mtInput, mtCounter, 50, 60));
+    }
+    const mdInput = document.querySelector('textarea[name="meta_description"]');
+    const mdCounter = document.getElementById('meta_description_counter');
+    if (mdInput && mdCounter) {
+        updateCharCounter(mdInput, mdCounter, 150, 160);
+        mdInput.addEventListener('input', () => updateCharCounter(mdInput, mdCounter, 150, 160));
+    }
 
     // Subtab switching
     document.querySelectorAll('.produkt-subtab').forEach(function(tab) {

--- a/assets/admin-style.css
+++ b/assets/admin-style.css
@@ -351,6 +351,7 @@
     margin-top: 0;
     margin-bottom: 15px;
     color: #3c434a;
+    font-size: 1.3rem;
 }
 
 .produkt-form-row {
@@ -930,3 +931,5 @@
         grid-template-columns: 1fr;
     }
 }
+
+.produkt-char-counter{font-size:0.85rem;text-align:right;margin-top:4px;} .produkt-char-counter.ok{color:#46b450;} .produkt-char-counter.warning{color:#ffb900;} .produkt-char-counter.error{color:#dc3232;}

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -28,16 +28,6 @@ class Admin {
             array($this, 'admin_page')
         );
         
-        // Submenu: Produkte
-        add_submenu_page(
-            'produkt-verleih',
-            'Produkte',
-            'Produkte',
-            'manage_options',
-            'produkt-categories',
-            array($this, 'categories_page')
-        );
-
         // Manage simple product categories
         add_submenu_page(
             'produkt-verleih',
@@ -48,6 +38,16 @@ class Admin {
             function () {
                 include PRODUKT_PLUGIN_PATH . 'admin/product-categories-page.php';
             }
+        );
+
+        // Submenu: Produkte
+        add_submenu_page(
+            'produkt-verleih',
+            'Produkte',
+            'Produkte',
+            'manage_options',
+            'produkt-categories',
+            array($this, 'categories_page')
         );
         
         // Submenu: Produktverwaltung
@@ -383,7 +383,7 @@ class Admin {
             }
             $meta_title = sanitize_text_field($_POST['meta_title']);
             $meta_description = sanitize_textarea_field($_POST['meta_description']);
-            $product_title = sanitize_text_field($_POST['product_title']);
+            $product_title = sanitize_text_field($_POST['product_title'] ?? $name);
             $short_description = sanitize_textarea_field($_POST['short_description']);
             $product_description = wp_kses_post($_POST['product_description']);
             $default_image = esc_url_raw($_POST['default_image']);
@@ -400,21 +400,22 @@ class Admin {
             $feature_4_icon = esc_url_raw($_POST['feature_4_icon']);
             $feature_4_title = sanitize_text_field($_POST['feature_4_title']);
             $feature_4_description = sanitize_textarea_field($_POST['feature_4_description']);
-            $button_text = sanitize_text_field($_POST['button_text']);
-            $button_icon = esc_url_raw($_POST['button_icon']);
-            $payment_icons = isset($_POST['payment_icons']) ? array_map('sanitize_text_field', (array) $_POST['payment_icons']) : array();
+            $global_ui = get_option('produkt_ui_settings', []);
+            $button_text = sanitize_text_field($_POST['button_text'] ?? ($global_ui['button_text'] ?? ''));
+            $button_icon = esc_url_raw($_POST['button_icon'] ?? ($global_ui['button_icon'] ?? ''));
+            $payment_icons = isset($_POST['payment_icons']) ? array_map('sanitize_text_field', (array) $_POST['payment_icons']) : (array)($global_ui['payment_icons'] ?? []);
             $payment_icons = implode(',', $payment_icons);
             $shipping_provider = '';
             $shipping_price_id = '';
             $shipping_label = '';
-            $price_label = sanitize_text_field($_POST['price_label']);
-            $price_period = sanitize_text_field($_POST['price_period']);
-            $vat_included = isset($_POST['vat_included']) ? 1 : 0;
+            $price_label = sanitize_text_field($_POST['price_label'] ?? ($global_ui['price_label'] ?? ''));
+            $price_period = sanitize_text_field($_POST['price_period'] ?? ($global_ui['price_period'] ?? 'month'));
+            $vat_included = isset($_POST['vat_included']) ? 1 : (isset($global_ui['vat_included']) ? intval($global_ui['vat_included']) : 0);
             $layout_style = sanitize_text_field($_POST['layout_style']);
-            $duration_tooltip = sanitize_textarea_field($_POST['duration_tooltip']);
-            $condition_tooltip = sanitize_textarea_field($_POST['condition_tooltip']);
+            $duration_tooltip = sanitize_textarea_field($_POST['duration_tooltip'] ?? ($global_ui['duration_tooltip'] ?? ''));
+            $condition_tooltip = sanitize_textarea_field($_POST['condition_tooltip'] ?? ($global_ui['condition_tooltip'] ?? ''));
             $show_features = isset($_POST['show_features']) ? 1 : 0;
-            $show_tooltips = isset($_POST['show_tooltips']) ? 1 : 0;
+            $show_tooltips = isset($_POST['show_tooltips']) ? 1 : (isset($global_ui['show_tooltips']) ? intval($global_ui['show_tooltips']) : 1);
             $show_rating = isset($_POST['show_rating']) ? 1 : 0;
             $rating_value_input = isset($_POST['rating_value']) ? str_replace(',', '.', $_POST['rating_value']) : '';
             $rating_value = $rating_value_input !== '' ? min(5, max(0, floatval($rating_value_input))) : 0;

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -170,6 +170,7 @@ class Plugin {
             'produkt_ct_shipping',
             'produkt_ct_submit',
             'produkt_ct_after_submit',
+            'produkt_ui_settings',
             PRODUKT_SHOP_PAGE_OPTION,
             PRODUKT_CUSTOMER_PAGE_OPTION,
         );

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -126,12 +126,10 @@ $feature_4_description = isset($category) ? $category->feature_4_description : '
 $show_features = isset($category) ? ($category->show_features ?? 1) : 1;
 
 // Button
-$button_text = isset($category) ? ($category->button_text ?: 'Jetzt Mieten') : 'Jetzt Mieten';
-$button_icon = isset($category) ? $category->button_icon : '';
-$payment_icons = [];
-if (isset($category) && property_exists($category, 'payment_icons')) {
-    $payment_icons = array_filter(array_map('trim', explode(',', $category->payment_icons)));
-}
+$ui = get_option('produkt_ui_settings', []);
+$button_text = $ui['button_text'] ?? 'Jetzt Mieten';
+$button_icon = $ui['button_icon'] ?? '';
+$payment_icons = is_array($ui['payment_icons'] ?? null) ? $ui['payment_icons'] : [];
 $accordions = isset($category) && property_exists($category, 'accordion_data') ? json_decode($category->accordion_data, true) : [];
 if (!is_array($accordions)) { $accordions = []; }
 
@@ -139,18 +137,18 @@ $shipping = $wpdb->get_row("SELECT * FROM {$wpdb->prefix}produkt_shipping_method
 $shipping_price_id = $shipping->stripe_price_id ?? '';
 $shipping_cost = $shipping->price ?? 0;
 $shipping_provider = $shipping->service_provider ?? '';
-$price_label = isset($category) ? ($category->price_label ?? 'Monatlicher Mietpreis') : 'Monatlicher Mietpreis';
+$price_label = $ui['price_label'] ?? 'Monatlicher Mietpreis';
 $shipping_label = 'Einmalige Versandkosten:';
-$price_period = isset($category) ? ($category->price_period ?? 'month') : 'month';
-$vat_included = isset($category) ? ($category->vat_included ?? 0) : 0;
+$price_period = $ui['price_period'] ?? 'month';
+$vat_included = isset($ui['vat_included']) ? intval($ui['vat_included']) : 0;
 
 // Layout
 $layout_style = isset($category) ? ($category->layout_style ?? 'default') : 'default';
 
 // Tooltips
-$duration_tooltip = isset($category) ? ($category->duration_tooltip ?? '') : '';
-$condition_tooltip = isset($category) ? ($category->condition_tooltip ?? '') : '';
-$show_tooltips = isset($category) ? ($category->show_tooltips ?? 1) : 1;
+$duration_tooltip = $ui['duration_tooltip'] ?? '';
+$condition_tooltip = $ui['condition_tooltip'] ?? '';
+$show_tooltips = isset($ui['show_tooltips']) ? intval($ui['show_tooltips']) : 1;
 $tooltip_icon = '<svg viewBox="0 0 16.7 16.9" width="16" height="16" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" fill-rule="evenodd" d="M8.3,16.4C3.9,16.4.3,12.8.3,8.4S3.9.4,8.3.4s8,3.6,8,8-3.6,8-8,8ZM7.4,10.4h1.7c0-.3,0-.5.1-.7s.2-.4.4-.6l.7-.6c.3-.3.5-.5.6-.8.1-.3.2-.6.2-.9,0-.7-.2-1.3-.7-1.7-.5-.4-1.2-.6-2-.6s-1.6.2-2,.7c-.5.4-.7,1-.7,1.8h2c0-.3,0-.5.2-.7.1-.2.3-.3.6-.3.5,0,.8.3.8.9s0,.5-.2.7-.4.4-.7.7c-.3.2-.5.5-.6.9-.1.3-.2.8-.2,1.4ZM7.2,12.2c0,.3.1.5.3.7s.5.3.8.3.6,0,.8-.3.3-.4.3-.7-.1-.5-.3-.7-.5-.3-.8-.3-.6,0-.8.3-.3.4-.3.7Z"/></svg>';
 $show_rating = isset($category) ? ($category->show_rating ?? 0) : 0;
 $rating_value = isset($category) ? floatval(str_replace(',', '.', $category->rating_value ?? 0)) : 0;


### PR DESCRIPTION
## Summary
- auto-fill shortcode from product name and add SEO char counters
- remove product title input and simplify page content area
- move button and tooltip settings to new global tab
- update menu order and add global defaults in Admin logic
- adjust styles for headings and add character counter colors

## Testing
- `php -l admin/settings-page.php`
- `php -l admin/tabs/categories-add-tab.php`
- `php -l admin/tabs/categories-edit-tab.php`
- `php -l includes/Admin.php`
- `php -l includes/Plugin.php`
- `php -l templates/product-page.php`
- `php -l admin/tabs/buttons-tab.php`

------
https://chatgpt.com/codex/tasks/task_b_6876aec8eaf8833097027a8ab844817c