### PR TITLE
Add filter management and assignment

### DIFF
--- a/admin/filters-page.php
+++ b/admin/filters-page.php
@@ -4,38 +4,68 @@ if (!defined('ABSPATH')) {
 }
 
 global $wpdb;
-$table = $wpdb->prefix . 'produkt_filters';
+$table_groups  = $wpdb->prefix . 'produkt_filter_groups';
+$table_filters = $wpdb->prefix . 'produkt_filters';
 
 $active_tab = isset($_GET['tab']) ? sanitize_text_field($_GET['tab']) : 'list';
 
 $edit_item = null;
 if (isset($_GET['edit'])) {
-    $edit_item = $wpdb->get_row($wpdb->prepare("SELECT * FROM $table WHERE id = %d", intval($_GET['edit'])));
+    $edit_item = $wpdb->get_row($wpdb->prepare("SELECT * FROM $table_groups WHERE id = %d", intval($_GET['edit'])));
     if ($edit_item) {
         $active_tab = 'edit';
     }
 }
 
-if (isset($_POST['submit_filter'])) {
+if (isset($_POST['submit_group'])) {
     \ProduktVerleih\Admin::verify_admin_action();
     $name = sanitize_text_field($_POST['name']);
-    $id = isset($_POST['id']) ? intval($_POST['id']) : 0;
+    $id   = isset($_POST['id']) ? intval($_POST['id']) : 0;
     if ($id) {
-        $wpdb->update($table, ['name' => $name], ['id' => $id]);
+        $wpdb->update($table_groups, ['name' => $name], ['id' => $id]);
     } else {
-        $wpdb->insert($table, ['name' => $name]);
+        $wpdb->insert($table_groups, ['name' => $name]);
         $id = $wpdb->insert_id;
     }
     $active_tab = 'list';
 }
 
-if (isset($_GET['delete']) && isset($_GET['fw_nonce']) && wp_verify_nonce($_GET['fw_nonce'], 'produkt_admin_action')) {
-    $del_id = intval($_GET['delete']);
-    $wpdb->delete($table, ['id' => $del_id]);
-    $wpdb->delete($wpdb->prefix . 'produkt_category_filters', ['filter_id' => $del_id]);
+if (isset($_POST['add_filter_item'])) {
+    \ProduktVerleih\Admin::verify_admin_action();
+    $name  = sanitize_text_field($_POST['filter_name']);
+    $gid   = intval($_POST['group_id']);
+    if ($name && $gid) {
+        $wpdb->insert($table_filters, ['group_id' => $gid, 'name' => $name]);
+    }
+    $active_tab = 'edit';
 }
 
-$filters = $wpdb->get_results("SELECT * FROM $table ORDER BY name");
+if (isset($_POST['update_filter_item'])) {
+    \ProduktVerleih\Admin::verify_admin_action();
+    $name = sanitize_text_field($_POST['filter_name']);
+    $fid  = intval($_POST['filter_id']);
+    $wpdb->update($table_filters, ['name' => $name], ['id' => $fid]);
+    $active_tab = 'edit';
+}
+
+if (isset($_GET['delete']) && isset($_GET['fw_nonce']) && wp_verify_nonce($_GET['fw_nonce'], 'produkt_admin_action')) {
+    $del_id = intval($_GET['delete']);
+    $wpdb->delete($table_groups, ['id' => $del_id]);
+    $filter_ids = $wpdb->get_col($wpdb->prepare("SELECT id FROM $table_filters WHERE group_id = %d", $del_id));
+    foreach ($filter_ids as $fid) {
+        $wpdb->delete($wpdb->prefix . 'produkt_category_filters', ['filter_id' => $fid]);
+    }
+    $wpdb->delete($table_filters, ['group_id' => $del_id]);
+}
+
+if (isset($_GET['delete_filter']) && isset($_GET['fw_nonce']) && wp_verify_nonce($_GET['fw_nonce'], 'produkt_admin_action')) {
+    $fid = intval($_GET['delete_filter']);
+    $wpdb->delete($table_filters, ['id' => $fid]);
+    $wpdb->delete($wpdb->prefix . 'produkt_category_filters', ['filter_id' => $fid]);
+    $active_tab = 'edit';
+}
+
+$groups  = $wpdb->get_results("SELECT * FROM $table_groups ORDER BY name");
 ?>
 <div class="wrap">
     <h1>Filter verwalten</h1>
@@ -48,36 +78,63 @@ $filters = $wpdb->get_results("SELECT * FROM $table ORDER BY name");
     </nav>
     <div class="produkt-tab-content">
         <?php if ($active_tab === 'add'): ?>
-            <h2>Neuen Filter hinzufügen</h2>
-            <form method="post">
-                <?php wp_nonce_field('produkt_admin_action', 'produkt_admin_nonce'); ?>
-                <table class="form-table">
-                    <tr>
-                        <th><label for="filter-name">Titel</label></th>
-                        <td><input type="text" name="name" id="filter-name" class="regular-text" required></td>
-                    </tr>
-                </table>
-                <?php submit_button('Hinzufügen', 'primary', 'submit_filter'); ?>
-            </form>
-        <?php elseif ($active_tab === 'edit' && $edit_item): ?>
-            <h2>Filter bearbeiten</h2>
-            <form method="post">
-                <?php wp_nonce_field('produkt_admin_action', 'produkt_admin_nonce'); ?>
-                <input type="hidden" name="id" value="<?php echo $edit_item->id; ?>">
-                <table class="form-table">
-                    <tr>
-                        <th><label for="filter-name">Titel</label></th>
-                        <td><input type="text" name="name" id="filter-name" value="<?php echo esc_attr($edit_item->name); ?>" class="regular-text" required></td>
-                    </tr>
-                </table>
-                <?php submit_button('Speichern', 'primary', 'submit_filter'); ?>
-            </form>
-        <?php else: ?>
-            <h2>Alle Filter</h2>
-            <table class="widefat striped">
-                <thead><tr><th>Titel</th><th>Aktion</th></tr></thead>
-                <tbody>
-                    <?php foreach ($filters as $f): ?>
+              <h2>Neue Filtergruppe hinzufügen</h2>
+              <form method="post">
+                  <?php wp_nonce_field('produkt_admin_action', 'produkt_admin_nonce'); ?>
+                  <table class="form-table">
+                      <tr>
+                          <th><label for="filter-name">Titel</label></th>
+                          <td><input type="text" name="name" id="filter-name" class="regular-text" required></td>
+                      </tr>
+                  </table>
+                  <?php submit_button('Hinzufügen', 'primary', 'submit_group'); ?>
+              </form>
+          <?php elseif ($active_tab === 'edit' && $edit_item): ?>
+              <h2>Filter bearbeiten</h2>
+              <form method="post">
+                  <?php wp_nonce_field('produkt_admin_action', 'produkt_admin_nonce'); ?>
+                  <input type="hidden" name="id" value="<?php echo $edit_item->id; ?>">
+                  <table class="form-table">
+                      <tr>
+                          <th><label for="filter-name">Titel</label></th>
+                          <td><input type="text" name="name" id="filter-name" value="<?php echo esc_attr($edit_item->name); ?>" class="regular-text" required></td>
+                      </tr>
+                  </table>
+                  <?php submit_button('Speichern', 'primary', 'submit_group'); ?>
+              </form>
+              <?php $group_filters = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_filters WHERE group_id = %d ORDER BY name", $edit_item->id)); ?>
+              <h3>Filteroptionen</h3>
+              <form method="post" style="margin-bottom:15px;">
+                  <?php wp_nonce_field('produkt_admin_action', 'produkt_admin_nonce'); ?>
+                  <input type="hidden" name="group_id" value="<?php echo $edit_item->id; ?>">
+                  <input type="text" name="filter_name" class="regular-text" required>
+                  <?php submit_button('Hinzufügen', 'secondary', 'add_filter_item', false); ?>
+              </form>
+              <table class="widefat striped">
+                  <thead><tr><th>Name</th><th>Aktion</th></tr></thead>
+                  <tbody>
+                      <?php foreach ($group_filters as $f): ?>
+                      <tr>
+                          <td>
+                              <form method="post">
+                                  <?php wp_nonce_field('produkt_admin_action', 'produkt_admin_nonce'); ?>
+                                  <input type="hidden" name="filter_id" value="<?php echo $f->id; ?>">
+                                  <input type="text" name="filter_name" value="<?php echo esc_attr($f->name); ?>">
+                                  <?php submit_button('Speichern', 'small', 'update_filter_item', false); ?>
+                                  <a href="<?php echo admin_url('admin.php?page=produkt-filters&edit=' . $edit_item->id . '&delete_filter=' . $f->id . '&fw_nonce=' . wp_create_nonce('produkt_admin_action')); ?>" onclick="return confirm('Löschen?');">Löschen</a>
+                              </form>
+                          </td>
+                          <td></td>
+                      </tr>
+                      <?php endforeach; ?>
+                  </tbody>
+              </table>
+          <?php else: ?>
+              <h2>Alle Filter</h2>
+              <table class="widefat striped">
+                  <thead><tr><th>Titel</th><th>Aktion</th></tr></thead>
+                  <tbody>
+                    <?php foreach ($groups as $f): ?>
                     <tr>
                         <td><?php echo esc_html($f->name); ?></td>
                         <td>
@@ -86,8 +143,8 @@ $filters = $wpdb->get_results("SELECT * FROM $table ORDER BY name");
                         </td>
                     </tr>
                     <?php endforeach; ?>
-                </tbody>
-            </table>
+                  </tbody>
+              </table>
         <?php endif; ?>
     </div>
 </div>

--- a/admin/filters-page.php
+++ b/admin/filters-page.php
@@ -1,0 +1,93 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+global $wpdb;
+$table = $wpdb->prefix . 'produkt_filters';
+
+$active_tab = isset($_GET['tab']) ? sanitize_text_field($_GET['tab']) : 'list';
+
+$edit_item = null;
+if (isset($_GET['edit'])) {
+    $edit_item = $wpdb->get_row($wpdb->prepare("SELECT * FROM $table WHERE id = %d", intval($_GET['edit'])));
+    if ($edit_item) {
+        $active_tab = 'edit';
+    }
+}
+
+if (isset($_POST['submit_filter'])) {
+    \ProduktVerleih\Admin::verify_admin_action();
+    $name = sanitize_text_field($_POST['name']);
+    $id = isset($_POST['id']) ? intval($_POST['id']) : 0;
+    if ($id) {
+        $wpdb->update($table, ['name' => $name], ['id' => $id]);
+    } else {
+        $wpdb->insert($table, ['name' => $name]);
+        $id = $wpdb->insert_id;
+    }
+    $active_tab = 'list';
+}
+
+if (isset($_GET['delete']) && isset($_GET['fw_nonce']) && wp_verify_nonce($_GET['fw_nonce'], 'produkt_admin_action')) {
+    $del_id = intval($_GET['delete']);
+    $wpdb->delete($table, ['id' => $del_id]);
+    $wpdb->delete($wpdb->prefix . 'produkt_category_filters', ['filter_id' => $del_id]);
+}
+
+$filters = $wpdb->get_results("SELECT * FROM $table ORDER BY name");
+?>
+<div class="wrap">
+    <h1>Filter verwalten</h1>
+    <nav class="produkt-tab-nav">
+        <a href="<?php echo admin_url('admin.php?page=produkt-filters&tab=list'); ?>" class="produkt-tab <?php echo $active_tab==='list'?'active':''; ?>">Übersicht</a>
+        <a href="<?php echo admin_url('admin.php?page=produkt-filters&tab=add'); ?>" class="produkt-tab <?php echo $active_tab==='add'?'active':''; ?>">Neu</a>
+        <?php if ($edit_item): ?>
+        <a href="<?php echo admin_url('admin.php?page=produkt-filters&tab=edit&edit=' . $edit_item->id); ?>" class="produkt-tab <?php echo $active_tab==='edit'?'active':''; ?>">Bearbeiten</a>
+        <?php endif; ?>
+    </nav>
+    <div class="produkt-tab-content">
+        <?php if ($active_tab === 'add'): ?>
+            <h2>Neuen Filter hinzufügen</h2>
+            <form method="post">
+                <?php wp_nonce_field('produkt_admin_action', 'produkt_admin_nonce'); ?>
+                <table class="form-table">
+                    <tr>
+                        <th><label for="filter-name">Titel</label></th>
+                        <td><input type="text" name="name" id="filter-name" class="regular-text" required></td>
+                    </tr>
+                </table>
+                <?php submit_button('Hinzufügen', 'primary', 'submit_filter'); ?>
+            </form>
+        <?php elseif ($active_tab === 'edit' && $edit_item): ?>
+            <h2>Filter bearbeiten</h2>
+            <form method="post">
+                <?php wp_nonce_field('produkt_admin_action', 'produkt_admin_nonce'); ?>
+                <input type="hidden" name="id" value="<?php echo $edit_item->id; ?>">
+                <table class="form-table">
+                    <tr>
+                        <th><label for="filter-name">Titel</label></th>
+                        <td><input type="text" name="name" id="filter-name" value="<?php echo esc_attr($edit_item->name); ?>" class="regular-text" required></td>
+                    </tr>
+                </table>
+                <?php submit_button('Speichern', 'primary', 'submit_filter'); ?>
+            </form>
+        <?php else: ?>
+            <h2>Alle Filter</h2>
+            <table class="widefat striped">
+                <thead><tr><th>Titel</th><th>Aktion</th></tr></thead>
+                <tbody>
+                    <?php foreach ($filters as $f): ?>
+                    <tr>
+                        <td><?php echo esc_html($f->name); ?></td>
+                        <td>
+                            <a href="<?php echo admin_url('admin.php?page=produkt-filters&edit=' . $f->id); ?>">Bearbeiten</a> |
+                            <a href="<?php echo admin_url('admin.php?page=produkt-filters&delete=' . $f->id . '&fw_nonce=' . wp_create_nonce('produkt_admin_action')); ?>" onclick="return confirm('Sind Sie sicher?');">Löschen</a>
+                        </td>
+                    </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        <?php endif; ?>
+    </div>
+</div>

--- a/admin/tabs/categories-add-tab.php
+++ b/admin/tabs/categories-add-tab.php
@@ -12,7 +12,16 @@
         <?php wp_nonce_field('produkt_admin_action', 'produkt_admin_nonce'); ?>
         <?php
         $all_product_cats = \ProduktVerleih\Database::get_product_categories_tree();
-        $filters = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_filters ORDER BY name");
+        $filter_groups = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_filter_groups ORDER BY name");
+        $filters_by_group = [];
+        foreach ($filter_groups as $g) {
+            $filters_by_group[$g->id] = $wpdb->get_results(
+                $wpdb->prepare(
+                    "SELECT * FROM {$wpdb->prefix}produkt_filters WHERE group_id = %d ORDER BY name",
+                    $g->id
+                )
+            );
+        }
         ?>
         <!-- Grunddaten -->
         <div class="produkt-form-section">
@@ -195,10 +204,13 @@
             <h4>🔎 Filter</h4>
             <input type="text" id="filter-search" placeholder="Filter suchen..." style="max-width:300px;width:100%;">
             <div id="filter-list" class="produkt-filter-list" style="margin-top:10px;">
-                <?php foreach ($filters as $f): ?>
-                <label class="produkt-filter-item" style="display:block;margin-bottom:4px;">
-                    <input type="checkbox" name="filters[]" value="<?php echo $f->id; ?>"> <?php echo esc_html($f->name); ?>
-                </label>
+                <?php foreach ($filter_groups as $group): ?>
+                    <strong><?php echo esc_html($group->name); ?></strong><br>
+                    <?php foreach ($filters_by_group[$group->id] as $f): ?>
+                    <label class="produkt-filter-item" style="display:block;margin-bottom:4px;">
+                        <input type="checkbox" name="filters[]" value="<?php echo $f->id; ?>"> <?php echo esc_html($f->name); ?>
+                    </label>
+                    <?php endforeach; ?>
                 <?php endforeach; ?>
             </div>
         </div>

--- a/admin/tabs/categories-add-tab.php
+++ b/admin/tabs/categories-add-tab.php
@@ -12,6 +12,7 @@
         <?php wp_nonce_field('produkt_admin_action', 'produkt_admin_nonce'); ?>
         <?php
         $all_product_cats = \ProduktVerleih\Database::get_product_categories_tree();
+        $filters = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_filters ORDER BY name");
         ?>
         <!-- Grunddaten -->
         <div class="produkt-form-section">
@@ -177,8 +178,8 @@
                     <input type="number" name="sort_order" min="0">
                 </div>
             </div>
-            <div class="produkt-form-group">
-                <label>Kategorien</label>
+        <div class="produkt-form-group">
+            <label>Kategorien</label>
                 <select name="product_categories[]" multiple style="width:100%; height:auto; min-height:100px;">
                     <?php foreach ($all_product_cats as $cat): ?>
                         <option value="<?php echo $cat->id; ?>">
@@ -187,6 +188,18 @@
                     <?php endforeach; ?>
                 </select>
                 <p class="description">Wählen Sie eine oder mehrere Kategorien für dieses Produkt.</p>
+            </div>
+        </div>
+
+        <div class="produkt-form-section">
+            <h4>🔎 Filter</h4>
+            <input type="text" id="filter-search" placeholder="Filter suchen..." style="max-width:300px;width:100%;">
+            <div id="filter-list" class="produkt-filter-list" style="margin-top:10px;">
+                <?php foreach ($filters as $f): ?>
+                <label class="produkt-filter-item" style="display:block;margin-bottom:4px;">
+                    <input type="checkbox" name="filters[]" value="<?php echo $f->id; ?>"> <?php echo esc_html($f->name); ?>
+                </label>
+                <?php endforeach; ?>
             </div>
         </div>
         
@@ -273,6 +286,16 @@ document.addEventListener('DOMContentLoaded', function() {
     if (mdInput && mdCounter) {
         updateCharCounter(mdInput, mdCounter, 150, 160);
         mdInput.addEventListener('input', () => updateCharCounter(mdInput, mdCounter, 150, 160));
+    }
+
+    const filterSearch = document.getElementById('filter-search');
+    if (filterSearch) {
+        filterSearch.addEventListener('input', function() {
+            const term = this.value.toLowerCase();
+            document.querySelectorAll('#filter-list .produkt-filter-item').forEach(function(el) {
+                el.style.display = el.textContent.toLowerCase().indexOf(term) !== -1 ? 'block' : 'none';
+            });
+        });
     }
 
     // Accordion fields are handled in admin-script.js

--- a/admin/tabs/categories-edit-tab.php
+++ b/admin/tabs/categories-edit-tab.php
@@ -20,12 +20,20 @@
                 $edit_item->id
             )
         );
+        $filters = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_filters ORDER BY name");
+        $selected_filters = $wpdb->get_col(
+            $wpdb->prepare(
+                "SELECT filter_id FROM {$wpdb->prefix}produkt_category_filters WHERE category_id = %d",
+                $edit_item->id
+            )
+        );
         ?>
 
         <div class="produkt-subtab-nav">
             <a href="#" class="produkt-subtab active" data-tab="general">Allgemein</a>
             <a href="#" class="produkt-subtab" data-tab="product">Produktseite</a>
             <a href="#" class="produkt-subtab" data-tab="features">Features</a>
+            <a href="#" class="produkt-subtab" data-tab="filters">Filter</a>
         </div>
 
         <div id="tab-general" class="produkt-subtab-content active">
@@ -232,6 +240,20 @@
 
         </div><!-- end tab-features -->
 
+        <div id="tab-filters" class="produkt-subtab-content">
+        <div class="produkt-form-section">
+            <h4>🔎 Filter</h4>
+            <input type="text" id="filter-search" placeholder="Filter suchen..." style="max-width:300px;width:100%;">
+            <div id="filter-list" class="produkt-filter-list" style="margin-top:10px;">
+                <?php foreach ($filters as $f): ?>
+                <label class="produkt-filter-item" style="display:block;margin-bottom:4px;">
+                    <input type="checkbox" name="filters[]" value="<?php echo $f->id; ?>" <?php checked(in_array($f->id, $selected_filters)); ?>> <?php echo esc_html($f->name); ?>
+                </label>
+                <?php endforeach; ?>
+            </div>
+        </div>
+        </div><!-- end tab-filters -->
+
 
 
 
@@ -367,6 +389,16 @@ document.addEventListener('DOMContentLoaded', function() {
             if (content) content.classList.add('active');
         });
     });
+
+    const filterSearch = document.getElementById('filter-search');
+    if (filterSearch) {
+        filterSearch.addEventListener('input', function() {
+            const term = this.value.toLowerCase();
+            document.querySelectorAll('#filter-list .produkt-filter-item').forEach(function(el) {
+                el.style.display = el.textContent.toLowerCase().indexOf(term) !== -1 ? 'block' : 'none';
+            });
+        });
+    }
 
     // Accordion fields are handled in admin-script.js
 });

--- a/admin/tabs/categories-edit-tab.php
+++ b/admin/tabs/categories-edit-tab.php
@@ -20,7 +20,16 @@
                 $edit_item->id
             )
         );
-        $filters = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_filters ORDER BY name");
+        $filter_groups = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_filter_groups ORDER BY name");
+        $filters_by_group = [];
+        foreach ($filter_groups as $g) {
+            $filters_by_group[$g->id] = $wpdb->get_results(
+                $wpdb->prepare(
+                    "SELECT * FROM {$wpdb->prefix}produkt_filters WHERE group_id = %d ORDER BY name",
+                    $g->id
+                )
+            );
+        }
         $selected_filters = $wpdb->get_col(
             $wpdb->prepare(
                 "SELECT filter_id FROM {$wpdb->prefix}produkt_category_filters WHERE category_id = %d",
@@ -245,10 +254,13 @@
             <h4>🔎 Filter</h4>
             <input type="text" id="filter-search" placeholder="Filter suchen..." style="max-width:300px;width:100%;">
             <div id="filter-list" class="produkt-filter-list" style="margin-top:10px;">
-                <?php foreach ($filters as $f): ?>
-                <label class="produkt-filter-item" style="display:block;margin-bottom:4px;">
-                    <input type="checkbox" name="filters[]" value="<?php echo $f->id; ?>" <?php checked(in_array($f->id, $selected_filters)); ?>> <?php echo esc_html($f->name); ?>
-                </label>
+                <?php foreach ($filter_groups as $group): ?>
+                    <strong><?php echo esc_html($group->name); ?></strong><br>
+                    <?php foreach ($filters_by_group[$group->id] as $f): ?>
+                    <label class="produkt-filter-item" style="display:block;margin-bottom:4px;">
+                        <input type="checkbox" name="filters[]" value="<?php echo $f->id; ?>" <?php checked(in_array($f->id, $selected_filters)); ?>> <?php echo esc_html($f->name); ?>
+                    </label>
+                    <?php endforeach; ?>
                 <?php endforeach; ?>
             </div>
         </div>

--- a/assets/script.js
+++ b/assets/script.js
@@ -1007,4 +1007,17 @@ jQuery(function($) {
         $('#shop-filter-overlay').removeClass('open');
         $('body').removeClass('shop-filter-open');
     });
+
+    function updateFilterQuery() {
+        const ids = $('.shop-filter-checkbox:checked').map(function(){ return this.value; }).get();
+        const params = new URLSearchParams(window.location.search);
+        if (ids.length) {
+            params.set('filter', ids.join(','));
+        } else {
+            params.delete('filter');
+        }
+        window.location.search = params.toString();
+    }
+
+    $(document).on('change', '.shop-filter-checkbox', updateFilterQuery);
 });

--- a/assets/style.css
+++ b/assets/style.css
@@ -1701,6 +1701,21 @@ body.produkt-popup-open {
     padding: 0;
 }
 
+.shop-filter-checkboxes {
+    margin-top: 2rem;
+}
+
+.shop-filter-checkboxes ul {
+    list-style: none;
+    margin: 0 0 1rem 0;
+    padding: 0;
+}
+
+.shop-filter-checkboxes label {
+    display: block;
+    font-size: 0.9rem;
+}
+
 #shop-filter-overlay a {
     text-decoration: none;
 }

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -126,7 +126,16 @@ class Admin {
             'produkt-shipping',
             array($this, 'shipping_page')
         );
-        
+
+        add_submenu_page(
+            'produkt-verleih',
+            'Filter',
+            'Filter',
+            'manage_options',
+            'produkt-filters',
+            array($this, 'filters_page')
+        );
+
 
         // New settings menu with Stripe integration tab
         add_submenu_page(
@@ -508,6 +517,17 @@ class Admin {
                             ]);
                         }
                     }
+
+                    if (isset($_POST['filters']) && is_array($_POST['filters'])) {
+                        $filter_ids = array_map('intval', $_POST['filters']);
+                        $wpdb->delete($wpdb->prefix . 'produkt_category_filters', ['category_id' => $produkt_id]);
+                        foreach ($filter_ids as $fid) {
+                            $wpdb->insert($wpdb->prefix . 'produkt_category_filters', [
+                                'category_id' => $produkt_id,
+                                'filter_id'   => $fid
+                            ]);
+                        }
+                    }
                     echo '<div class="notice notice-success"><p>✅ Produkt erfolgreich aktualisiert!</p></div>';
                 } else {
                     echo '<div class="notice notice-error"><p>❌ Fehler beim Aktualisieren: ' . esc_html($wpdb->last_error) . '</p></div>';
@@ -572,6 +592,17 @@ class Admin {
                             $wpdb->insert($wpdb->prefix . 'produkt_product_to_category', [
                                 'produkt_id' => $produkt_id,
                                 'category_id' => intval($cat_id)
+                            ]);
+                        }
+                    }
+
+                    if (isset($_POST['filters']) && is_array($_POST['filters'])) {
+                        $filter_ids = array_map('intval', $_POST['filters']);
+                        $wpdb->delete($wpdb->prefix . 'produkt_category_filters', ['category_id' => $produkt_id]);
+                        foreach ($filter_ids as $fid) {
+                            $wpdb->insert($wpdb->prefix . 'produkt_category_filters', [
+                                'category_id' => $produkt_id,
+                                'filter_id'   => $fid
                             ]);
                         }
                     }
@@ -800,6 +831,10 @@ class Admin {
 
     public function shipping_page() {
         include PRODUKT_PLUGIN_PATH . 'admin/shipping-page.php';
+    }
+
+    public function filters_page() {
+        include PRODUKT_PLUGIN_PATH . 'admin/filters-page.php';
     }
 
 


### PR DESCRIPTION
## Summary
- add Filters admin page with CRUD operations
- create new database tables for filters
- allow assigning filters when adding/editing products
- include Filters submenu in admin

## Testing
- `php -l admin/filters-page.php`
- `php -l admin/tabs/categories-add-tab.php`
- `php -l admin/tabs/categories-edit-tab.php`
- `php -l includes/Admin.php`
- `php -l includes/Database.php`


------
https://chatgpt.com/codex/tasks/task_b_687973edcc7483309856c53710d5c226