### PR TITLE
Fix Stripe product archive badges

### DIFF
--- a/admin/product-categories-page.php
+++ b/admin/product-categories-page.php
@@ -39,7 +39,13 @@ if (isset($_GET['delete'])) {
 }
 
 global $wpdb;
-$categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_product_categories ORDER BY name ASC");
+$categories = $wpdb->get_results(
+    "SELECT c.*, COUNT(ptc.produkt_id) AS product_count
+     FROM {$wpdb->prefix}produkt_product_categories c
+     LEFT JOIN {$wpdb->prefix}produkt_product_to_category ptc ON c.id = ptc.category_id
+     GROUP BY c.id
+     ORDER BY c.name ASC"
+);
 
 // Wenn Bearbeiten
 $edit_category = null;
@@ -79,6 +85,7 @@ if (isset($_GET['edit'])) {
             <tr>
                 <th>Name</th>
                 <th>Slug</th>
+                <th>Produkte</th>
                 <th>Aktionen</th>
             </tr>
         </thead>
@@ -87,6 +94,7 @@ if (isset($_GET['edit'])) {
                 <tr>
                     <td><?= esc_html($cat->name) ?></td>
                     <td><?= esc_html($cat->slug) ?></td>
+                    <td><?= intval($cat->product_count) ?></td>
                     <td>
                         <a href="?page=produkt-kategorien&edit=<?= $cat->id ?>" class="button">Bearbeiten</a>
                         <a href="?page=produkt-kategorien&delete=<?= $cat->id ?>" class="button button-danger" onclick="return confirm('Wirklich löschen?')">Löschen</a>

--- a/admin/products-page.php
+++ b/admin/products-page.php
@@ -5,6 +5,17 @@ if (!defined('ABSPATH')) {
 
 global $wpdb;
 
+// Hard delete a product if requested
+if (isset($_GET['delete']) && isset($_GET['fw_nonce']) && wp_verify_nonce($_GET['fw_nonce'], 'produkt_admin_action')) {
+    $id = intval($_GET['delete']);
+
+    // Optional: verknüpfte Daten wie Bilder, Varianten etc. löschen
+
+    $wpdb->delete($wpdb->prefix . 'produkt_products', ['id' => $id], ['%d']);
+
+    echo '<div class="notice notice-success"><p>✅ Produkt gelöscht!</p></div>';
+}
+
 // Get all categories for dropdown
 $categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_categories ORDER BY sort_order, name");
 

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -53,7 +53,7 @@ foreach ($branding_results as $result) {
         </a>
         <a href="<?php echo admin_url('admin.php?page=produkt-settings&tab=debug'); ?>"
            class="produkt-tab <?php echo $active_tab === 'debug' ? 'active' : ''; ?>">
-            🔧 Debug
+            🛠 Debug
         </a>
         <a href="<?php echo admin_url('admin.php?page=produkt-settings&tab=notifications'); ?>"
            class="produkt-tab <?php echo $active_tab === 'notifications' ? 'active' : ''; ?>">

--- a/admin/tabs/durations-list-tab.php
+++ b/admin/tabs/durations-list-tab.php
@@ -23,8 +23,18 @@
         <div class="produkt-duration-card">
             <div class="produkt-duration-header">
                 <h4><?php echo esc_html($duration->name); ?></h4>
-                <?php if (isset($duration->active) && $duration->active == 0): ?>
-                    <span class="badge badge-gray">Archiviert bei Stripe</span>
+                <?php
+                $is_archived = \ProduktVerleih\StripeService::is_price_archived_cached($duration->stripe_price_id);
+                if ($is_archived): ?>
+                    <span class="badge badge-warning">Archivierter oder ungültiger Stripe-Preis</span>
+                <?php endif; ?>
+                <?php
+                $product_archived = false;
+                if (!empty($duration->stripe_product_id)) {
+                    $product_archived = \ProduktVerleih\StripeService::is_product_archived_cached($duration->stripe_product_id);
+                }
+                if ($product_archived): ?>
+                    <span class="badge badge-danger">⚠️ Produkt bei Stripe archiviert</span>
                 <?php endif; ?>
                 <?php if ($duration->show_badge): ?>
                     <span class="produkt-discount-badge">Badge</span>

--- a/admin/tabs/extras-list-tab.php
+++ b/admin/tabs/extras-list-tab.php
@@ -38,8 +38,14 @@
             
             <div class="produkt-extra-content">
                 <h4><?php echo esc_html($extra->name); ?></h4>
-                <?php if (isset($extra->active) && $extra->active == 0): ?>
-                    <span class="badge badge-gray">Archiviert bei Stripe</span>
+                <?php
+                $archived = false;
+                if (!empty($extra->stripe_product_id)) {
+                    $archived = \ProduktVerleih\StripeService::is_product_archived_cached($extra->stripe_product_id);
+                }
+                ?>
+                <?php if ($archived): ?>
+                    <span class="badge badge-danger">⚠️ Produkt bei Stripe archiviert</span>
                 <?php endif; ?>
                 
                 <div class="produkt-extra-meta">

--- a/admin/tabs/extras-tab.php
+++ b/admin/tabs/extras-tab.php
@@ -109,7 +109,7 @@ if (isset($_GET['delete_extra'])) {
     $del_id = intval($_GET['delete_extra']);
     $row = $wpdb->get_row($wpdb->prepare("SELECT stripe_product_id FROM $table_name WHERE id = %d", $del_id));
     if ($row && $row->stripe_product_id) {
-        produkt_delete_or_archive_stripe_product($row->stripe_product_id);
+        produkt_delete_or_archive_stripe_product($row->stripe_product_id, $del_id, 'produkt_extras');
     }
     $result = $wpdb->delete($table_name, array('id' => $del_id), array('%d'));
     if ($result !== false) {

--- a/admin/tabs/variants-list-tab.php
+++ b/admin/tabs/variants-list-tab.php
@@ -59,8 +59,14 @@
             
             <div class="produkt-variant-content">
                 <h4><?php echo esc_html($variant->name); ?></h4>
-                <?php if (isset($variant->active) && $variant->active == 0): ?>
-                    <span class="badge badge-gray">Archiviert bei Stripe</span>
+                <?php
+                $archived = false;
+                if (!empty($variant->stripe_product_id)) {
+                    $archived = \ProduktVerleih\StripeService::is_product_archived_cached($variant->stripe_product_id);
+                }
+                ?>
+                <?php if ($archived): ?>
+                    <span class="badge badge-danger">⚠️ Produkt bei Stripe archiviert</span>
                 <?php endif; ?>
                 <p class="produkt-variant-description"><?php echo esc_html($variant->description); ?></p>
                 

--- a/admin/variants-page.php
+++ b/admin/variants-page.php
@@ -32,6 +32,13 @@ if (empty($price_column_exists)) {
     $wpdb->query("ALTER TABLE $table_name ADD COLUMN stripe_price_id VARCHAR(255) DEFAULT '' AFTER name");
 }
 
+// Ensure stripe_archived column exists
+$archived_column_exists = $wpdb->get_results("SHOW COLUMNS FROM $table_name LIKE 'stripe_archived'");
+if (empty($archived_column_exists)) {
+    $after = !empty($price_column_exists) ? 'stripe_price_id' : 'name';
+    $wpdb->query("ALTER TABLE $table_name ADD COLUMN stripe_archived TINYINT(1) DEFAULT 0 AFTER $after");
+}
+
 // Ensure category_id column exists
 $category_column_exists = $wpdb->get_results("SHOW COLUMNS FROM $table_name LIKE 'category_id'");
 if (empty($category_column_exists)) {

--- a/includes/stripe-sync.php
+++ b/includes/stripe-sync.php
@@ -7,7 +7,7 @@ if (!defined('ABSPATH')) {
 
 use ProduktVerleih\StripeService;
 
-function produkt_delete_or_archive_stripe_product($product_id) {
+function produkt_delete_or_archive_stripe_product($product_id, $local_id = null, $table = 'produkt_variants') {
     if (!$product_id) {
         return;
     }
@@ -30,7 +30,74 @@ function produkt_delete_or_archive_stripe_product($product_id) {
             }
         }
 
+        if ($local_id && in_array($table, ['produkt_variants', 'produkt_extras'])) {
+            global $wpdb;
+            $wpdb->update(
+                $wpdb->prefix . $table,
+                ['stripe_archived' => 1],
+                ['id' => $local_id],
+                ['%d'],
+                ['%d']
+            );
+        }
+
+    } catch (\Stripe\Exception\InvalidRequestException $e) {
+        if (strpos($e->getMessage(), 'No such product') !== false) {
+            error_log('Stripe-Produkt existiert nicht mehr – wird lokal archiviert: ' . $product_id);
+            if ($local_id && in_array($table, ['produkt_variants', 'produkt_extras'])) {
+                global $wpdb;
+                $wpdb->update(
+                    $wpdb->prefix . $table,
+                    ['stripe_archived' => 1],
+                    ['id' => $local_id],
+                    ['%d'],
+                    ['%d']
+                );
+            }
+        } else {
+            error_log('Stripe archive error: ' . $e->getMessage());
+        }
     } catch (\Exception $e) {
         error_log('Stripe archive error: ' . $e->getMessage());
     }
+}
+
+function produkt_deactivate_stripe_price($price_id) {
+    if (!$price_id) {
+        error_log('Keine Stripe-Preis-ID übergeben, Abbruch.');
+        return;
+    }
+
+    $secret_key = get_option('produkt_stripe_secret_key');
+    $stripe = new \Stripe\StripeClient($secret_key);
+
+    try {
+        $price = $stripe->prices->retrieve($price_id);
+    } catch (\Stripe\Exception\InvalidRequestException $e) {
+        error_log("Preis nicht gefunden, überspringe: $price_id");
+        return;
+    } catch (\Exception $e) {
+        error_log('Stripe price retrieve error: ' . $e->getMessage());
+        return;
+    }
+
+    if ($price->active) {
+        try {
+            $stripe->prices->update($price_id, ['active' => false]);
+            error_log("Stripe-Preis {$price_id} deaktiviert.");
+        } catch (\Stripe\Exception\InvalidRequestException $e) {
+            error_log('Stripe price archive error: ' . $e->getMessage());
+        } catch (\Exception $e) {
+            error_log('Stripe price archive error: ' . $e->getMessage());
+        }
+    }
+
+    global $wpdb;
+    $wpdb->update(
+        $wpdb->prefix . 'produkt_duration_prices',
+        ['stripe_archived' => 1],
+        ['stripe_price_id' => $price_id],
+        ['%d'],
+        ['%s']
+    );
 }

--- a/produkt-verleih.php
+++ b/produkt-verleih.php
@@ -63,6 +63,20 @@ if (file_exists($webhook_file)) {
 register_activation_hook(__FILE__, ['ProduktVerleih\\Plugin', 'activate_plugin']);
 register_deactivation_hook(__FILE__, ['ProduktVerleih\\Plugin', 'deactivate_plugin']);
 
+// Schedule daily cron job to refresh Stripe archive cache
+register_activation_hook(__FILE__, function () {
+    if (!wp_next_scheduled('produkt_stripe_status_cron')) {
+        wp_schedule_event(time(), 'daily', 'produkt_stripe_status_cron');
+    }
+});
+
+// Clear cron job on deactivation
+register_deactivation_hook(__FILE__, function () {
+    wp_clear_scheduled_hook('produkt_stripe_status_cron');
+});
+
+add_action('produkt_stripe_status_cron', ['\ProduktVerleih\StripeService', 'cron_refresh_stripe_archive_cache']);
+
 // Initialize the plugin after WordPress has loaded
 add_action('plugins_loaded', function () {
     new \ProduktVerleih\Plugin();

--- a/templates/product-archive.php
+++ b/templates/product-archive.php
@@ -106,7 +106,14 @@ if (!function_exists('get_lowest_stripe_price_by_category')) {
 
     <?php
     global $wpdb;
-    $kats = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_product_categories ORDER BY name ASC");
+    $kats = $wpdb->get_results(
+        "SELECT pc.*, COUNT(ptc.produkt_id) AS product_count
+         FROM {$wpdb->prefix}produkt_product_categories pc
+         LEFT JOIN {$wpdb->prefix}produkt_product_to_category ptc ON pc.id = ptc.category_id
+         GROUP BY pc.id
+         HAVING product_count > 0
+         ORDER BY pc.name ASC"
+    );
     ?>
 
     <div class="shop-overview-layout">


### PR DESCRIPTION
## Summary
- add cached helpers to test if Stripe prices or products are archived
- allow clearing Stripe archive caches from the Debug tab
- display archive badges using cached checks
- change Settings nav label to "🛠 Debug"
- refresh Stripe archive cache daily via cron
- show number of products per category in the admin
- hide empty categories from the shop overview
- hard delete products via products page and add cleanup option in Debug tab

## Testing
- `php -l admin/settings-page.php`
- `php -l admin/tabs/debug-tab.php`
- `php -l admin/tabs/durations-edit-tab.php`
- `php -l admin/tabs/durations-list-tab.php`
- `php -l admin/tabs/extras-list-tab.php`
- `php -l admin/tabs/variants-list-tab.php`
- `php -l includes/StripeService.php`
- `php -l produkt-verleih.php`
- `php -l admin/product-categories-page.php`
- `php -l templates/product-archive.php`
- `php -l includes/Plugin.php`
- `php -l admin/products-page.php`


------
https://chatgpt.com/codex/tasks/task_b_6877c7bdd8a483309a434620d1b7a60c