### PR TITLE
Fix variant-specific discount badges

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -415,6 +415,18 @@ jQuery(document).ready(function($) {
         }
     }
 
+    function updateDiscountBadges(discounts) {
+        $('.produkt-options.durations .produkt-option').each(function(){
+            const id = $(this).data('id');
+            const badge = $(this).find('.produkt-discount-badge');
+            badge.remove();
+            if (discounts && typeof discounts[id] !== 'undefined' && discounts[id] > 0) {
+                const pct = (discounts[id] * 100).toFixed(1).replace('.', ',');
+                $(this).find('.produkt-duration-header').append(`<span class="produkt-discount-badge">-${pct}%</span>`);
+            }
+        });
+    }
+
     function updateVariantOptions(variantId) {
         // Get variant-specific options via AJAX
         $.ajax({
@@ -453,6 +465,7 @@ jQuery(document).ready(function($) {
                     updateExtraImage(null);
                     updateColorImage(null);
 
+                    updateDiscountBadges(data.duration_discounts || {});
                     updatePriceAndButton();
                 }
             }


### PR DESCRIPTION
## Summary
- compute duration discount per variant in `get_variant_options` API
- return discount data to the frontend and update badges dynamically

## Testing
- `php -l includes/Ajax.php`
- `node --check assets/script.js`


------
https://chatgpt.com/codex/tasks/task_b_687c15b341cc8330833b8b56d1b642af