### PR TITLE
Fix Stripe archive badge checks

### DIFF
--- a/admin/durations-page.php
+++ b/admin/durations-page.php
@@ -7,6 +7,12 @@ global $wpdb;
 $table_name = $wpdb->prefix . 'produkt_durations';
 $table_prices = $wpdb->prefix . 'produkt_duration_prices';
 
+// Ensure stripe_archived column exists in price table
+$archived_col = $wpdb->get_results("SHOW COLUMNS FROM $table_prices LIKE 'stripe_archived'");
+if (empty($archived_col)) {
+    $wpdb->query("ALTER TABLE $table_prices ADD COLUMN stripe_archived TINYINT(1) DEFAULT 0 AFTER stripe_price_id");
+}
+
 // Get all categories for dropdown
 $categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_categories ORDER BY sort_order, name");
 

--- a/admin/durations-page.php
+++ b/admin/durations-page.php
@@ -198,10 +198,8 @@ if (isset($_GET['edit'])) {
 // Get current category info
 $current_category = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$wpdb->prefix}produkt_categories WHERE id = %d", $selected_category));
 
-// Get all durations for selected category
-$durations = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE category_id = %d ORDER BY sort_order, months_minimum", $selected_category));
+$durations = $wpdb->get_results($wpdb->prepare("SELECT d.*, MAX(p.stripe_price_id) AS stripe_price_id, MAX(p.stripe_archived) AS stripe_archived FROM $table_name d LEFT JOIN $table_prices p ON p.duration_id = d.id WHERE d.category_id = %d GROUP BY d.id ORDER BY d.sort_order, d.months_minimum", $selected_category));
 $variants = $wpdb->get_results($wpdb->prepare("SELECT id, name, stripe_price_id FROM {$wpdb->prefix}produkt_variants WHERE category_id = %d ORDER BY sort_order", $selected_category));
-?>
 
 <div class="wrap">
     <!-- Kompakter Header -->

--- a/admin/durations-page.php
+++ b/admin/durations-page.php
@@ -198,7 +198,7 @@ if (isset($_GET['edit'])) {
 // Get current category info
 $current_category = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$wpdb->prefix}produkt_categories WHERE id = %d", $selected_category));
 
-$durations = $wpdb->get_results($wpdb->prepare("SELECT d.*, MAX(p.stripe_price_id) AS stripe_price_id, MAX(p.stripe_archived) AS stripe_archived FROM $table_name d LEFT JOIN $table_prices p ON p.duration_id = d.id WHERE d.category_id = %d GROUP BY d.id ORDER BY d.sort_order, d.months_minimum", $selected_category));
+$durations = $wpdb->get_results($wpdb->prepare("SELECT d.*, MAX(p.stripe_price_id) AS stripe_price_id, MAX(p.stripe_product_id) AS stripe_product_id, MAX(p.stripe_archived) AS stripe_archived FROM $table_name d LEFT JOIN $table_prices p ON p.duration_id = d.id WHERE d.category_id = %d GROUP BY d.id ORDER BY d.sort_order, d.months_minimum", $selected_category));
 $variants = $wpdb->get_results($wpdb->prepare("SELECT id, name, stripe_price_id FROM {$wpdb->prefix}produkt_variants WHERE category_id = %d ORDER BY sort_order", $selected_category));
 ?>
 <div class="wrap">

--- a/admin/durations-page.php
+++ b/admin/durations-page.php
@@ -200,7 +200,7 @@ $current_category = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$wpdb->prefix}
 
 $durations = $wpdb->get_results($wpdb->prepare("SELECT d.*, MAX(p.stripe_price_id) AS stripe_price_id, MAX(p.stripe_archived) AS stripe_archived FROM $table_name d LEFT JOIN $table_prices p ON p.duration_id = d.id WHERE d.category_id = %d GROUP BY d.id ORDER BY d.sort_order, d.months_minimum", $selected_category));
 $variants = $wpdb->get_results($wpdb->prepare("SELECT id, name, stripe_price_id FROM {$wpdb->prefix}produkt_variants WHERE category_id = %d ORDER BY sort_order", $selected_category));
-
+?>
 <div class="wrap">
     <!-- Kompakter Header -->
     <div class="produkt-admin-header-compact">

--- a/admin/extras-page.php
+++ b/admin/extras-page.php
@@ -33,6 +33,13 @@ if (empty($price_id_exists)) {
     $wpdb->query("ALTER TABLE $table_name ADD COLUMN stripe_price_id VARCHAR(255) DEFAULT '' AFTER name");
 }
 
+// Ensure stripe_archived column exists
+$archived_column_exists = $wpdb->get_results("SHOW COLUMNS FROM $table_name LIKE 'stripe_archived'");
+if (empty($archived_column_exists)) {
+    $after = !empty($price_id_exists) ? 'stripe_price_id' : 'name';
+    $wpdb->query("ALTER TABLE $table_name ADD COLUMN stripe_archived TINYINT(1) DEFAULT 0 AFTER $after");
+}
+
 // Ensure category_id column exists
 $category_column_exists = $wpdb->get_results("SHOW COLUMNS FROM $table_name LIKE 'category_id'");
 if (empty($category_column_exists)) {

--- a/admin/extras-page.php
+++ b/admin/extras-page.php
@@ -163,7 +163,18 @@ if (isset($_POST['submit'])) {
 
 // Handle delete
 if (isset($_GET['delete']) && isset($_GET['fw_nonce']) && wp_verify_nonce($_GET['fw_nonce'], 'produkt_admin_action')) {
-    $result = $wpdb->delete($table_name, array('id' => intval($_GET['delete'])), array('%d'));
+    $extra_id = intval($_GET['delete']);
+    $stripe_product_id = $wpdb->get_var($wpdb->prepare(
+        "SELECT stripe_product_id FROM $table_name WHERE id = %d",
+        $extra_id
+    ));
+
+    if (!empty($stripe_product_id)) {
+        require_once PRODUKT_PLUGIN_PATH . 'includes/stripe-sync.php';
+        produkt_delete_or_archive_stripe_product($stripe_product_id, $extra_id, 'produkt_extras');
+    }
+
+    $result = $wpdb->delete($table_name, array('id' => $extra_id), array('%d'));
     if ($result !== false) {
         echo '<div class="notice notice-success"><p>✅ Extra gelöscht!</p></div>';
     } else {

--- a/admin/product-categories-page.php
+++ b/admin/product-categories-page.php
@@ -39,7 +39,13 @@ if (isset($_GET['delete'])) {
 }
 
 global $wpdb;
-$categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_product_categories ORDER BY name ASC");
+$categories = $wpdb->get_results(
+    "SELECT c.*, COUNT(ptc.produkt_id) AS product_count
+     FROM {$wpdb->prefix}produkt_product_categories c
+     LEFT JOIN {$wpdb->prefix}produkt_product_to_category ptc ON c.id = ptc.category_id
+     GROUP BY c.id
+     ORDER BY c.name ASC"
+);
 
 // Wenn Bearbeiten
 $edit_category = null;
@@ -79,6 +85,7 @@ if (isset($_GET['edit'])) {
             <tr>
                 <th>Name</th>
                 <th>Slug</th>
+                <th>Produkte</th>
                 <th>Aktionen</th>
             </tr>
         </thead>
@@ -87,6 +94,7 @@ if (isset($_GET['edit'])) {
                 <tr>
                     <td><?= esc_html($cat->name) ?></td>
                     <td><?= esc_html($cat->slug) ?></td>
+                    <td><?= intval($cat->product_count) ?></td>
                     <td>
                         <a href="?page=produkt-kategorien&edit=<?= $cat->id ?>" class="button">Bearbeiten</a>
                         <a href="?page=produkt-kategorien&delete=<?= $cat->id ?>" class="button button-danger" onclick="return confirm('Wirklich löschen?')">Löschen</a>

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -53,7 +53,7 @@ foreach ($branding_results as $result) {
         </a>
         <a href="<?php echo admin_url('admin.php?page=produkt-settings&tab=debug'); ?>"
            class="produkt-tab <?php echo $active_tab === 'debug' ? 'active' : ''; ?>">
-            🔧 Debug
+            🛠 Debug
         </a>
         <a href="<?php echo admin_url('admin.php?page=produkt-settings&tab=notifications'); ?>"
            class="produkt-tab <?php echo $active_tab === 'notifications' ? 'active' : ''; ?>">

--- a/admin/tabs/debug-tab.php
+++ b/admin/tabs/debug-tab.php
@@ -39,6 +39,12 @@ if (isset($_POST['manual_stripe_sync'])) {
     }
 }
 
+// Clear Stripe status cache
+if (isset($_POST['clear_stripe_cache']) && check_admin_referer('clear_stripe_cache_action')) {
+    \ProduktVerleih\StripeService::clear_stripe_archive_cache();
+    echo '<div class="notice notice-success"><p>✅ Stripe-Caches wurden geleert.</p></div>';
+}
+
 // Get table structure
 $table_variants = $wpdb->prefix . 'produkt_variants';
 
@@ -72,6 +78,11 @@ $sample_variant = $wpdb->get_row("SELECT * FROM $table_variants LIMIT 1");
             <button type="submit" name="manual_stripe_sync" class="button button-primary">
                 🔁 Stripe Sync starten
             </button>
+        </form>
+        <form method="post" action="" style="margin-top:10px;">
+            <?php wp_nonce_field('clear_stripe_cache_action'); ?>
+            <p><strong>Stripe-Status-Cache leeren:</strong> Dies erzwingt eine erneute Prüfung der Stripe-Archivierung für Produkte und Preise (Mietdauer, Extras, Ausführungen).</p>
+            <input type="submit" name="clear_stripe_cache" class="button button-secondary" value="Stripe-Status neu prüfen">
         </form>
     </div>
     

--- a/admin/tabs/debug-tab.php
+++ b/admin/tabs/debug-tab.php
@@ -84,6 +84,9 @@ $sample_variant = $wpdb->get_row("SELECT * FROM $table_variants LIMIT 1");
             <p><strong>Stripe-Status-Cache leeren:</strong> Dies erzwingt eine erneute Prüfung der Stripe-Archivierung für Produkte und Preise (Mietdauer, Extras, Ausführungen).</p>
             <input type="submit" name="clear_stripe_cache" class="button button-secondary" value="Stripe-Status neu prüfen">
         </form>
+        <?php if (wp_next_scheduled('produkt_stripe_status_cron')): ?>
+            <p>Nächster automatischer Stripe-Archiv-Check: <?php echo date('d.m.Y H:i:s', wp_next_scheduled('produkt_stripe_status_cron')); ?></p>
+        <?php endif; ?>
     </div>
     
     <div class="produkt-debug-sections">

--- a/admin/tabs/durations-edit-tab.php
+++ b/admin/tabs/durations-edit-tab.php
@@ -67,13 +67,13 @@
                 $archived = false;
                 $price_id = $duration_prices[$variant->id]['stripe_price_id'] ?? '';
                 if ($price_id) {
-                    $archived = \ProduktVerleih\StripeService::is_price_archived($price_id);
+                    $archived = \ProduktVerleih\StripeService::is_price_archived_cached($price_id);
                 } elseif (!empty($duration_prices[$variant->id]['stripe_archived'])) {
                     $archived = true;
                 }
                 $product_archived = false;
                 if (!empty($variant->stripe_product_id)) {
-                    $product_archived = \ProduktVerleih\StripeService::is_product_archived($variant->stripe_product_id);
+                    $product_archived = \ProduktVerleih\StripeService::is_product_archived_cached($variant->stripe_product_id);
                 }
                 ?>
                 <?php if ($archived): ?>

--- a/admin/tabs/durations-edit-tab.php
+++ b/admin/tabs/durations-edit-tab.php
@@ -63,7 +63,16 @@
                 <label><?php echo esc_html($variant->name); ?></label>
                 <input type="number" step="0.01" name="variant_custom_price[<?php echo $variant->id; ?>]" value="<?php echo esc_attr($duration_prices[$variant->id]['custom_price'] ?? ''); ?>">
                 <small>Preis (monatlich in €)</small>
-                <?php if (!empty($duration_prices[$variant->id]['stripe_archived'])): ?>
+                <?php
+                $archived = false;
+                $price_id = $duration_prices[$variant->id]['stripe_price_id'] ?? '';
+                if ($price_id) {
+                    $archived = \ProduktVerleih\StripeService::is_price_archived($price_id);
+                } elseif (!empty($duration_prices[$variant->id]['stripe_archived'])) {
+                    $archived = true;
+                }
+                ?>
+                <?php if ($archived): ?>
                     <span class="badge badge-gray">Archivierter Stripe-Preis</span>
                 <?php endif; ?>
             </div>

--- a/admin/tabs/durations-edit-tab.php
+++ b/admin/tabs/durations-edit-tab.php
@@ -3,12 +3,13 @@
 ?>
 
 <?php
-    $price_rows = $wpdb->get_results($wpdb->prepare("SELECT variant_id, custom_price FROM $table_prices WHERE duration_id = %d", $edit_item->id), OBJECT_K);
+    $price_rows = $wpdb->get_results($wpdb->prepare("SELECT variant_id, custom_price, stripe_archived FROM $table_prices WHERE duration_id = %d", $edit_item->id), OBJECT_K);
     $duration_prices = array();
     if ($price_rows) {
         foreach ($price_rows as $pid => $obj) {
             $duration_prices[$pid] = [
-                'custom_price' => $obj->custom_price,
+                'custom_price'    => $obj->custom_price,
+                'stripe_archived' => $obj->stripe_archived,
             ];
         }
     }
@@ -62,6 +63,9 @@
                 <label><?php echo esc_html($variant->name); ?></label>
                 <input type="number" step="0.01" name="variant_custom_price[<?php echo $variant->id; ?>]" value="<?php echo esc_attr($duration_prices[$variant->id]['custom_price'] ?? ''); ?>">
                 <small>Preis (monatlich in €)</small>
+                <?php if (!empty($duration_prices[$variant->id]['stripe_archived'])): ?>
+                    <span class="badge badge-gray">Archivierter Stripe-Preis</span>
+                <?php endif; ?>
             </div>
             <?php endforeach; ?>
         </div>

--- a/admin/tabs/durations-edit-tab.php
+++ b/admin/tabs/durations-edit-tab.php
@@ -71,9 +71,16 @@
                 } elseif (!empty($duration_prices[$variant->id]['stripe_archived'])) {
                     $archived = true;
                 }
+                $product_archived = false;
+                if (!empty($variant->stripe_product_id)) {
+                    $product_archived = \ProduktVerleih\StripeService::is_product_archived($variant->stripe_product_id);
+                }
                 ?>
                 <?php if ($archived): ?>
                     <span class="badge badge-gray">Archivierter Stripe-Preis</span>
+                <?php endif; ?>
+                <?php if ($product_archived): ?>
+                    <span class="badge badge-danger">⚠️ Produkt bei Stripe archiviert</span>
                 <?php endif; ?>
             </div>
             <?php endforeach; ?>

--- a/admin/tabs/durations-list-tab.php
+++ b/admin/tabs/durations-list-tab.php
@@ -23,12 +23,28 @@
         <div class="produkt-duration-card">
             <div class="produkt-duration-header">
                 <h4><?php echo esc_html($duration->name); ?></h4>
-                <?php if (!empty($duration->stripe_price_id)) :
+                <?php
+                $archived_price = false;
+                if (!empty($duration->stripe_price_id)) {
                     $active = \ProduktVerleih\StripeService::is_price_active($duration->stripe_price_id);
-                    if ($active === false) : ?>
-                        <span class="badge badge-gray">Archiviert bei Stripe</span>
-                    <?php endif;
-                endif; ?>
+                    if ($active === false) {
+                        $archived_price = true;
+                    }
+                    if (!$archived_price) {
+                        $archived_price = (bool) $wpdb->get_var($wpdb->prepare(
+                            "SELECT stripe_archived FROM {$wpdb->prefix}produkt_duration_prices WHERE stripe_price_id = %s LIMIT 1",
+                            $duration->stripe_price_id
+                        ));
+                    }
+                } else {
+                    $archived_price = (bool) $wpdb->get_var($wpdb->prepare(
+                        "SELECT stripe_archived FROM {$wpdb->prefix}produkt_duration_prices WHERE duration_id = %d LIMIT 1",
+                        $duration->id
+                    ));
+                }
+                if ($archived_price) : ?>
+                    <span class="badge badge-gray">Archivierter Stripe-Preis</span>
+                <?php endif; ?>
                 <?php if ($duration->show_badge): ?>
                     <span class="produkt-discount-badge">Badge</span>
                 <?php endif; ?>

--- a/admin/tabs/durations-list-tab.php
+++ b/admin/tabs/durations-list-tab.php
@@ -23,8 +23,10 @@
         <div class="produkt-duration-card">
             <div class="produkt-duration-header">
                 <h4><?php echo esc_html($duration->name); ?></h4>
-                <?php if (!empty($duration->stripe_archived)) : ?>
-                    <span class="badge badge-warning">Archiviert bei Stripe</span>
+                <?php
+                $is_archived = \ProduktVerleih\StripeService::is_price_archived($duration->stripe_price_id);
+                if ($is_archived): ?>
+                    <span class="badge badge-warning">Archivierter oder ungültiger Stripe-Preis</span>
                 <?php endif; ?>
                 <?php if ($duration->show_badge): ?>
                     <span class="produkt-discount-badge">Badge</span>

--- a/admin/tabs/durations-list-tab.php
+++ b/admin/tabs/durations-list-tab.php
@@ -23,21 +23,12 @@
         <div class="produkt-duration-card">
             <div class="produkt-duration-header">
                 <h4><?php echo esc_html($duration->name); ?></h4>
-                <?php
-                $archived = false;
-                if (isset($duration->stripe_product_id) && !empty($duration->stripe_product_id)) {
-                    try {
-                        \Stripe\Stripe::setApiKey(get_option('produkt_stripe_secret_key'));
-                        $stripe_product = \Stripe\Product::retrieve($duration->stripe_product_id);
-                        $archived = !$stripe_product->active;
-                    } catch (\Exception $e) {
-                        $archived = false; // Fehler bei Stripe, lieber Badge weglassen
-                    }
-                }
-                ?>
-                <?php if ($archived): ?>
-                    <span class="badge badge-gray">Archiviert bei Stripe</span>
-                <?php endif; ?>
+                <?php if (!empty($duration->stripe_price_id)) :
+                    $active = \ProduktVerleih\StripeService::is_price_active($duration->stripe_price_id);
+                    if ($active === false) : ?>
+                        <span class="badge badge-gray">Archiviert bei Stripe</span>
+                    <?php endif;
+                endif; ?>
                 <?php if ($duration->show_badge): ?>
                     <span class="produkt-discount-badge">Badge</span>
                 <?php endif; ?>

--- a/admin/tabs/durations-list-tab.php
+++ b/admin/tabs/durations-list-tab.php
@@ -24,14 +24,14 @@
             <div class="produkt-duration-header">
                 <h4><?php echo esc_html($duration->name); ?></h4>
                 <?php
-                $is_archived = \ProduktVerleih\StripeService::is_price_archived($duration->stripe_price_id);
+                $is_archived = \ProduktVerleih\StripeService::is_price_archived_cached($duration->stripe_price_id);
                 if ($is_archived): ?>
                     <span class="badge badge-warning">Archivierter oder ungültiger Stripe-Preis</span>
                 <?php endif; ?>
                 <?php
                 $product_archived = false;
                 if (!empty($duration->stripe_product_id)) {
-                    $product_archived = \ProduktVerleih\StripeService::is_product_archived($duration->stripe_product_id);
+                    $product_archived = \ProduktVerleih\StripeService::is_product_archived_cached($duration->stripe_product_id);
                 }
                 if ($product_archived): ?>
                     <span class="badge badge-danger">⚠️ Produkt bei Stripe archiviert</span>

--- a/admin/tabs/durations-list-tab.php
+++ b/admin/tabs/durations-list-tab.php
@@ -23,7 +23,19 @@
         <div class="produkt-duration-card">
             <div class="produkt-duration-header">
                 <h4><?php echo esc_html($duration->name); ?></h4>
-                <?php if (isset($duration->active) && $duration->active == 0): ?>
+                <?php
+                $archived = false;
+                if (isset($duration->stripe_product_id) && !empty($duration->stripe_product_id)) {
+                    try {
+                        \Stripe\Stripe::setApiKey(get_option('produkt_stripe_secret_key'));
+                        $stripe_product = \Stripe\Product::retrieve($duration->stripe_product_id);
+                        $archived = !$stripe_product->active;
+                    } catch (\Exception $e) {
+                        $archived = false; // Fehler bei Stripe, lieber Badge weglassen
+                    }
+                }
+                ?>
+                <?php if ($archived): ?>
                     <span class="badge badge-gray">Archiviert bei Stripe</span>
                 <?php endif; ?>
                 <?php if ($duration->show_badge): ?>

--- a/admin/tabs/durations-list-tab.php
+++ b/admin/tabs/durations-list-tab.php
@@ -23,27 +23,8 @@
         <div class="produkt-duration-card">
             <div class="produkt-duration-header">
                 <h4><?php echo esc_html($duration->name); ?></h4>
-                <?php
-                $archived_price = false;
-                if (!empty($duration->stripe_price_id)) {
-                    $active = \ProduktVerleih\StripeService::is_price_active($duration->stripe_price_id);
-                    if ($active === false) {
-                        $archived_price = true;
-                    }
-                    if (!$archived_price) {
-                        $archived_price = (bool) $wpdb->get_var($wpdb->prepare(
-                            "SELECT stripe_archived FROM {$wpdb->prefix}produkt_duration_prices WHERE stripe_price_id = %s LIMIT 1",
-                            $duration->stripe_price_id
-                        ));
-                    }
-                } else {
-                    $archived_price = (bool) $wpdb->get_var($wpdb->prepare(
-                        "SELECT stripe_archived FROM {$wpdb->prefix}produkt_duration_prices WHERE duration_id = %d LIMIT 1",
-                        $duration->id
-                    ));
-                }
-                if ($archived_price) : ?>
-                    <span class="badge badge-gray">Archivierter Stripe-Preis</span>
+                <?php if (!empty($duration->stripe_archived)) : ?>
+                    <span class="badge badge-warning">Archiviert bei Stripe</span>
                 <?php endif; ?>
                 <?php if ($duration->show_badge): ?>
                     <span class="produkt-discount-badge">Badge</span>

--- a/admin/tabs/durations-list-tab.php
+++ b/admin/tabs/durations-list-tab.php
@@ -28,6 +28,14 @@
                 if ($is_archived): ?>
                     <span class="badge badge-warning">Archivierter oder ungültiger Stripe-Preis</span>
                 <?php endif; ?>
+                <?php
+                $product_archived = false;
+                if (!empty($duration->stripe_product_id)) {
+                    $product_archived = \ProduktVerleih\StripeService::is_product_archived($duration->stripe_product_id);
+                }
+                if ($product_archived): ?>
+                    <span class="badge badge-danger">⚠️ Produkt bei Stripe archiviert</span>
+                <?php endif; ?>
                 <?php if ($duration->show_badge): ?>
                     <span class="produkt-discount-badge">Badge</span>
                 <?php endif; ?>

--- a/admin/tabs/extras-list-tab.php
+++ b/admin/tabs/extras-list-tab.php
@@ -38,7 +38,19 @@
             
             <div class="produkt-extra-content">
                 <h4><?php echo esc_html($extra->name); ?></h4>
-                <?php if (isset($extra->active) && $extra->active == 0): ?>
+                <?php
+                $archived = false;
+                if (!empty($extra->stripe_product_id)) {
+                    try {
+                        \Stripe\Stripe::setApiKey(get_option('produkt_stripe_secret_key'));
+                        $stripe_product = \Stripe\Product::retrieve($extra->stripe_product_id);
+                        $archived = !$stripe_product->active;
+                    } catch (\Exception $e) {
+                        $archived = false; // Fehler bei Stripe, lieber Badge weglassen
+                    }
+                }
+                ?>
+                <?php if ($archived): ?>
                     <span class="badge badge-gray">Archiviert bei Stripe</span>
                 <?php endif; ?>
                 

--- a/admin/tabs/extras-list-tab.php
+++ b/admin/tabs/extras-list-tab.php
@@ -41,7 +41,7 @@
                 <?php
                 $archived = false;
                 if (!empty($extra->stripe_product_id)) {
-                    $archived = \ProduktVerleih\StripeService::is_product_archived($extra->stripe_product_id);
+                    $archived = \ProduktVerleih\StripeService::is_product_archived_cached($extra->stripe_product_id);
                 }
                 ?>
                 <?php if ($archived): ?>

--- a/admin/tabs/extras-list-tab.php
+++ b/admin/tabs/extras-list-tab.php
@@ -41,17 +41,11 @@
                 <?php
                 $archived = false;
                 if (!empty($extra->stripe_product_id)) {
-                    try {
-                        \Stripe\Stripe::setApiKey(get_option('produkt_stripe_secret_key'));
-                        $stripe_product = \Stripe\Product::retrieve($extra->stripe_product_id);
-                        $archived = !$stripe_product->active;
-                    } catch (\Exception $e) {
-                        $archived = false; // Fehler bei Stripe, lieber Badge weglassen
-                    }
+                    $archived = \ProduktVerleih\StripeService::is_product_archived($extra->stripe_product_id);
                 }
                 ?>
                 <?php if ($archived): ?>
-                    <span class="badge badge-gray">Archiviert bei Stripe</span>
+                    <span class="badge badge-danger">⚠️ Produkt bei Stripe archiviert</span>
                 <?php endif; ?>
                 
                 <div class="produkt-extra-meta">

--- a/admin/tabs/extras-tab.php
+++ b/admin/tabs/extras-tab.php
@@ -109,7 +109,7 @@ if (isset($_GET['delete_extra'])) {
     $del_id = intval($_GET['delete_extra']);
     $row = $wpdb->get_row($wpdb->prepare("SELECT stripe_product_id FROM $table_name WHERE id = %d", $del_id));
     if ($row && $row->stripe_product_id) {
-        produkt_delete_or_archive_stripe_product($row->stripe_product_id);
+        produkt_delete_or_archive_stripe_product($row->stripe_product_id, $del_id, 'produkt_extras');
     }
     $result = $wpdb->delete($table_name, array('id' => $del_id), array('%d'));
     if ($result !== false) {

--- a/admin/tabs/variants-list-tab.php
+++ b/admin/tabs/variants-list-tab.php
@@ -62,17 +62,11 @@
                 <?php
                 $archived = false;
                 if (!empty($variant->stripe_product_id)) {
-                    try {
-                        \Stripe\Stripe::setApiKey(get_option('produkt_stripe_secret_key'));
-                        $stripe_product = \Stripe\Product::retrieve($variant->stripe_product_id);
-                        $archived = !$stripe_product->active;
-                    } catch (\Exception $e) {
-                        $archived = false; // Fehler bei Stripe, lieber Badge weglassen
-                    }
+                    $archived = \ProduktVerleih\StripeService::is_product_archived($variant->stripe_product_id);
                 }
                 ?>
                 <?php if ($archived): ?>
-                    <span class="badge badge-gray">Archiviert bei Stripe</span>
+                    <span class="badge badge-danger">⚠️ Produkt bei Stripe archiviert</span>
                 <?php endif; ?>
                 <p class="produkt-variant-description"><?php echo esc_html($variant->description); ?></p>
                 

--- a/admin/tabs/variants-list-tab.php
+++ b/admin/tabs/variants-list-tab.php
@@ -59,7 +59,19 @@
             
             <div class="produkt-variant-content">
                 <h4><?php echo esc_html($variant->name); ?></h4>
-                <?php if (isset($variant->active) && $variant->active == 0): ?>
+                <?php
+                $archived = false;
+                if (!empty($variant->stripe_product_id)) {
+                    try {
+                        \Stripe\Stripe::setApiKey(get_option('produkt_stripe_secret_key'));
+                        $stripe_product = \Stripe\Product::retrieve($variant->stripe_product_id);
+                        $archived = !$stripe_product->active;
+                    } catch (\Exception $e) {
+                        $archived = false; // Fehler bei Stripe, lieber Badge weglassen
+                    }
+                }
+                ?>
+                <?php if ($archived): ?>
                     <span class="badge badge-gray">Archiviert bei Stripe</span>
                 <?php endif; ?>
                 <p class="produkt-variant-description"><?php echo esc_html($variant->description); ?></p>

--- a/admin/tabs/variants-list-tab.php
+++ b/admin/tabs/variants-list-tab.php
@@ -62,7 +62,7 @@
                 <?php
                 $archived = false;
                 if (!empty($variant->stripe_product_id)) {
-                    $archived = \ProduktVerleih\StripeService::is_product_archived($variant->stripe_product_id);
+                    $archived = \ProduktVerleih\StripeService::is_product_archived_cached($variant->stripe_product_id);
                 }
                 ?>
                 <?php if ($archived): ?>

--- a/admin/variants-page.php
+++ b/admin/variants-page.php
@@ -32,6 +32,13 @@ if (empty($price_column_exists)) {
     $wpdb->query("ALTER TABLE $table_name ADD COLUMN stripe_price_id VARCHAR(255) DEFAULT '' AFTER name");
 }
 
+// Ensure stripe_archived column exists
+$archived_column_exists = $wpdb->get_results("SHOW COLUMNS FROM $table_name LIKE 'stripe_archived'");
+if (empty($archived_column_exists)) {
+    $after = !empty($price_column_exists) ? 'stripe_price_id' : 'name';
+    $wpdb->query("ALTER TABLE $table_name ADD COLUMN stripe_archived TINYINT(1) DEFAULT 0 AFTER $after");
+}
+
 // Ensure category_id column exists
 $category_column_exists = $wpdb->get_results("SHOW COLUMNS FROM $table_name LIKE 'category_id'");
 if (empty($category_column_exists)) {

--- a/includes/Database.php
+++ b/includes/Database.php
@@ -55,6 +55,13 @@ class Database {
                 $wpdb->query("ALTER TABLE $table_variants ADD COLUMN $column $type AFTER $after");
             }
         }
+
+        // Ensure stripe_archived column exists
+        $archived_exists = $wpdb->get_results("SHOW COLUMNS FROM $table_variants LIKE 'stripe_archived'");
+        if (empty($archived_exists)) {
+            $after = isset($columns_to_add['stripe_price_id']) ? 'stripe_price_id' : 'name';
+            $wpdb->query("ALTER TABLE $table_variants ADD COLUMN stripe_archived TINYINT(1) DEFAULT 0 AFTER $after");
+        }
         
         // Remove old single image_url column if it exists
         $old_column_exists = $wpdb->get_results("SHOW COLUMNS FROM $table_variants LIKE 'image_url'");
@@ -78,6 +85,13 @@ class Database {
         if (empty($price_id_exists)) {
             $after = $product_id_exists ? 'stripe_product_id' : 'name';
             $wpdb->query("ALTER TABLE $table_extras ADD COLUMN stripe_price_id VARCHAR(255) DEFAULT NULL AFTER $after");
+        }
+
+        // Ensure stripe_archived column exists
+        $archived_exists = $wpdb->get_results("SHOW COLUMNS FROM $table_extras LIKE 'stripe_archived'");
+        if (empty($archived_exists)) {
+            $after = !empty($price_id_exists) ? 'stripe_price_id' : 'name';
+            $wpdb->query("ALTER TABLE $table_extras ADD COLUMN stripe_archived TINYINT(1) DEFAULT 0 AFTER $after");
         }
 
         // Ensure show_badge column exists for durations
@@ -784,6 +798,7 @@ class Database {
             description text,
             stripe_product_id varchar(255) DEFAULT NULL,
             stripe_price_id varchar(255) DEFAULT NULL,
+            stripe_archived tinyint(1) DEFAULT 0,
             mietpreis_monatlich decimal(10,2) DEFAULT 0,
             verkaufspreis_einmalig decimal(10,2) DEFAULT 0,
             base_price decimal(10,2) NOT NULL,
@@ -809,6 +824,7 @@ class Database {
             name varchar(255) NOT NULL,
             stripe_product_id varchar(255) DEFAULT NULL,
             stripe_price_id varchar(255) DEFAULT NULL,
+            stripe_archived tinyint(1) DEFAULT 0,
             price decimal(10,2) NOT NULL,
             image_url text,
             active tinyint(1) DEFAULT 1,

--- a/includes/Database.php
+++ b/includes/Database.php
@@ -432,6 +432,7 @@ class Database {
                 variant_id mediumint(9) NOT NULL,
                 stripe_product_id varchar(255) DEFAULT NULL,
                 stripe_price_id varchar(255) DEFAULT NULL,
+                stripe_archived tinyint(1) DEFAULT 0,
                 PRIMARY KEY (id),
                 UNIQUE KEY duration_variant (duration_id, variant_id)
             ) $charset_collate;";
@@ -458,6 +459,12 @@ class Database {
             $exists = $wpdb->get_results("SHOW COLUMNS FROM $table_duration_prices LIKE 'custom_price'");
             if (empty($exists)) {
                 $wpdb->query("ALTER TABLE $table_duration_prices ADD COLUMN custom_price DECIMAL(10,2) DEFAULT NULL AFTER verkaufspreis_einmalig");
+            }
+
+            // Ensure stripe_archived column exists
+            $exists = $wpdb->get_results("SHOW COLUMNS FROM $table_duration_prices LIKE 'stripe_archived'");
+            if (empty($exists)) {
+                $wpdb->query("ALTER TABLE $table_duration_prices ADD COLUMN stripe_archived TINYINT(1) DEFAULT 0 AFTER stripe_price_id");
             }
         }
         
@@ -951,6 +958,7 @@ class Database {
             variant_id mediumint(9) NOT NULL,
             stripe_product_id varchar(255) DEFAULT NULL,
             stripe_price_id varchar(255) DEFAULT NULL,
+            stripe_archived tinyint(1) DEFAULT 0,
             mietpreis_monatlich decimal(10,2) DEFAULT 0,
             verkaufspreis_einmalig decimal(10,2) DEFAULT 0,
             custom_price decimal(10,2) DEFAULT NULL,

--- a/includes/Database.php
+++ b/includes/Database.php
@@ -644,13 +644,12 @@ class Database {
         if (!$webhook_exists) {
             $charset_collate = $wpdb->get_charset_collate();
             $sql = "CREATE TABLE $table_webhooks (
-                id INT AUTO_INCREMENT PRIMARY KEY,
-                event_type VARCHAR(100),
-                stripe_object TEXT,
-                message TEXT,
-                created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+                id INT NOT NULL AUTO_INCREMENT,
+                event_type VARCHAR(255),
+                payload LONGTEXT,
+                created_at DATETIME,
+                PRIMARY KEY (id)
             ) $charset_collate;";
-
             require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
             dbDelta($sql);
         }
@@ -1110,11 +1109,11 @@ class Database {
         // Webhook logs table
         $table_webhooks = $wpdb->prefix . 'produkt_webhook_logs';
         $sql_webhooks = "CREATE TABLE $table_webhooks (
-            id INT AUTO_INCREMENT PRIMARY KEY,
-            event_type VARCHAR(100),
-            stripe_object TEXT,
-            message TEXT,
-            created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            id INT NOT NULL AUTO_INCREMENT,
+            event_type VARCHAR(255),
+            payload LONGTEXT,
+            created_at DATETIME,
+            PRIMARY KEY (id)
         ) $charset_collate;";
 
         dbDelta($sql_webhooks);

--- a/includes/StripeService.php
+++ b/includes/StripeService.php
@@ -537,6 +537,25 @@ class StripeService {
     }
 
     /**
+     * Check if a Stripe price is currently active.
+     *
+     * @param string $price_id
+     * @return bool|null True if active, false if archived, null on error
+     */
+    public static function is_price_active($price_id) {
+        $init = self::init();
+        if (is_wp_error($init)) {
+            return null;
+        }
+        try {
+            $price = \Stripe\Price::retrieve($price_id);
+            return $price->active;
+        } catch (\Exception $e) {
+            return null;
+        }
+    }
+
+    /**
      * Trigger a synchronization of all Stripe products and prices.
      * Placeholder implementation that fetches items from Stripe.
      */

--- a/includes/StripeService.php
+++ b/includes/StripeService.php
@@ -556,6 +556,30 @@ class StripeService {
     }
 
     /**
+     * Determine if a Stripe price is archived or invalid.
+     *
+     * @param string $price_id
+     * @return bool True if archived or not found, false if active
+     */
+    public static function is_price_archived($price_id) {
+        if (!$price_id) {
+            return true;
+        }
+
+        $init = self::init();
+        if (is_wp_error($init)) {
+            return true;
+        }
+
+        try {
+            $price = \Stripe\Price::retrieve($price_id);
+            return !$price->active;
+        } catch (\Exception $e) {
+            return true;
+        }
+    }
+
+    /**
      * Trigger a synchronization of all Stripe products and prices.
      * Placeholder implementation that fetches items from Stripe.
      */

--- a/includes/StripeService.php
+++ b/includes/StripeService.php
@@ -580,6 +580,30 @@ class StripeService {
     }
 
     /**
+     * Determine if a Stripe product is archived or invalid.
+     *
+     * @param string $product_id
+     * @return bool True if archived or not found, false if active
+     */
+    public static function is_product_archived($product_id) {
+        if (!$product_id) {
+            return true;
+        }
+
+        $init = self::init();
+        if (is_wp_error($init)) {
+            return true;
+        }
+
+        try {
+            $product = \Stripe\Product::retrieve($product_id);
+            return !$product->active;
+        } catch (\Exception $e) {
+            return true;
+        }
+    }
+
+    /**
      * Trigger a synchronization of all Stripe products and prices.
      * Placeholder implementation that fetches items from Stripe.
      */

--- a/includes/stripe-sync.php
+++ b/includes/stripe-sync.php
@@ -7,7 +7,7 @@ if (!defined('ABSPATH')) {
 
 use ProduktVerleih\StripeService;
 
-function produkt_delete_or_archive_stripe_product($product_id) {
+function produkt_delete_or_archive_stripe_product($product_id, $local_id = null, $table = 'produkt_variants') {
     if (!$product_id) {
         return;
     }
@@ -28,6 +28,17 @@ function produkt_delete_or_archive_stripe_product($product_id) {
             if ($price->active) {
                 \Stripe\Price::update($price->id, ['active' => false]);
             }
+        }
+
+        if ($local_id && in_array($table, ['produkt_variants', 'produkt_extras'])) {
+            global $wpdb;
+            $wpdb->update(
+                $wpdb->prefix . $table,
+                ['stripe_archived' => 1],
+                ['id' => $local_id],
+                ['%d'],
+                ['%d']
+            );
         }
 
     } catch (\Exception $e) {

--- a/includes/stripe-sync.php
+++ b/includes/stripe-sync.php
@@ -45,3 +45,21 @@ function produkt_delete_or_archive_stripe_product($product_id, $local_id = null,
         error_log('Stripe archive error: ' . $e->getMessage());
     }
 }
+
+function produkt_deactivate_stripe_price($price_id) {
+    if (!$price_id) {
+        return;
+    }
+
+    try {
+        \Stripe\Stripe::setApiKey(get_option('produkt_stripe_secret_key'));
+
+        $price = \Stripe\Price::retrieve($price_id);
+        if ($price && $price->active) {
+            \Stripe\Price::update($price_id, ['active' => false]);
+        }
+
+    } catch (\Exception $e) {
+        error_log('Stripe price archive error: ' . $e->getMessage());
+    }
+}

--- a/includes/stripe-sync.php
+++ b/includes/stripe-sync.php
@@ -75,6 +75,16 @@ function produkt_deactivate_stripe_price($price_id) {
             \Stripe\Price::update($price_id, ['active' => false]);
         }
 
+        // Mark local record as archived
+        global $wpdb;
+        $wpdb->update(
+            $wpdb->prefix . 'produkt_duration_prices',
+            ['stripe_archived' => 1],
+            ['stripe_price_id' => $price_id],
+            ['%d'],
+            ['%s']
+        );
+
     } catch (\Exception $e) {
         error_log('Stripe price archive error: ' . $e->getMessage());
     }

--- a/produkt-verleih.php
+++ b/produkt-verleih.php
@@ -63,6 +63,20 @@ if (file_exists($webhook_file)) {
 register_activation_hook(__FILE__, ['ProduktVerleih\\Plugin', 'activate_plugin']);
 register_deactivation_hook(__FILE__, ['ProduktVerleih\\Plugin', 'deactivate_plugin']);
 
+// Schedule daily cron job to refresh Stripe archive cache
+register_activation_hook(__FILE__, function () {
+    if (!wp_next_scheduled('produkt_stripe_status_cron')) {
+        wp_schedule_event(time(), 'daily', 'produkt_stripe_status_cron');
+    }
+});
+
+// Clear cron job on deactivation
+register_deactivation_hook(__FILE__, function () {
+    wp_clear_scheduled_hook('produkt_stripe_status_cron');
+});
+
+add_action('produkt_stripe_status_cron', ['\ProduktVerleih\StripeService', 'cron_refresh_stripe_archive_cache']);
+
 // Initialize the plugin after WordPress has loaded
 add_action('plugins_loaded', function () {
     new \ProduktVerleih\Plugin();

--- a/templates/product-archive.php
+++ b/templates/product-archive.php
@@ -106,7 +106,14 @@ if (!function_exists('get_lowest_stripe_price_by_category')) {
 
     <?php
     global $wpdb;
-    $kats = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_product_categories ORDER BY name ASC");
+    $kats = $wpdb->get_results(
+        "SELECT pc.*, COUNT(ptc.produkt_id) AS product_count
+         FROM {$wpdb->prefix}produkt_product_categories pc
+         LEFT JOIN {$wpdb->prefix}produkt_product_to_category ptc ON pc.id = ptc.category_id
+         GROUP BY pc.id
+         HAVING product_count > 0
+         ORDER BY pc.name ASC"
+    );
     ?>
 
     <div class="shop-overview-layout">


### PR DESCRIPTION
## Summary
- ensure archive badge checks against live Stripe product status
- apply updated logic for variants, extras, and durations admin lists

## Testing
- `php -l admin/tabs/variants-list-tab.php`
- `php -l admin/tabs/extras-list-tab.php`
- `php -l admin/tabs/durations-list-tab.php`


------
https://chatgpt.com/codex/tasks/task_b_6877c7bdd8a483309a434620d1b7a60c