### PR TITLE
Implement hierarchical categories

### DIFF
--- a/admin/content-blocks-page.php
+++ b/admin/content-blocks-page.php
@@ -4,7 +4,7 @@ if (!defined('ABSPATH')) { exit; }
 global $wpdb;
 $table_name = $wpdb->prefix . 'produkt_content_blocks';
 
-$categories = $wpdb->get_results("SELECT id, name FROM {$wpdb->prefix}produkt_product_categories ORDER BY name");
+$categories = \ProduktVerleih\Database::get_product_categories_tree();
 array_unshift($categories, (object)['id' => 0, 'name' => 'Alle Kategorien']);
 $selected_category = isset($_GET['category']) ? intval($_GET['category']) : ($categories[0]->id ?? 0);
 $action = isset($_GET['action']) ? sanitize_text_field($_GET['action']) : 'list';
@@ -54,7 +54,7 @@ $blocks = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE cat
         <label for="cb-category-select"><strong>Kategorie:</strong></label>
         <select id="cb-category-select" name="category" onchange="this.form.submit()">
             <?php foreach ($categories as $cat): ?>
-                <option value="<?php echo $cat->id; ?>" <?php selected($selected_category, $cat->id); ?>><?php echo esc_html($cat->name); ?></option>
+                <option value="<?php echo $cat->id; ?>" <?php selected($selected_category, $cat->id); ?>><?php echo str_repeat('--', $cat->depth ?? 0) . ' ' . esc_html($cat->name); ?></option>
             <?php endforeach; ?>
         </select>
         <noscript><input type="submit" value="Wechseln" class="button"></noscript>

--- a/admin/product-categories-page.php
+++ b/admin/product-categories-page.php
@@ -10,6 +10,7 @@ if (isset($_POST['save_category'])) {
     $name = sanitize_text_field($_POST['name']);
     $slug = sanitize_title($_POST['slug']);
     $description = sanitize_textarea_field($_POST['description']);
+    $parent_id = isset($_POST['parent_id']) ? intval($_POST['parent_id']) : 0;
     $id = isset($_POST['category_id']) ? intval($_POST['category_id']) : 0;
 
     global $wpdb;
@@ -19,13 +20,15 @@ if (isset($_POST['save_category'])) {
         $wpdb->update($table, [
             'name' => $name,
             'slug' => $slug,
-            'description' => $description
+            'description' => $description,
+            'parent_id' => $parent_id ?: null
         ], ['id' => $id]);
     } else {
         $wpdb->insert($table, [
             'name' => $name,
             'slug' => $slug,
-            'description' => $description
+            'description' => $description,
+            'parent_id' => $parent_id ?: null
         ]);
     }
 }
@@ -39,14 +42,17 @@ if (isset($_GET['delete'])) {
 }
 
 global $wpdb;
-$categories = $wpdb->get_results(
+$raw_cats = $wpdb->get_results(
     "SELECT c.*, COUNT(p.id) AS product_count
      FROM {$wpdb->prefix}produkt_product_categories c
      LEFT JOIN {$wpdb->prefix}produkt_product_to_category ptc ON c.id = ptc.category_id
      LEFT JOIN {$wpdb->prefix}produkt_categories p ON p.id = ptc.produkt_id
-     GROUP BY c.id
-     ORDER BY c.name ASC"
+     GROUP BY c.id"
 );
+$categories = Database::get_product_categories_tree();
+$counts = [];
+foreach ($raw_cats as $r) { $counts[$r->id] = $r->product_count; }
+foreach ($categories as $c) { $c->product_count = $counts[$c->id] ?? 0; }
 
 // Wenn Bearbeiten
 $edit_category = null;
@@ -73,6 +79,21 @@ if (isset($_GET['edit'])) {
                 <td><input name="slug" type="text" required value="<?= esc_attr($edit_category->slug ?? '') ?>" class="regular-text"></td>
             </tr>
             <tr>
+                <th><label for="parent_id">Übergeordnete Kategorie</label></th>
+                <td>
+                    <select name="parent_id">
+                        <option value="0">Keine</option>
+                        <?php foreach ($categories as $cat_option): ?>
+                            <?php if (!isset($edit_category->id) || $cat_option->id != $edit_category->id): ?>
+                                <option value="<?= $cat_option->id ?>" <?= isset($edit_category->parent_id) && $edit_category->parent_id == $cat_option->id ? 'selected' : '' ?>>
+                                    <?= str_repeat('--', $cat_option->depth) . ' ' . esc_html($cat_option->name) ?>
+                                </option>
+                            <?php endif; ?>
+                        <?php endforeach; ?>
+                    </select>
+                </td>
+            </tr>
+            <tr>
                 <th><label for="description">Beschreibung</label></th>
                 <td><textarea name="description" class="large-text"><?= esc_textarea($edit_category->description ?? '') ?></textarea></td>
             </tr>
@@ -93,7 +114,7 @@ if (isset($_GET['edit'])) {
         <tbody>
             <?php foreach ($categories as $cat): ?>
                 <tr>
-                    <td><?= esc_html($cat->name) ?></td>
+                    <td><?= str_repeat('--', $cat->depth) . ' ' . esc_html($cat->name) ?></td>
                     <td><?= esc_html($cat->slug) ?></td>
                     <td><?= intval($cat->product_count) ?></td>
                     <td>

--- a/admin/tabs/categories-add-tab.php
+++ b/admin/tabs/categories-add-tab.php
@@ -11,8 +11,7 @@
     <form method="post" action="" class="produkt-compact-form">
         <?php wp_nonce_field('produkt_admin_action', 'produkt_admin_nonce'); ?>
         <?php
-        global $wpdb;
-        $all_product_cats = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_product_categories ORDER BY name ASC");
+        $all_product_cats = \ProduktVerleih\Database::get_product_categories_tree();
         ?>
         <!-- Grunddaten -->
         <div class="produkt-form-section">
@@ -183,7 +182,7 @@
                 <select name="product_categories[]" multiple style="width:100%; height:auto; min-height:100px;">
                     <?php foreach ($all_product_cats as $cat): ?>
                         <option value="<?php echo $cat->id; ?>">
-                            <?php echo esc_html($cat->name); ?>
+                            <?php echo str_repeat('--', $cat->depth) . ' ' . esc_html($cat->name); ?>
                         </option>
                     <?php endforeach; ?>
                 </select>

--- a/admin/tabs/categories-edit-tab.php
+++ b/admin/tabs/categories-edit-tab.php
@@ -12,8 +12,7 @@
         <?php wp_nonce_field('produkt_admin_action', 'produkt_admin_nonce'); ?>
         <input type="hidden" name="id" value="<?php echo esc_attr($edit_item->id); ?>">
         <?php
-        global $wpdb;
-        $all_product_cats = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_product_categories ORDER BY name ASC");
+        $all_product_cats = \ProduktVerleih\Database::get_product_categories_tree();
         $selected_product_cats = $wpdb->get_col(
             $wpdb->prepare(
                 "SELECT category_id FROM {$wpdb->prefix}produkt_product_to_category WHERE produkt_id = %d",
@@ -85,7 +84,7 @@
                 <select name="product_categories[]" multiple style="width:100%; height:auto; min-height:100px;">
                     <?php foreach ($all_product_cats as $cat): ?>
                         <option value="<?php echo $cat->id; ?>" <?php echo in_array($cat->id, $selected_product_cats) ? 'selected' : ''; ?>>
-                            <?php echo esc_html($cat->name); ?>
+                            <?php echo str_repeat('--', $cat->depth) . ' ' . esc_html($cat->name); ?>
                         </option>
                     <?php endforeach; ?>
                 </select>

--- a/admin/tabs/categories-list-tab.php
+++ b/admin/tabs/categories-list-tab.php
@@ -11,7 +11,7 @@
             <select name="prodcat">
                 <option value="0">Alle Kategorien</option>
                 <?php foreach ($product_categories as $pc): ?>
-                    <option value="<?php echo $pc->id; ?>" <?php selected($selected_prodcat, $pc->id); ?>><?php echo esc_html($pc->name); ?></option>
+                    <option value="<?php echo $pc->id; ?>" <?php selected($selected_prodcat, $pc->id); ?>><?php echo str_repeat('--', $pc->depth) . ' ' . esc_html($pc->name); ?></option>
                 <?php endforeach; ?>
             </select>
             <input type="text" name="s" value="<?php echo esc_attr($search_term); ?>" placeholder="Produkt suchen...">

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -613,7 +613,7 @@ class Admin {
         }
 
         // Filter & Suche
-        $product_categories = $wpdb->get_results("SELECT id, name FROM {$wpdb->prefix}produkt_product_categories ORDER BY name ASC");
+        $product_categories = \ProduktVerleih\Database::get_product_categories_tree();
         $selected_prodcat = isset($_GET['prodcat']) ? intval($_GET['prodcat']) : 0;
         $search_term = isset($_GET['s']) ? sanitize_text_field($_GET['s']) : '';
 

--- a/includes/Database.php
+++ b/includes/Database.php
@@ -19,6 +19,14 @@ class Database {
                 $wpdb->query("ALTER TABLE $table_name ADD COLUMN category_id mediumint(9) DEFAULT 1 AFTER id");
             }
         }
+
+        // Ensure parent_id column exists for product categories
+        $table_prod_cats = $wpdb->prefix . 'produkt_product_categories';
+        $parent_exists = $wpdb->get_results("SHOW COLUMNS FROM $table_prod_cats LIKE 'parent_id'");
+        if (empty($parent_exists)) {
+            $wpdb->query("ALTER TABLE $table_prod_cats ADD COLUMN parent_id INT UNSIGNED DEFAULT NULL AFTER id");
+            $wpdb->query("ALTER TABLE $table_prod_cats ADD KEY parent_id (parent_id)");
+        }
         
         // Add image columns to variants table if they don't exist
         $table_variants = $wpdb->prefix . 'produkt_variants';
@@ -729,11 +737,13 @@ class Database {
         $table_prod_categories = $wpdb->prefix . 'produkt_product_categories';
         $sql_prod_categories = "CREATE TABLE IF NOT EXISTS $table_prod_categories (
             id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+            parent_id INT UNSIGNED DEFAULT NULL,
             name VARCHAR(255) NOT NULL,
             slug VARCHAR(255) NOT NULL UNIQUE,
             description TEXT DEFAULT NULL,
             created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-            PRIMARY KEY (id)
+            PRIMARY KEY (id),
+            KEY parent_id (parent_id)
         ) $charset_collate;";
 
         // Mapping table between products and categories
@@ -1428,5 +1438,58 @@ class Database {
 
         $sql = "SELECT *, stripe_subscription_id AS subscription_id FROM $table WHERE customer_email = %s ORDER BY created_at";
         return $wpdb->get_results($wpdb->prepare($sql, $email));
+    }
+
+    /**
+     * Retrieve all product categories sorted hierarchically.
+     * Each returned object has a 'depth' property for indentation.
+     *
+     * @return array
+     */
+    public static function get_product_categories_tree() {
+        global $wpdb;
+        $table = $wpdb->prefix . 'produkt_product_categories';
+        $cats = $wpdb->get_results("SELECT id, parent_id, name, slug FROM $table ORDER BY name");
+        $map = [];
+        foreach ($cats as $c) {
+            $c->children = [];
+            $map[$c->id] = $c;
+        }
+        foreach ($cats as $c) {
+            if ($c->parent_id && isset($map[$c->parent_id])) {
+                $map[$c->parent_id]->children[] = $c;
+            }
+        }
+        $ordered = [];
+        $add = function($cat, $level) use (&$ordered, &$add) {
+            $cat->depth = $level;
+            $ordered[] = $cat;
+            foreach ($cat->children as $child) {
+                $add($child, $level + 1);
+            }
+        };
+        foreach ($cats as $c) {
+            if (empty($c->parent_id)) {
+                $add($c, 0);
+            }
+        }
+        return $ordered;
+    }
+
+    /**
+     * Get IDs of all descendant categories of a given parent.
+     *
+     * @param int $parent_id
+     * @return array
+     */
+    public static function get_descendant_category_ids($parent_id) {
+        global $wpdb;
+        $table = $wpdb->prefix . 'produkt_product_categories';
+        $ids = $wpdb->get_col($wpdb->prepare("SELECT id FROM $table WHERE parent_id = %d", $parent_id));
+        $all = $ids;
+        foreach ($ids as $id) {
+            $all = array_merge($all, self::get_descendant_category_ids($id));
+        }
+        return $all;
     }
 }

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -246,9 +246,11 @@ class Plugin {
             ));
 
             if ($category) {
+                $cat_ids = array_merge([$category->id], Database::get_descendant_category_ids($category->id));
+                $placeholders = implode(',', array_fill(0, count($cat_ids), '%d'));
                 $product_ids = $wpdb->get_col($wpdb->prepare(
-                    "SELECT produkt_id FROM {$wpdb->prefix}produkt_product_to_category WHERE category_id = %d",
-                    $category->id
+                    "SELECT produkt_id FROM {$wpdb->prefix}produkt_product_to_category WHERE category_id IN ($placeholders)",
+                    $cat_ids
                 ));
 
                 $categories = array_filter($categories, function ($prod) use ($product_ids) {

--- a/templates/product-archive.php
+++ b/templates/product-archive.php
@@ -32,10 +32,12 @@ if (!empty($category_slug)) {
     ));
 
     if (!empty($category)) {
-        // Gefundene Kategorie → filtern
+        // Gefundene Kategorie → filtern inkl. Unterkategorien
+        $cat_ids = array_merge([$category->id], Database::get_descendant_category_ids($category->id));
+        $placeholders = implode(',', array_fill(0, count($cat_ids), '%d'));
         $filtered_product_ids = $wpdb->get_col($wpdb->prepare(
-            "SELECT produkt_id FROM {$wpdb->prefix}produkt_product_to_category WHERE category_id = %d",
-            $category->id
+            "SELECT produkt_id FROM {$wpdb->prefix}produkt_product_to_category WHERE category_id IN ($placeholders)",
+            $cat_ids
         ));
         $categories = array_filter($categories ?? [], function ($product) use ($filtered_product_ids) {
             return in_array($product->id, $filtered_product_ids);
@@ -106,15 +108,17 @@ if (!function_exists('get_lowest_stripe_price_by_category')) {
 
     <?php
     global $wpdb;
-    $kats = $wpdb->get_results(
-        "SELECT pc.*, COUNT(p.id) AS product_count
+    $kats_raw = $wpdb->get_results(
+        "SELECT pc.id, pc.parent_id, pc.name, pc.slug, COUNT(ptc.produkt_id) AS product_count
          FROM {$wpdb->prefix}produkt_product_categories pc
          LEFT JOIN {$wpdb->prefix}produkt_product_to_category ptc ON pc.id = ptc.category_id
-         INNER JOIN {$wpdb->prefix}produkt_categories p ON p.id = ptc.produkt_id
-         GROUP BY pc.id
-         HAVING product_count > 0
-         ORDER BY pc.name ASC"
+         GROUP BY pc.id"
     );
+    $kats = Database::get_product_categories_tree();
+    $cnt_map = [];
+    foreach ($kats_raw as $r) { $cnt_map[$r->id] = $r->product_count; }
+    foreach ($kats as $c) { $c->product_count = $cnt_map[$c->id] ?? 0; }
+    $kats = array_filter($kats, function($c){ return $c->product_count > 0; });
     ?>
 
     <div class="shop-overview-layout">
@@ -125,7 +129,7 @@ if (!function_exists('get_lowest_stripe_price_by_category')) {
                 <?php foreach ($kats as $kat): ?>
                     <li>
                         <a href="<?php echo esc_url(home_url('/shop/' . $kat->slug)); ?>" class="<?php echo ($category_slug === $kat->slug) ? 'active' : ''; ?>">
-                            <?php echo esc_html($kat->name); ?>
+                            <?php echo str_repeat('--', $kat->depth) . ' ' . esc_html($kat->name); ?>
                         </a>
                     </li>
                 <?php endforeach; ?>
@@ -247,7 +251,7 @@ if (!function_exists('get_lowest_stripe_price_by_category')) {
             <?php foreach ($kats as $kat): ?>
                 <li>
                     <a href="<?php echo esc_url(home_url('/shop/' . $kat->slug)); ?>" class="<?php echo ($category_slug === $kat->slug) ? 'active' : ''; ?>">
-                        <?php echo esc_html($kat->name); ?>
+                        <?php echo str_repeat('--', $kat->depth) . ' ' . esc_html($kat->name); ?>
                     </a>
                 </li>
             <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- support parent-child relations in product category table
- update database schema and admin pages for new parent selection
- show categories with `--` indentation across admin and shop
- include subcategory products when filtering

## Testing
- `php -l admin/content-blocks-page.php`
- `php -l admin/product-categories-page.php`
- `php -l admin/tabs/categories-add-tab.php`
- `php -l admin/tabs/categories-edit-tab.php`
- `php -l admin/tabs/categories-list-tab.php`
- `php -l includes/Admin.php`
- `php -l includes/Database.php`
- `php -l includes/Plugin.php`
- `php -l templates/product-archive.php`

------
https://chatgpt.com/codex/tasks/task_b_68794661d1288330ae66a9e55ee426d0