### PR TITLE
Refactor account dashboard view

### DIFF
--- a/admin/categories-page.php
+++ b/admin/categories-page.php
@@ -2,6 +2,8 @@
 if (!defined('ABSPATH')) {
     exit;
 }
+
+global $wpdb;
 ?>
 
 <div class="wrap">

--- a/admin/tabs/categories-add-tab.php
+++ b/admin/tabs/categories-add-tab.php
@@ -1,5 +1,6 @@
 <?php
 // Categories Add Tab Content
+global $wpdb;
 ?>
 
 <div class="produkt-add-category">

--- a/assets/account-style.css
+++ b/assets/account-style.css
@@ -5,6 +5,17 @@
     background: transparent;
     border-radius: 1rem;
 }
+img.wp-smiley, img.emoji {
+    height: 1em;
+    width: 1em;
+    margin: 0 .07em;
+    vertical-align: -0.1em;
+    background: none !important;
+    padding: 0 !important;
+    border: none !important;
+    box-shadow: none !important;
+}
+
 
 /* Layout with sidebar similar to the shop pages */
 .account-layout {

--- a/assets/admin-style.css
+++ b/assets/admin-style.css
@@ -2010,7 +2010,7 @@
 
 .produkt-form-section:last-child {
     border-bottom: none;
-    padding-bottom: 0;
+    padding-bottom: 25px;
 }
 
 .produkt-form-section h4 {

--- a/assets/style.css
+++ b/assets/style.css
@@ -943,8 +943,14 @@ img.wp-smiley, img.emoji {
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 2rem;
+    font-size: 1.5rem;
     overflow: hidden;
+}
+
+.produkt-feature-icon-large img.wp-smiley,
+.produkt-feature-icon-large img.emoji {
+    height: 1.5rem;
+    width: 1.5rem;
 }
 
 .produkt-feature-text h4 {

--- a/assets/style.css
+++ b/assets/style.css
@@ -568,6 +568,14 @@ img.wp-smiley, img.emoji {
     border: 1px solid #fecaca;
 }
 
+.produkt-unavailable-badge .produkt-emoji {
+    display: inline-block;
+    width: 1em;
+    height: 1em;
+    line-height: 1;
+    vertical-align: -0.1em;
+}
+
 .produkt-availability-note {
     font-size: 0.75rem;
     color: #6b7280;

--- a/assets/style.css
+++ b/assets/style.css
@@ -7,6 +7,17 @@
     --produkt-button-text: #ffffff;
     --produkt-filter-button-bg: #5f7f5f;
 }
+img.wp-smiley, img.emoji {
+    height: 1em;
+    width: 1em;
+    margin: 0 .07em;
+    vertical-align: -0.1em;
+    background: none !important;
+    padding: 0 !important;
+    border: none !important;
+    box-shadow: none !important;
+}
+
 #page {
     min-height: auto !important;
 }

--- a/includes/Database.php
+++ b/includes/Database.php
@@ -1526,6 +1526,16 @@ class Database {
         $sql = "SELECT *, stripe_subscription_id AS subscription_id FROM $table WHERE customer_email = %s ORDER BY created_at";
         return $wpdb->get_results($wpdb->prepare($sql, $email));
     }
+    /**
+     * Get the Stripe customer ID for a WordPress user.
+     *
+     * @param int $user_id User ID
+     * @return string Customer ID or empty string if none found
+     */
+    public static function get_stripe_customer_id_for_user($user_id) {
+        return get_user_meta($user_id, 'stripe_customer_id', true);
+    }
+
 
     /**
      * Retrieve all product categories sorted hierarchically.

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -393,10 +393,10 @@ class Plugin {
                                 if (is_wp_error($res)) {
                                     $message = '<p style="color:red;">' . esc_html($res->get_error_message()) . '</p>';
                                 } else {
-                                    $message = '<p>K\xFCndigung vorgemerkt. Laufzeit endet am ' . esc_html($period_end_date) . '.</p>';
+                                    $message = '<p>' . esc_html__('Kündigung vorgemerkt. Laufzeit endet am ', 'h2-concepts') . esc_html($period_end_date) . '</p>';
                                 }
                             } else {
-                                $message = '<p style="color:red;">Dieses Abo kann noch nicht gek\xC3\xBCndigt werden.</p>';
+                                $message = '<p style="color:red;">' . esc_html__('Dieses Abo kann noch nicht gekündigt werden.', 'h2-concepts') . '</p>';
                             }
 
                             break;

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -360,7 +360,7 @@ class Plugin {
         $subscriptions  = [];
         $current_user_id = get_current_user_id();
         if ($current_user_id) {
-            $customer_id = get_user_meta($current_user_id, 'stripe_customer_id', true);
+            $customer_id = Database::get_stripe_customer_id_for_user($current_user_id);
 
             if ($customer_id && isset($_POST['cancel_subscription'])) {
                 $sub_id = sanitize_text_field($_POST['cancel_subscription']);

--- a/includes/account-helpers.php
+++ b/includes/account-helpers.php
@@ -21,3 +21,19 @@ function pv_get_subscription_status_badge($status) {
             return '<span class="badge badge-default">Unbekannt</span>';
     }
 }
+
+function pv_get_minimum_duration_months($order) {
+    global $wpdb;
+    if ($order && !empty($order->duration_id)) {
+        $months = (int) $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT months_minimum FROM {$wpdb->prefix}produkt_durations WHERE id = %d",
+                $order->duration_id
+            )
+        );
+        if ($months) {
+            return $months;
+        }
+    }
+    return 3;
+}

--- a/includes/account-helpers.php
+++ b/includes/account-helpers.php
@@ -37,3 +37,35 @@ function pv_get_minimum_duration_months($order) {
     }
     return 3;
 }
+
+/**
+ * Retrieve the best image URL for a subscription's variant or category.
+ *
+ * @param int $variant_id  Variant ID from the order.
+ * @param int $category_id Category ID from the order.
+ * @return string Image URL or empty string when none found.
+ */
+function pv_get_image_url_by_variant_or_category($variant_id, $category_id) {
+    global $wpdb;
+
+    $image_url = '';
+    if ($variant_id) {
+        $image_url = $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT image_url_1 FROM {$wpdb->prefix}produkt_variants WHERE id = %d",
+                $variant_id
+            )
+        );
+    }
+
+    if (empty($image_url) && $category_id) {
+        $image_url = $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT default_image FROM {$wpdb->prefix}produkt_categories WHERE id = %d",
+                $category_id
+            )
+        );
+    }
+
+    return $image_url ?: '';
+}

--- a/includes/shop-helpers.php
+++ b/includes/shop-helpers.php
@@ -1,0 +1,69 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+
+use ProduktVerleih\StripeService;
+
+/**
+ * Get the lowest Stripe price for all variants and durations in a category.
+ *
+ * @param int $category_id Category ID.
+ * @return array{amount: ?float, price_id: ?string, count: int}
+ */
+function pv_get_lowest_stripe_price_by_category($category_id) {
+    global $wpdb;
+
+    $variant_ids = $wpdb->get_col(
+        $wpdb->prepare(
+            "SELECT id FROM {$wpdb->prefix}produkt_variants WHERE category_id = %d",
+            $category_id
+        )
+    );
+
+    $duration_ids = $wpdb->get_col(
+        $wpdb->prepare(
+            "SELECT id FROM {$wpdb->prefix}produkt_durations WHERE category_id = %d",
+            $category_id
+        )
+    );
+
+    $price_data = StripeService::get_lowest_price_with_durations($variant_ids, $duration_ids);
+
+    $price_count = 0;
+    if (!empty($variant_ids) && !empty($duration_ids)) {
+        $placeholders_variant  = implode(',', array_fill(0, count($variant_ids), '%d'));
+        $placeholders_duration = implode(',', array_fill(0, count($duration_ids), '%d'));
+        $count_query = $wpdb->prepare(
+            "SELECT COUNT(*) FROM {$wpdb->prefix}produkt_duration_prices
+             WHERE variant_id IN ($placeholders_variant)
+               AND duration_id IN ($placeholders_duration)",
+            array_merge($variant_ids, $duration_ids)
+        );
+        $price_count = (int) $wpdb->get_var($count_query);
+    }
+
+    return [
+        'amount'   => $price_data['amount'] ?? null,
+        'price_id' => $price_data['price_id'] ?? null,
+        'count'    => $price_count,
+    ];
+}
+
+/**
+ * Format a price label based on price data.
+ *
+ * @param array|null $price_data Price data array from pv_get_lowest_stripe_price_by_category.
+ * @return string Formatted price string.
+ */
+function pv_format_price_label($price_data) {
+    if (!$price_data || !isset($price_data['amount'])) {
+        return 'Preis auf Anfrage';
+    }
+
+    $formatted = number_format((float) $price_data['amount'], 2, ',', '.');
+    if (($price_data['count'] ?? 0) > 1) {
+        return 'ab ' . $formatted . '€';
+    }
+
+    return $formatted . '€';
+}
+

--- a/templates/account-page.php
+++ b/templates/account-page.php
@@ -21,28 +21,31 @@ if (isset($_POST['cancel_subscription'], $_POST['cancel_subscription_nonce'])) {
     }
 }
 
+$orders       = [];
 $subscriptions = [];
-$current_user_id = get_current_user_id();
-if ($current_user_id) {
-    $stripe_customer_id = $db->get_stripe_customer_id_for_user($current_user_id);
-    if ($stripe_customer_id) {
-        $subs = \ProduktVerleih\StripeService::get_active_subscriptions_for_customer($stripe_customer_id);
-        if (!is_wp_error($subs)) {
-            $subscriptions = $subs;
+$full_name     = '';
+
+if (is_user_logged_in()) {
+    $user_id = get_current_user_id();
+    $orders  = Database::get_orders_for_user($user_id);
+
+    foreach ($orders as $o) {
+        if (!empty($o->stripe_customer_id)) {
+            $subs = \ProduktVerleih\StripeService::get_active_subscriptions_for_customer($o->stripe_customer_id);
+            if (!is_wp_error($subs)) {
+                $subscriptions = $subs;
+            }
+            break;
         }
     }
-}
 
-$orders    = [];
-$full_name = '';
-if (is_user_logged_in()) {
-    $orders = Database::get_orders_for_user(get_current_user_id());
     foreach ($orders as $o) {
         if (!empty($o->customer_name)) {
             $full_name = $o->customer_name;
             break;
         }
     }
+
     if (!$full_name) {
         $full_name = wp_get_current_user()->display_name;
     }

--- a/templates/account-page.php
+++ b/templates/account-page.php
@@ -7,8 +7,6 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-$db = new Database();
-
 if (isset($_POST['cancel_subscription'], $_POST['cancel_subscription_nonce'])) {
     if (wp_verify_nonce($_POST['cancel_subscription_nonce'], 'cancel_subscription_action')) {
         $sub_id = sanitize_text_field($_POST['subscription_id']);
@@ -20,6 +18,7 @@ if (isset($_POST['cancel_subscription'], $_POST['cancel_subscription_nonce'])) {
         }
     }
 }
+
 
 $orders       = [];
 $order_map    = [];
@@ -36,13 +35,11 @@ if (is_user_logged_in()) {
         }
     }
 
-    foreach ($orders as $o) {
-        if (!empty($o->stripe_customer_id)) {
-            $subs = \ProduktVerleih\StripeService::get_active_subscriptions_for_customer($o->stripe_customer_id);
-            if (!is_wp_error($subs)) {
-                $subscriptions = $subs;
-            }
-            break;
+    $customer_id = Database::get_stripe_customer_id_for_user($user_id);
+    if ($customer_id) {
+        $subs = \ProduktVerleih\StripeService::get_active_subscriptions_for_customer($customer_id);
+        if (!is_wp_error($subs)) {
+            $subscriptions = $subs;
         }
     }
 

--- a/templates/account-page.php
+++ b/templates/account-page.php
@@ -22,12 +22,19 @@ if (isset($_POST['cancel_subscription'], $_POST['cancel_subscription_nonce'])) {
 }
 
 $orders       = [];
+$order_map    = [];
 $subscriptions = [];
 $full_name     = '';
 
 if (is_user_logged_in()) {
     $user_id = get_current_user_id();
     $orders  = Database::get_orders_for_user($user_id);
+
+    foreach ($orders as $o) {
+        if (!empty($o->subscription_id)) {
+            $order_map[$o->subscription_id] = $o;
+        }
+    }
 
     foreach ($orders as $o) {
         if (!empty($o->stripe_customer_id)) {

--- a/templates/account-page.php
+++ b/templates/account-page.php
@@ -21,7 +21,17 @@ if (isset($_POST['cancel_subscription'], $_POST['cancel_subscription_nonce'])) {
     }
 }
 
-$subscriptions = $subscriptions ?? [];
+$subscriptions = [];
+$current_user_id = get_current_user_id();
+if ($current_user_id) {
+    $stripe_customer_id = get_user_meta($current_user_id, 'stripe_customer_id', true);
+    if ($stripe_customer_id) {
+        $subs = \ProduktVerleih\StripeService::get_active_subscriptions_for_customer($stripe_customer_id);
+        if (!is_wp_error($subs)) {
+            $subscriptions = $subs;
+        }
+    }
+}
 
 $orders    = [];
 $full_name = '';

--- a/templates/account-page.php
+++ b/templates/account-page.php
@@ -16,7 +16,7 @@ if (isset($_POST['cancel_subscription'], $_POST['cancel_subscription_nonce'])) {
         if (is_wp_error($res)) {
             $message = '<p style="color:red;">' . esc_html($res->get_error_message()) . '</p>';
         } else {
-            $message = '<p>K\xFCndigung vorgemerkt.</p>';
+            $message = '<p>' . esc_html__('Kündigung vorgemerkt.', 'h2-concepts') . '</p>';
         }
     }
 }

--- a/templates/account-page.php
+++ b/templates/account-page.php
@@ -24,7 +24,7 @@ if (isset($_POST['cancel_subscription'], $_POST['cancel_subscription_nonce'])) {
 $subscriptions = [];
 $current_user_id = get_current_user_id();
 if ($current_user_id) {
-    $stripe_customer_id = get_user_meta($current_user_id, 'stripe_customer_id', true);
+    $stripe_customer_id = $db->get_stripe_customer_id_for_user($current_user_id);
     if ($stripe_customer_id) {
         $subs = \ProduktVerleih\StripeService::get_active_subscriptions_for_customer($stripe_customer_id);
         if (!is_wp_error($subs)) {

--- a/templates/account-page.php
+++ b/templates/account-page.php
@@ -16,132 +16,26 @@ if (isset($_POST['cancel_subscription'], $_POST['cancel_subscription_nonce'])) {
         if (is_wp_error($res)) {
             $message = '<p style="color:red;">' . esc_html($res->get_error_message()) . '</p>';
         } else {
-            $message = '<p>Kündigung vorgemerkt.</p>';
+            $message = '<p>K\xFCndigung vorgemerkt.</p>';
         }
     }
 }
 
-?>
-<?php if (!is_user_logged_in()) : ?>
-<div class="produkt-login-wrapper">
-    <div class="login-box">
-        <h1>Login</h1>
-        <p>Bitte die Email Adresse eingeben die bei Ihrer Bestellung verwendet wurde.</p>
-        <?php echo $message; ?>
-        <form method="post" class="login-email-form">
-            <input type="email" name="email" placeholder="Ihre E-Mail" value="<?php echo esc_attr($email_value); ?>" required>
-            <button type="submit" name="request_login_code">Code zum einloggen anfordern</button>
-        </form>
-        <?php if ($show_code_form) : ?>
-        <form method="post" class="login-code-form">
-            <input type="hidden" name="email" value="<?php echo esc_attr($email_value); ?>">
-            <input type="text" name="code" placeholder="6-stelliger Code" required>
-            <button type="submit" name="verify_login_code">Einloggen</button>
-        </form>
-        <?php endif; ?>
-    </div>
-</div>
-<?php else : ?>
-<div class="produkt-account-wrapper produkt-container shop-overview-container">
-    <h1>Kundenkonto</h1>
-    <?php echo $message; ?>
-        <?php
-        $orders = Database::get_orders_for_user(get_current_user_id());
-        $full_name = '';
-        foreach ($orders as $o) {
-            if (!empty($o->customer_name)) {
-                $full_name = $o->customer_name;
-                break;
-            }
+$subscriptions = $subscriptions ?? [];
+
+$orders    = [];
+$full_name = '';
+if (is_user_logged_in()) {
+    $orders = Database::get_orders_for_user(get_current_user_id());
+    foreach ($orders as $o) {
+        if (!empty($o->customer_name)) {
+            $full_name = $o->customer_name;
+            break;
         }
-        if (!$full_name) {
-            $full_name = wp_get_current_user()->display_name;
-        }
-        ?>
-        <div class="account-layout">
-            <aside class="account-sidebar shop-category-list">
-                <h2>Hallo <?php echo esc_html($full_name); ?></h2>
-                <ul>
-                    <li>
-                        <a href="#" class="active"><span class="menu-icon">📦</span> Abos</a>
-                    </li>
-                    <li>
-                        <a href="<?php echo esc_url(wp_logout_url(get_permalink())); ?>">
-                            <span class="menu-icon">🚪</span> Logout
-                        </a>
-                    </li>
-                </ul>
-            </aside>
-            <div>
-        <?php if (!empty($subscriptions)) : ?>
-            <?php
-            $order_map = [];
-            foreach ($orders as $o) {
-                $order_map[$o->subscription_id] = $o;
-            }
-            ?>
-            <?php foreach ($subscriptions as $sub) : ?>
-                <?php
-                $order = $order_map[$sub['subscription_id']] ?? null;
-                $product_name = $order->produkt_name ?? $sub['subscription_id'];
-                $start_ts = strtotime($sub['start_date']);
-                $start_formatted = date_i18n('d.m.Y', $start_ts);
-                $laufzeit_in_monaten = 3;
-                if ($order && !empty($order->duration_id)) {
-                    global $wpdb;
-                    $laufzeit_in_monaten = (int) $wpdb->get_var(
-                        $wpdb->prepare(
-                            "SELECT months_minimum FROM {$wpdb->prefix}produkt_durations WHERE id = %d",
-                            $order->duration_id
-                        )
-                    );
-                    if (!$laufzeit_in_monaten) {
-                        $laufzeit_in_monaten = 3; // Fallback
-                    }
-                }
-                $cancelable_ts            = strtotime("+{$laufzeit_in_monaten} months", $start_ts);
-                $kuendigungsfenster_ts    = strtotime('-14 days', $cancelable_ts);
-                $kuendigbar_ab_date       = date_i18n('d.m.Y', $kuendigungsfenster_ts);
-                $cancelable               = time() >= $kuendigungsfenster_ts;
-                $is_extended              = time() > $cancelable_ts;
+    }
+    if (!$full_name) {
+        $full_name = wp_get_current_user()->display_name;
+    }
+}
 
-                $period_end_ts   = null;
-                $period_end_date = '';
-                if (!empty($sub['current_period_end'])) {
-                    $period_end_ts   = strtotime($sub['current_period_end']);
-                    $period_end_date = date_i18n('d.m.Y', $period_end_ts);
-                }
-
-                $image_url = '';
-                if ($order) {
-                    global $wpdb;
-                    if (!empty($order->variant_id)) {
-                        $image_url = $wpdb->get_var(
-                            $wpdb->prepare(
-                                "SELECT image_url_1 FROM {$wpdb->prefix}produkt_variants WHERE id = %d",
-                                $order->variant_id
-                            )
-                        );
-                    }
-
-                    if (empty($image_url) && !empty($order->category_id)) {
-                        $image_url = $wpdb->get_var(
-                            $wpdb->prepare(
-                                "SELECT default_image FROM {$wpdb->prefix}produkt_categories WHERE id = %d",
-                                $order->category_id
-                            )
-                        );
-                    }
-                }
-
-                $address = trim($order->customer_street . ', ' . $order->customer_postal . ' ' . $order->customer_city);
-                ?>
-                <?php include PRODUKT_PLUGIN_PATH . 'includes/render-subscription.php'; ?>
-            <?php endforeach; ?>
-        <?php else : ?>
-            <p>Keine aktiven Abos.</p>
-        <?php endif; ?>
-            </div>
-        </div>
-    <?php endif; ?>
-</div>
+include PRODUKT_PLUGIN_PATH . 'views/account/dashboard.php';

--- a/templates/product-archive.php
+++ b/templates/product-archive.php
@@ -9,6 +9,7 @@ get_header();
 
 use ProduktVerleih\Database;
 use ProduktVerleih\StripeService;
+require_once PRODUKT_PLUGIN_PATH . 'includes/shop-helpers.php';
 
 $categories = Database::get_all_categories(true);
 if (!is_array($categories)) {
@@ -75,43 +76,6 @@ $blocks_by_position_mobile  = [];
 foreach ($content_blocks as $b) {
     $blocks_by_position_desktop[$b->position][] = $b;
     $blocks_by_position_mobile[$b->position_mobile][] = $b;
-}
-
-if (!function_exists('get_lowest_stripe_price_by_category')) {
-    function get_lowest_stripe_price_by_category($category_id) {
-        global $wpdb;
-
-        $variant_ids  = $wpdb->get_col($wpdb->prepare(
-            "SELECT id FROM {$wpdb->prefix}produkt_variants WHERE category_id = %d",
-            $category_id
-        ));
-        $duration_ids = $wpdb->get_col($wpdb->prepare(
-            "SELECT id FROM {$wpdb->prefix}produkt_durations WHERE category_id = %d",
-            $category_id
-        ));
-
-        $price_data = StripeService::get_lowest_price_with_durations($variant_ids, $duration_ids);
-
-        // Zähle alle gültigen Preis-Kombinationen (für Anzeige von "ab")
-        $price_count = 0;
-        if (!empty($variant_ids) && !empty($duration_ids)) {
-            $placeholders_variant  = implode(',', array_fill(0, count($variant_ids), '%d'));
-            $placeholders_duration = implode(',', array_fill(0, count($duration_ids), '%d'));
-            $count_query = $wpdb->prepare(
-                "SELECT COUNT(*) FROM {$wpdb->prefix}produkt_duration_prices
-                 WHERE variant_id IN ($placeholders_variant)
-                   AND duration_id IN ($placeholders_duration)",
-                array_merge($variant_ids, $duration_ids)
-            );
-            $price_count = (int) $wpdb->get_var($count_query);
-        }
-
-        return [
-            'amount'     => $price_data['amount'] ?? null,
-            'price_id'   => $price_data['price_id'] ?? null,
-            'count'      => $price_count
-        ];
-    }
 }
 
 ?>
@@ -203,7 +167,7 @@ if (!function_exists('get_lowest_stripe_price_by_category')) {
             <div class="shop-product-grid">
         <?php $produkt_index = 0; foreach (($categories ?? []) as $cat): $produkt_index++; ?>
         <?php $url = home_url('/shop/produkt/' . sanitize_title($cat->product_title)); ?>
-        <?php $price_data = get_lowest_stripe_price_by_category($cat->id); ?>
+        <?php $price_data = pv_get_lowest_stripe_price_by_category($cat->id); ?>
         <div class="shop-product-item">
             <a href="<?php echo esc_url($url); ?>">
                 <div class="shop-product-image">
@@ -225,21 +189,16 @@ if (!function_exists('get_lowest_stripe_price_by_category')) {
                         </div>
                     <?php endif; ?>
                     <div class="shop-product-price">
-                        <?php if ($price_data && isset($price_data['amount'])): ?>
-                            <?php if ($price_data['count'] > 1): ?>
-                                ab <?php echo esc_html(number_format((float)$price_data['amount'], 2, ',', '.')); ?>€
-                            <?php else: ?>
-                                <?php echo esc_html(number_format((float)$price_data['amount'], 2, ',', '.')); ?>€
-                            <?php endif; ?>
-                        <?php else: ?>
-                            Preis auf Anfrage
-                        <?php endif; ?>
+                        <?php echo esc_html(pv_format_price_label($price_data)); ?>
                     </div>
                 </div>
             </a>
         </div>
         <?php
             $next_index = $produkt_index + 1;
+            if (!isset($blocks_by_position_desktop[$next_index]) && !isset($blocks_by_position_mobile[$next_index])) {
+                continue;
+            }
             if (isset($blocks_by_position_desktop[$next_index])) {
                 foreach ($blocks_by_position_desktop[$next_index] as $block) {
                     ?>

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -5,6 +5,7 @@ if (!defined('ABSPATH')) {
 }
 
 global $wpdb;
+require_once PRODUKT_PLUGIN_PATH . 'includes/shop-helpers.php';
 
 get_header();
 
@@ -197,17 +198,15 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
                 
                 <div class="produkt-product-details">
                     <h1><?php echo esc_html($product_title); ?></h1>
-                    <?php if ($price_data && isset($price_data['amount'])): ?>
-                        <div class="produkt-card-price">
-                            <?php if ($price_count > 1): ?>
-                                ab <?php echo esc_html(number_format((float)$price_data['amount'], 2, ',', '.')); ?>€
-                            <?php else: ?>
-                                <?php echo esc_html(number_format((float)$price_data['amount'], 2, ',', '.')); ?>€
-                            <?php endif; ?>
-                        </div>
-                    <?php else: ?>
-                        <div class="produkt-card-price">Preis auf Anfrage</div>
-                    <?php endif; ?>
+                    <div class="produkt-card-price">
+                        <?php
+                            $pd = $price_data;
+                            if (is_array($pd)) {
+                                $pd['count'] = $price_count;
+                            }
+                            echo esc_html(pv_format_price_label($pd));
+                        ?>
+                    </div>
                     <?php if ($show_rating && $rating_value > 0): ?>
                     <div class="produkt-rating">
                         <span class="produkt-rating-number"><?php echo esc_html($rating_display); ?></span>

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -290,7 +290,7 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
                                 <p class="produkt-option-price"><?php echo number_format($display_price, 2, ',', '.'); ?>€<?php echo $price_period === 'month' ? '/Monat' : ''; ?></p>
                                 <?php if (!($variant->available ?? 1)): ?>
                                     <div class="produkt-availability-notice">
-                                        <span class="produkt-unavailable-badge">❌ Nicht verfügbar</span>
+                                        <span class="produkt-unavailable-badge"><span class="produkt-emoji">❌</span> Nicht verfügbar</span>
                                         <?php if (!empty($variant->availability_note)): ?>
                                             <p class="produkt-availability-note"><?php echo esc_html($variant->availability_note); ?></p>
                                         <?php endif; ?>

--- a/views/account/dashboard.php
+++ b/views/account/dashboard.php
@@ -1,0 +1,110 @@
+<?php if (!is_user_logged_in()) : ?>
+<div class="produkt-login-wrapper">
+    <div class="login-box">
+        <h1>Login</h1>
+        <p>Bitte die Email Adresse eingeben die bei Ihrer Bestellung verwendet wurde.</p>
+        <?php echo $message; ?>
+        <form method="post" class="login-email-form">
+            <input type="email" name="email" placeholder="Ihre E-Mail" value="<?php echo esc_attr($email_value); ?>" required>
+            <button type="submit" name="request_login_code">Code zum einloggen anfordern</button>
+        </form>
+        <?php if ($show_code_form) : ?>
+        <form method="post" class="login-code-form">
+            <input type="hidden" name="email" value="<?php echo esc_attr($email_value); ?>">
+            <input type="text" name="code" placeholder="6-stelliger Code" required>
+            <button type="submit" name="verify_login_code">Einloggen</button>
+        </form>
+        <?php endif; ?>
+    </div>
+</div>
+<?php else : ?>
+<div class="produkt-account-wrapper produkt-container shop-overview-container">
+    <h1>Kundenkonto</h1>
+    <?php echo $message; ?>
+        <div class="account-layout">
+            <aside class="account-sidebar shop-category-list">
+                <h2>Hallo <?php echo esc_html($full_name); ?></h2>
+                <ul>
+                    <li>
+                        <a href="#" class="active"><span class="menu-icon">📦</span> Abos</a>
+                    </li>
+                    <li>
+                        <a href="<?php echo esc_url(wp_logout_url(get_permalink())); ?>">
+                            <span class="menu-icon">🚪</span> Logout
+                        </a>
+                    </li>
+                </ul>
+            </aside>
+            <div>
+        <?php if (!empty($subscriptions)) : ?>
+            <?php
+            $order_map = [];
+            foreach ($orders as $o) {
+                $order_map[$o->subscription_id] = $o;
+            }
+            ?>
+            <?php foreach ($subscriptions as $sub) : ?>
+                <?php
+                $order = $order_map[$sub['subscription_id']] ?? null;
+                $product_name = $order->produkt_name ?? $sub['subscription_id'];
+                $start_ts = strtotime($sub['start_date']);
+                $start_formatted = date_i18n('d.m.Y', $start_ts);
+                $laufzeit_in_monaten = 3;
+                if ($order && !empty($order->duration_id)) {
+                    global $wpdb;
+                    $laufzeit_in_monaten = (int) $wpdb->get_var(
+                        $wpdb->prepare(
+                            "SELECT months_minimum FROM {$wpdb->prefix}produkt_durations WHERE id = %d",
+                            $order->duration_id
+                        )
+                    );
+                    if (!$laufzeit_in_monaten) {
+                        $laufzeit_in_monaten = 3; // Fallback
+                    }
+                }
+                $cancelable_ts            = strtotime("+{$laufzeit_in_monaten} months", $start_ts);
+                $kuendigungsfenster_ts    = strtotime('-14 days', $cancelable_ts);
+                $kuendigbar_ab_date       = date_i18n('d.m.Y', $kuendigungsfenster_ts);
+                $cancelable               = time() >= $kuendigungsfenster_ts;
+                $is_extended              = time() > $cancelable_ts;
+
+                $period_end_ts   = null;
+                $period_end_date = '';
+                if (!empty($sub['current_period_end'])) {
+                    $period_end_ts   = strtotime($sub['current_period_end']);
+                    $period_end_date = date_i18n('d.m.Y', $period_end_ts);
+                }
+
+                $image_url = '';
+                if ($order) {
+                    global $wpdb;
+                    if (!empty($order->variant_id)) {
+                        $image_url = $wpdb->get_var(
+                            $wpdb->prepare(
+                                "SELECT image_url_1 FROM {$wpdb->prefix}produkt_variants WHERE id = %d",
+                                $order->variant_id
+                            )
+                        );
+                    }
+
+                    if (empty($image_url) && !empty($order->category_id)) {
+                        $image_url = $wpdb->get_var(
+                            $wpdb->prepare(
+                                "SELECT default_image FROM {$wpdb->prefix}produkt_categories WHERE id = %d",
+                                $order->category_id
+                            )
+                        );
+                    }
+                }
+
+                $address = esc_html(trim($order->customer_street . ', ' . $order->customer_postal . ' ' . $order->customer_city));
+                ?>
+                <?php include PRODUKT_PLUGIN_PATH . 'includes/render-subscription.php'; ?>
+            <?php endforeach; ?>
+        <?php else : ?>
+            <p>Keine aktiven Abos.</p>
+        <?php endif; ?>
+            </div>
+        </div>
+    <?php endif; ?>
+</div>

--- a/views/account/dashboard.php
+++ b/views/account/dashboard.php
@@ -3,13 +3,15 @@
     <div class="login-box">
         <h1>Login</h1>
         <p>Bitte die Email Adresse eingeben die bei Ihrer Bestellung verwendet wurde.</p>
-        <?php echo $message; ?>
+        <?php if (!empty($message)) { echo $message; } ?>
         <form method="post" class="login-email-form">
+            <?php wp_nonce_field('request_login_code_action', 'request_login_code_nonce'); ?>
             <input type="email" name="email" placeholder="Ihre E-Mail" value="<?php echo esc_attr($email_value); ?>" required>
             <button type="submit" name="request_login_code">Code zum einloggen anfordern</button>
         </form>
         <?php if ($show_code_form) : ?>
         <form method="post" class="login-code-form">
+            <?php wp_nonce_field('verify_login_code_action', 'verify_login_code_nonce'); ?>
             <input type="hidden" name="email" value="<?php echo esc_attr($email_value); ?>">
             <input type="text" name="code" placeholder="6-stelliger Code" required>
             <button type="submit" name="verify_login_code">Einloggen</button>
@@ -20,7 +22,7 @@
 <?php else : ?>
 <div class="produkt-account-wrapper produkt-container shop-overview-container">
     <h1>Kundenkonto</h1>
-    <?php echo $message; ?>
+    <?php if (!empty($message)) { echo $message; } ?>
         <div class="account-layout">
             <aside class="account-sidebar shop-category-list">
                 <h2>Hallo <?php echo esc_html($full_name); ?></h2>
@@ -49,19 +51,7 @@
                 $product_name = $order->produkt_name ?? $sub['subscription_id'];
                 $start_ts = strtotime($sub['start_date']);
                 $start_formatted = date_i18n('d.m.Y', $start_ts);
-                $laufzeit_in_monaten = 3;
-                if ($order && !empty($order->duration_id)) {
-                    global $wpdb;
-                    $laufzeit_in_monaten = (int) $wpdb->get_var(
-                        $wpdb->prepare(
-                            "SELECT months_minimum FROM {$wpdb->prefix}produkt_durations WHERE id = %d",
-                            $order->duration_id
-                        )
-                    );
-                    if (!$laufzeit_in_monaten) {
-                        $laufzeit_in_monaten = 3; // Fallback
-                    }
-                }
+                $laufzeit_in_monaten = pv_get_minimum_duration_months($order);
                 $cancelable_ts            = strtotime("+{$laufzeit_in_monaten} months", $start_ts);
                 $kuendigungsfenster_ts    = strtotime('-14 days', $cancelable_ts);
                 $kuendigbar_ab_date       = date_i18n('d.m.Y', $kuendigungsfenster_ts);


### PR DESCRIPTION
## Summary
- move HTML for account page to a dedicated view (`views/account/dashboard.php`)
- initialise `$subscriptions` to an empty array if not set
- calculate user data in `account-page.php` and load the view
- escape the generated address when rendering subscriptions

## Testing
- `php -l templates/account-page.php`
- `php -l views/account/dashboard.php`


------
https://chatgpt.com/codex/tasks/task_b_687d0c22918483308e23e9a86e9716e8