### PR TITLE
Add one-time price field for extras

### DIFF
--- a/admin/calendar-page.php
+++ b/admin/calendar-page.php
@@ -101,6 +101,7 @@ foreach ($orders as $o) {
             $date  = sprintf('%04d-%02d-%02d', $year, $month, $d);
             $cls   = '';
             $title = '';
+            $count = 0;
             if (isset($orders_by_day[$date])) {
                 $count = count($orders_by_day[$date]);
                 if ($count === 1) {
@@ -112,7 +113,12 @@ foreach ($orders as $o) {
                 }
             }
         ?>
-            <div class="calendar-day <?php echo $cls; ?>" data-date="<?php echo $date; ?>"<?php echo $title ? ' title="' . esc_attr($title) . '"' : ''; ?>><?php echo $d; ?></div>
+            <div class="calendar-day <?php echo $cls; ?>" data-date="<?php echo $date; ?>"<?php echo $title ? ' title="' . esc_attr($title) . '"' : ''; ?>>
+                <?php echo $d; ?>
+                <?php if ($count > 1): ?>
+                    <span class="booking-count"><?php echo $count; ?></span>
+                <?php endif; ?>
+            </div>
         <?php endfor; ?>
     </div>
 </div>
@@ -131,6 +137,7 @@ foreach ($orders as $o) {
     border-radius:4px;
     min-height:40px;
     border:1px solid #ddd;
+    position:relative;
 }
 #produkt-admin-calendar .booked-open{
     background:#fff3cd;
@@ -140,6 +147,18 @@ foreach ($orders as $o) {
 }
 #produkt-admin-calendar .booked-multiple{
     background:#f8d7da;
+}
+#produkt-admin-calendar .booking-count{
+    position:absolute;
+    right:2px;
+    bottom:2px;
+    font-size:12px;
+    background:#dc3545;
+    color:#fff;
+    border-radius:50%;
+    padding:1px 4px;
+    min-width:16px;
+    line-height:1.2;
 }
 </style>
 

--- a/admin/calendar-page.php
+++ b/admin/calendar-page.php
@@ -149,11 +149,12 @@ foreach ($orders as $o) {
 #produkt-admin-calendar .day-name,
 #produkt-admin-calendar .calendar-day{
     text-align:center;
-    padding:8px;
+    padding:18px;
     border-radius:4px;
-    min-height:40px;
+    min-height:60px;
     border:1px solid #ddd;
     position:relative;
+    background-color:#fff;
 }
 #produkt-admin-calendar .booked-open{
     background:#fff3cd;

--- a/admin/calendar-page.php
+++ b/admin/calendar-page.php
@@ -98,13 +98,21 @@ foreach ($orders as $o) {
             <div class="empty"></div>
         <?php endfor; ?>
         <?php for ($d=1; $d<=$last_day; $d++):
-            $date = sprintf('%04d-%02d-%02d', $year, $month, $d);
-            $cls = '';
-            if (isset($booked[$date])) {
-                $cls = $booked[$date] === 'completed' ? 'booked-completed' : 'booked-open';
+            $date  = sprintf('%04d-%02d-%02d', $year, $month, $d);
+            $cls   = '';
+            $title = '';
+            if (isset($orders_by_day[$date])) {
+                $count = count($orders_by_day[$date]);
+                if ($count === 1) {
+                    $status = $orders_by_day[$date][0]->status === 'abgeschlossen' ? 'completed' : 'open';
+                    $cls    = $status === 'open' ? 'booked-open' : 'booked-completed';
+                } elseif ($count > 1) {
+                    $cls   = 'booked-multiple';
+                    $title = $count . ' Buchungen';
+                }
             }
         ?>
-            <div class="calendar-day <?php echo $cls; ?>" data-date="<?php echo $date; ?>"><?php echo $d; ?></div>
+            <div class="calendar-day <?php echo $cls; ?>" data-date="<?php echo $date; ?>"<?php echo $title ? ' title="' . esc_attr($title) . '"' : ''; ?>><?php echo $d; ?></div>
         <?php endfor; ?>
     </div>
 </div>
@@ -129,6 +137,9 @@ foreach ($orders as $o) {
 }
 #produkt-admin-calendar .booked-completed{
     background:#d4edda;
+}
+#produkt-admin-calendar .booked-multiple{
+    background:#f8d7da;
 }
 </style>
 

--- a/admin/calendar-page.php
+++ b/admin/calendar-page.php
@@ -3,6 +3,8 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+global $wpdb;
+
 $monthNames = ['Januar','Februar','März','April','Mai','Juni','Juli','August','September','Oktober','November','Dezember'];
 $dayNames   = ['Mo','Di','Mi','Do','Fr','Sa','So'];
 

--- a/admin/calendar-page.php
+++ b/admin/calendar-page.php
@@ -1,0 +1,101 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$monthNames = ['Januar','Februar','März','April','Mai','Juni','Juli','August','September','Oktober','November','Dezember'];
+$dayNames   = ['Mo','Di','Mi','Do','Fr','Sa','So'];
+
+$year  = isset($_GET['year']) ? intval($_GET['year']) : intval(date('Y'));
+$month = isset($_GET['month']) ? intval($_GET['month']) : intval(date('n'));
+if ($month < 1) { $month = 1; } elseif ($month > 12) { $month = 12; }
+
+$prev_month = $month - 1;
+$prev_year  = $year;
+if ($prev_month < 1) { $prev_month = 12; $prev_year--; }
+$next_month = $month + 1;
+$next_year  = $year;
+if ($next_month > 12) { $next_month = 1; $next_year++; }
+
+$first_day_ts = strtotime(sprintf('%04d-%02d-01', $year, $month));
+$last_day      = intval(date('t', $first_day_ts));
+$start_index   = (int)date('N', $first_day_ts) - 1; // 0=Mo
+
+// collect booking days per status
+$booked = [];
+$orders = $wpdb->get_results("SELECT dauer_text, status FROM {$wpdb->prefix}produkt_orders WHERE mode = 'kauf'");
+foreach ($orders as $o) {
+    if (preg_match('/(\d{4}-\d{2}-\d{2})\s*-\s*(\d{4}-\d{2}-\d{2})/', $o->dauer_text, $m)) {
+        $start = strtotime($m[1]);
+        $end   = strtotime($m[2]);
+        while ($start <= $end) {
+            $d = date('Y-m-d', $start);
+            $status = ($o->status === 'abgeschlossen') ? 'completed' : 'open';
+            if (!isset($booked[$d]) || $booked[$d] !== 'open') {
+                $booked[$d] = $status;
+            }
+            if ($status === 'open') {
+                $booked[$d] = 'open';
+            }
+            $start = strtotime('+1 day', $start);
+        }
+    }
+}
+?>
+
+<div class="wrap" id="produkt-admin-calendar">
+    <div class="produkt-admin-header">
+        <div class="produkt-admin-logo">📅</div>
+        <div class="produkt-admin-title">
+            <h1>Kalender</h1>
+            <p>Übersicht der Verkaufstage</p>
+        </div>
+    </div>
+
+    <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:20px;">
+        <a class="button" href="<?php echo admin_url('admin.php?page=produkt-calendar&month=' . $prev_month . '&year=' . $prev_year); ?>">&laquo; <?php echo $monthNames[$prev_month-1]; ?></a>
+        <h2 style="margin:0;"><?php echo $monthNames[$month-1] . ' ' . $year; ?></h2>
+        <a class="button" href="<?php echo admin_url('admin.php?page=produkt-calendar&month=' . $next_month . '&year=' . $next_year); ?>"><?php echo $monthNames[$next_month-1]; ?> &raquo;</a>
+    </div>
+
+    <div class="calendar-grid">
+        <?php foreach ($dayNames as $dn): ?>
+            <div class="day-name"><?php echo esc_html($dn); ?></div>
+        <?php endforeach; ?>
+        <?php for ($i=0; $i<$start_index; $i++): ?>
+            <div class="empty"></div>
+        <?php endfor; ?>
+        <?php for ($d=1; $d<=$last_day; $d++):
+            $date = sprintf('%04d-%02d-%02d', $year, $month, $d);
+            $cls = '';
+            if (isset($booked[$date])) {
+                $cls = $booked[$date] === 'completed' ? 'booked-completed' : 'booked-open';
+            }
+        ?>
+            <div class="calendar-day <?php echo $cls; ?>"><?php echo $d; ?></div>
+        <?php endfor; ?>
+    </div>
+</div>
+
+<style>
+#produkt-admin-calendar .calendar-grid{
+    display:grid;
+    grid-template-columns:repeat(7,1fr);
+    gap:6px;
+    font-size:16px;
+}
+#produkt-admin-calendar .day-name,
+#produkt-admin-calendar .calendar-day{
+    text-align:center;
+    padding:8px;
+    border-radius:4px;
+    min-height:40px;
+    border:1px solid #ddd;
+}
+#produkt-admin-calendar .booked-open{
+    background:#fff3cd;
+}
+#produkt-admin-calendar .booked-completed{
+    background:#d4edda;
+}
+</style>

--- a/admin/extras-page.php
+++ b/admin/extras-page.php
@@ -54,7 +54,8 @@ if (isset($_POST['submit'])) {
     $modus       = get_option('produkt_betriebsmodus', 'miete');
     $sale_price  = isset($_POST['sale_price']) ? floatval($_POST['sale_price']) : 0;
     $price       = isset($_POST['price']) ? floatval($_POST['price']) : 0;
-    $stripe_price = $modus === 'kauf' ? $sale_price : $price;
+    $price_input = $modus === 'kauf' ? ($_POST['sale_price'] ?? '') : ($_POST['price'] ?? '');
+    $stripe_price = floatval($price_input);
     $image_url = esc_url_raw($_POST['image_url']);
     $active = isset($_POST['active']) ? 1 : 0;
     $sort_order = intval($_POST['sort_order']);

--- a/admin/extras-page.php
+++ b/admin/extras-page.php
@@ -104,11 +104,16 @@ if (isset($_POST['submit'])) {
                 }
             } else {
                 $res = \ProduktVerleih\StripeService::create_extra_price($extra_base_name, $stripe_price, $main_product_name, $modus);
-                if (!is_wp_error($res)) {
+                if (is_wp_error($res)) {
+                    error_log('❌ Fehler beim Stripe Extra-Preis: ' . $res->get_error_message());
+                } elseif (!empty($res['price_id'])) {
+                    error_log('✅ Extra-Preis erfolgreich erstellt: ' . $res['price_id']);
                     $wpdb->update($table_name, [
                         'stripe_product_id' => $res['product_id'],
                         'stripe_price_id'   => $res['price_id'],
                     ], ['id' => $extra_id]);
+                } else {
+                    error_log('⚠️ Keine Fehler, aber auch kein Preis erstellt.');
                 }
             }
         } else {
@@ -133,11 +138,16 @@ if (isset($_POST['submit'])) {
             $extra_id = $wpdb->insert_id;
             echo '<div class="notice notice-success"><p>✅ Extra erfolgreich hinzugefügt!</p></div>';
             $res = \ProduktVerleih\StripeService::create_extra_price($extra_base_name, $stripe_price, $main_product_name, $modus);
-            if (!is_wp_error($res)) {
+            if (is_wp_error($res)) {
+                error_log('❌ Fehler beim Stripe Extra-Preis: ' . $res->get_error_message());
+            } elseif (!empty($res['price_id'])) {
+                error_log('✅ Extra-Preis erfolgreich erstellt: ' . $res['price_id']);
                 $wpdb->update($table_name, [
                     'stripe_product_id' => $res['product_id'],
                     'stripe_price_id'   => $res['price_id'],
                 ], ['id' => $extra_id]);
+            } else {
+                error_log('⚠️ Keine Fehler, aber auch kein Preis erstellt.');
             }
         } else {
             echo '<div class="notice notice-error"><p>❌ Fehler beim Hinzufügen: ' . esc_html($wpdb->last_error) . '</p></div>';

--- a/admin/extras-page.php
+++ b/admin/extras-page.php
@@ -52,8 +52,9 @@ if (isset($_POST['submit'])) {
     $category_id = intval($_POST['category_id']);
     $name        = sanitize_text_field($_POST['name']);
     $modus       = get_option('produkt_betriebsmodus', 'miete');
-    $price_input = $modus === 'kauf' ? ($_POST['sale_price'] ?? '') : ($_POST['price'] ?? '');
-    $price       = floatval($price_input);
+    $sale_price  = isset($_POST['sale_price']) ? floatval($_POST['sale_price']) : 0;
+    $price       = isset($_POST['price']) ? floatval($_POST['price']) : 0;
+    $stripe_price = $modus === 'kauf' ? $sale_price : $price;
     $image_url = esc_url_raw($_POST['image_url']);
     $active = isset($_POST['active']) ? 1 : 0;
     $sort_order = intval($_POST['sort_order']);
@@ -96,12 +97,12 @@ if (isset($_POST['submit'])) {
             $ids = $wpdb->get_row($wpdb->prepare("SELECT stripe_product_id FROM $table_name WHERE id = %d", $extra_id));
             if ($ids && $ids->stripe_product_id) {
                 \ProduktVerleih\StripeService::update_product_name($ids->stripe_product_id, $stripe_product_name);
-                $new_price = \ProduktVerleih\StripeService::create_price($ids->stripe_product_id, round($price * 100), $modus);
+                $new_price = \ProduktVerleih\StripeService::create_price($ids->stripe_product_id, round($stripe_price * 100), $modus);
                 if (!is_wp_error($new_price)) {
                     $wpdb->update($table_name, ['stripe_price_id' => $new_price->id], ['id' => $extra_id], ['%s'], ['%d']);
                 }
             } else {
-                $res = \ProduktVerleih\StripeService::create_extra_price($extra_base_name, $price, $main_product_name, $modus);
+                $res = \ProduktVerleih\StripeService::create_extra_price($extra_base_name, $stripe_price, $main_product_name, $modus);
                 if (!is_wp_error($res)) {
                     $wpdb->update($table_name, [
                         'stripe_product_id' => $res['product_id'],
@@ -130,7 +131,7 @@ if (isset($_POST['submit'])) {
         if ($result !== false) {
             $extra_id = $wpdb->insert_id;
             echo '<div class="notice notice-success"><p>✅ Extra erfolgreich hinzugefügt!</p></div>';
-            $res = \ProduktVerleih\StripeService::create_extra_price($extra_base_name, $price, $main_product_name, $modus);
+            $res = \ProduktVerleih\StripeService::create_extra_price($extra_base_name, $stripe_price, $main_product_name, $modus);
             if (!is_wp_error($res)) {
                 $wpdb->update($table_name, [
                     'stripe_product_id' => $res['product_id'],

--- a/admin/tabs/extras-add-tab.php
+++ b/admin/tabs/extras-add-tab.php
@@ -15,15 +15,22 @@
         <!-- Grunddaten -->
         <div class="produkt-form-section">
             <h4>📝 Grunddaten</h4>
+            <?php $modus = get_option('produkt_betriebsmodus', 'miete'); ?>
             <div class="produkt-form-row">
                 <div class="produkt-form-group">
                     <label>Name *</label>
                     <input type="text" name="name" required placeholder="z.B. Himmel, Zubehör-Set">
                 </div>
                 <div class="produkt-form-group">
-                    <label>Preis (EUR) *</label>
-                    <input type="number" step="0.01" name="price" placeholder="0.00" required>
+                    <label>Preis (EUR)<?php echo $modus === 'kauf' ? '' : ' *'; ?></label>
+                    <input type="number" step="0.01" name="price" placeholder="0.00" <?php echo $modus === 'kauf' ? '' : 'required'; ?>>
                 </div>
+                <?php if ($modus === 'kauf'): ?>
+                <div class="produkt-form-group">
+                    <label>Einmalpreis (EUR) *</label>
+                    <input type="number" step="0.01" name="sale_price" placeholder="0.00" required>
+                </div>
+                <?php endif; ?>
             </div>
         </div>
         

--- a/admin/tabs/extras-edit-tab.php
+++ b/admin/tabs/extras-edit-tab.php
@@ -17,11 +17,11 @@
         <div class="produkt-form-section">
             <h4>📝 Grunddaten</h4>
             <?php $modus = get_option('produkt_betriebsmodus', 'miete');
-                  $sale_price = 0;
+                  $sale_price = '';
                   if ($modus === 'kauf' && !empty($edit_item->stripe_price_id_sale)) {
                       $p = \ProduktVerleih\StripeService::get_price_amount($edit_item->stripe_price_id_sale);
                       if (!is_wp_error($p)) {
-                          $sale_price = $p;
+                          $sale_price = number_format((float) $p, 2, ',', '.');
                       }
                   }
             ?>
@@ -32,7 +32,8 @@
                 </div>
                 <div class="produkt-form-group">
                     <label>Preis (EUR)<?php echo $modus === 'kauf' ? '' : ' *'; ?></label>
-                    <input type="number" step="0.01" name="price" value="<?php echo esc_attr($edit_item->price); ?>" <?php echo $modus === 'kauf' ? '' : 'required'; ?>>
+                    <?php $price_value = $edit_item->price !== '' ? number_format((float) $edit_item->price, 2, ',', '.') : ''; ?>
+                    <input type="number" step="0.01" name="price" value="<?php echo esc_attr($price_value); ?>" <?php echo $modus === 'kauf' ? '' : 'required'; ?>>
                 </div>
                 <?php if ($modus === 'kauf'): ?>
                 <div class="produkt-form-group">

--- a/admin/tabs/extras-edit-tab.php
+++ b/admin/tabs/extras-edit-tab.php
@@ -16,15 +16,22 @@
         <!-- Grunddaten -->
         <div class="produkt-form-section">
             <h4>📝 Grunddaten</h4>
+            <?php $modus = get_option('produkt_betriebsmodus', 'miete'); ?>
             <div class="produkt-form-row">
                 <div class="produkt-form-group">
                     <label>Name *</label>
                     <input type="text" name="name" value="<?php echo esc_attr($edit_item->name); ?>" required>
                 </div>
                 <div class="produkt-form-group">
-                    <label>Preis (EUR) *</label>
-                    <input type="number" step="0.01" name="price" value="<?php echo esc_attr($edit_item->price); ?>" required>
+                    <label>Preis (EUR)<?php echo $modus === 'kauf' ? '' : ' *'; ?></label>
+                    <input type="number" step="0.01" name="price" value="<?php echo esc_attr($edit_item->price); ?>" <?php echo $modus === 'kauf' ? '' : 'required'; ?>>
                 </div>
+                <?php if ($modus === 'kauf'): ?>
+                <div class="produkt-form-group">
+                    <label>Einmalpreis (EUR) *</label>
+                    <input type="number" step="0.01" name="sale_price" value="<?php echo esc_attr($edit_item->price); ?>" required>
+                </div>
+                <?php endif; ?>
             </div>
         </div>
         

--- a/admin/tabs/extras-edit-tab.php
+++ b/admin/tabs/extras-edit-tab.php
@@ -16,8 +16,20 @@
         <!-- Grunddaten -->
         <div class="produkt-form-section">
             <h4>📝 Grunddaten</h4>
-            <?php $modus = get_option('produkt_betriebsmodus', 'miete');
-                  $sale_price = '';
+            <?php
+                  $modus       = get_option('produkt_betriebsmodus', 'miete');
+                  $sale_price  = '';
+                  $price_value = '';
+
+                  if (!empty($edit_item->stripe_price_id_rent)) {
+                      $p = \ProduktVerleih\StripeService::get_price_amount($edit_item->stripe_price_id_rent);
+                      if (!is_wp_error($p)) {
+                          $price_value = number_format((float) $p, 2, ',', '.');
+                      }
+                  } elseif ($edit_item->price !== '') {
+                      $price_value = number_format((float) $edit_item->price, 2, ',', '.');
+                  }
+
                   if ($modus === 'kauf' && !empty($edit_item->stripe_price_id_sale)) {
                       $p = \ProduktVerleih\StripeService::get_price_amount($edit_item->stripe_price_id_sale);
                       if (!is_wp_error($p)) {
@@ -32,7 +44,6 @@
                 </div>
                 <div class="produkt-form-group">
                     <label>Preis (EUR)<?php echo $modus === 'kauf' ? '' : ' *'; ?></label>
-                    <?php $price_value = $edit_item->price !== '' ? number_format((float) $edit_item->price, 2, ',', '.') : ''; ?>
                     <input type="number" step="0.01" name="price" value="<?php echo esc_attr($price_value); ?>" <?php echo $modus === 'kauf' ? '' : 'required'; ?>>
                 </div>
                 <?php if ($modus === 'kauf'): ?>

--- a/admin/tabs/extras-edit-tab.php
+++ b/admin/tabs/extras-edit-tab.php
@@ -16,7 +16,15 @@
         <!-- Grunddaten -->
         <div class="produkt-form-section">
             <h4>📝 Grunddaten</h4>
-            <?php $modus = get_option('produkt_betriebsmodus', 'miete'); ?>
+            <?php $modus = get_option('produkt_betriebsmodus', 'miete');
+                  $sale_price = 0;
+                  if ($modus === 'kauf' && !empty($edit_item->stripe_price_id)) {
+                      $p = \ProduktVerleih\StripeService::get_price_amount($edit_item->stripe_price_id);
+                      if (!is_wp_error($p)) {
+                          $sale_price = $p;
+                      }
+                  }
+            ?>
             <div class="produkt-form-row">
                 <div class="produkt-form-group">
                     <label>Name *</label>
@@ -29,7 +37,7 @@
                 <?php if ($modus === 'kauf'): ?>
                 <div class="produkt-form-group">
                     <label>Einmalpreis (EUR) *</label>
-                    <input type="number" step="0.01" name="sale_price" value="<?php echo esc_attr($edit_item->price); ?>" required>
+                    <input type="number" step="0.01" name="sale_price" value="<?php echo esc_attr($sale_price); ?>" required>
                 </div>
                 <?php endif; ?>
             </div>

--- a/admin/tabs/extras-edit-tab.php
+++ b/admin/tabs/extras-edit-tab.php
@@ -18,8 +18,8 @@
             <h4>📝 Grunddaten</h4>
             <?php $modus = get_option('produkt_betriebsmodus', 'miete');
                   $sale_price = 0;
-                  if ($modus === 'kauf' && !empty($edit_item->stripe_price_id)) {
-                      $p = \ProduktVerleih\StripeService::get_price_amount($edit_item->stripe_price_id);
+                  if ($modus === 'kauf' && !empty($edit_item->stripe_price_id_sale)) {
+                      $p = \ProduktVerleih\StripeService::get_price_amount($edit_item->stripe_price_id_sale);
                       if (!is_wp_error($p)) {
                           $sale_price = $p;
                       }

--- a/admin/tabs/extras-list-tab.php
+++ b/admin/tabs/extras-list-tab.php
@@ -51,11 +51,15 @@
                 <div class="produkt-extra-meta">
                     <div class="produkt-extra-price">
                         <?php
-                        $display_price = $extra->price;
+                        $modus = get_option('produkt_betriebsmodus', 'miete');
+                        $display_price = ($modus === 'kauf') ? 0 : $extra->price;
                         $missing_price = false;
-                        if (!empty($extra->stripe_price_id)) {
-                            if (\ProduktVerleih\StripeService::price_exists($extra->stripe_price_id)) {
-                                $p = \ProduktVerleih\StripeService::get_price_amount($extra->stripe_price_id);
+
+                        $price_col = $modus === 'kauf' ? ($extra->stripe_price_id_sale ?? '') : ($extra->stripe_price_id_rent ?? '');
+
+                        if (!empty($price_col)) {
+                            if (\ProduktVerleih\StripeService::price_exists($price_col)) {
+                                $p = \ProduktVerleih\StripeService::get_price_amount($price_col);
                                 if (!is_wp_error($p)) {
                                     $display_price = $p;
                                 }
@@ -63,6 +67,7 @@
                                 $missing_price = true;
                             }
                         }
+
                         if ($display_price > 0) {
                             echo '<strong>' . number_format($display_price, 2, ',', '.') . "€</strong>";
                         }

--- a/admin/tabs/extras-tab.php
+++ b/admin/tabs/extras-tab.php
@@ -71,11 +71,16 @@ if (isset($_POST['submit_extra'])) {
                 }
             } else {
                 $res = \ProduktVerleih\StripeService::create_extra_price($extra_base_name, $stripe_price, $main_product_name, $modus);
-                if (!is_wp_error($res)) {
+                if (is_wp_error($res)) {
+                    error_log('❌ Fehler beim Stripe Extra-Preis: ' . $res->get_error_message());
+                } elseif (!empty($res['price_id'])) {
+                    error_log('✅ Extra-Preis erfolgreich erstellt: ' . $res['price_id']);
                     $wpdb->update($table_name, [
                         'stripe_product_id' => $res['product_id'],
                         'stripe_price_id'   => $res['price_id'],
                     ], ['id' => $extra_id]);
+                } else {
+                    error_log('⚠️ Keine Fehler, aber auch kein Preis erstellt.');
                 }
             }
         }
@@ -98,11 +103,16 @@ if (isset($_POST['submit_extra'])) {
             echo '<div class="notice notice-success"><p>✅ Extra erfolgreich hinzugefügt!</p></div>';
             $mode         = get_option('produkt_betriebsmodus', 'miete');
             $res = \ProduktVerleih\StripeService::create_extra_price($extra_base_name, $stripe_price, $main_product_name, $modus);
-            if (!is_wp_error($res)) {
+            if (is_wp_error($res)) {
+                error_log('❌ Fehler beim Stripe Extra-Preis: ' . $res->get_error_message());
+            } elseif (!empty($res['price_id'])) {
+                error_log('✅ Extra-Preis erfolgreich erstellt: ' . $res['price_id']);
                 $wpdb->update($table_name, [
                     'stripe_product_id' => $res['product_id'],
                     'stripe_price_id'   => $res['price_id'],
                 ], ['id' => $extra_id]);
+            } else {
+                error_log('⚠️ Keine Fehler, aber auch kein Preis erstellt.');
             }
         }
     }

--- a/admin/tabs/extras-tab.php
+++ b/admin/tabs/extras-tab.php
@@ -21,7 +21,8 @@ if (isset($_POST['submit_extra'])) {
     $modus       = get_option('produkt_betriebsmodus', 'miete');
     $sale_price  = isset($_POST['sale_price']) ? floatval($_POST['sale_price']) : 0;
     $price       = isset($_POST['price']) ? floatval($_POST['price']) : 0;
-    $stripe_price = $modus === 'kauf' ? $sale_price : $price;
+    $price_input = $modus === 'kauf' ? ($_POST['sale_price'] ?? '') : ($_POST['price'] ?? '');
+    $stripe_price = floatval($price_input);
     $image_url   = esc_url_raw($_POST['image_url']);
     $sort_order  = intval($_POST['sort_order']);
 

--- a/admin/tabs/extras-tab.php
+++ b/admin/tabs/extras-tab.php
@@ -190,8 +190,20 @@ $extras = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE cat
                 <h4>Neues Extra hinzufügen</h4>
             <?php endif; ?>
             
-            <?php $modus = get_option('produkt_betriebsmodus', 'miete');
-                  $sale_price = '';
+            <?php
+                  $modus       = get_option('produkt_betriebsmodus', 'miete');
+                  $sale_price  = '';
+                  $price_value = '';
+
+                  if ($edit_item && !empty($edit_item->stripe_price_id_rent)) {
+                      $p = \ProduktVerleih\StripeService::get_price_amount($edit_item->stripe_price_id_rent);
+                      if (!is_wp_error($p)) {
+                          $price_value = number_format((float) $p, 2, ',', '.');
+                      }
+                  } elseif ($edit_item && $edit_item->price !== '') {
+                      $price_value = number_format((float) $edit_item->price, 2, ',', '.');
+                  }
+
                   if ($modus === 'kauf' && $edit_item && !empty($edit_item->stripe_price_id_sale)) {
                       $p = \ProduktVerleih\StripeService::get_price_amount($edit_item->stripe_price_id_sale);
                       if (!is_wp_error($p)) {
@@ -207,12 +219,6 @@ $extras = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE cat
 
                 <div class="produkt-form-group">
                     <label>Preis (EUR)<?php echo $modus === 'kauf' ? '' : ' *'; ?></label>
-                    <?php
-                    $price_value = '';
-                    if ($edit_item && $edit_item->price !== '') {
-                        $price_value = number_format((float) $edit_item->price, 2, ',', '.');
-                    }
-                    ?>
                     <input type="number" step="0.01" name="price" value="<?php echo esc_attr($price_value); ?>" placeholder="0.00" <?php echo $modus === 'kauf' ? '' : 'required'; ?>>
                 </div>
                 <?php if ($modus === 'kauf'): ?>

--- a/admin/tabs/variants-list-tab.php
+++ b/admin/tabs/variants-list-tab.php
@@ -1,5 +1,6 @@
 <?php
 // Variants List Tab Content
+$modus = get_option('produkt_betriebsmodus', 'miete');
 ?>
 
 <div class="produkt-variants-list">
@@ -85,14 +86,16 @@
                             }
                         }
                     ?>
+                    <?php if ($modus !== 'kauf'): ?>
                     <div class="produkt-variant-price">
                         <strong><?php echo number_format($price, 2, ',', '.'); ?>€</strong>
                         <small>/Monat</small>
                     </div>
+                    <?php else: ?>
                     <div class="produkt-variant-sale-price">
                         <strong><?php echo number_format($variant->verkaufspreis_einmalig, 2, ',', '.'); ?>€</strong>
-                        <small>einmalig</small>
                     </div>
+                    <?php endif; ?>
                     <?php if ($missing_price): ?>
                         <span class="badge badge-warning">Preis fehlt bei Stripe</span>
                     <?php endif; ?>

--- a/assets/admin-style.css
+++ b/assets/admin-style.css
@@ -1932,7 +1932,7 @@
 }
 
 .produkt-variant-sale-price strong {
-    color: var(--produkt-secondary);
+    color: #2a372a;
     font-size: 1.2rem;
 }
 

--- a/assets/script.js
+++ b/assets/script.js
@@ -898,6 +898,7 @@ jQuery(document).ready(function($) {
             today.setHours(0,0,0,0);
             let cls = 'calendar-day';
             if (cellDate < today) cls += ' disabled';
+            if (Array.isArray(produkt_ajax.blocked_days) && produkt_ajax.blocked_days.includes(dateStr)) cls += ' disabled blocked';
             if (startDate === dateStr) cls += ' start';
             if (endDate === dateStr) cls += ' end';
             if (startDate && endDate && cellDate > new Date(startDate) && cellDate < new Date(endDate)) cls += ' in-range';

--- a/assets/script.js
+++ b/assets/script.js
@@ -918,6 +918,7 @@ jQuery(document).ready(function($) {
     });
     $(document).on('click', '#booking-calendar .calendar-day:not(.disabled)', function(){
         const dateStr = $(this).data('date');
+
         if (!startDate || (startDate && endDate)) {
             startDate = dateStr;
             endDate = null;
@@ -925,8 +926,30 @@ jQuery(document).ready(function($) {
             startDate = dateStr;
             endDate = null;
         } else {
-            endDate = dateStr;
+            // check for blocked days between startDate and selected end date
+            let s = new Date(startDate);
+            let e = new Date(dateStr);
+            let hasBlocked = false;
+            if (Array.isArray(produkt_ajax.blocked_days)) {
+                let d = new Date(s.getTime());
+                while (d <= e) {
+                    const ds = d.getFullYear() + '-' + String(d.getMonth()+1).padStart(2,'0') + '-' + String(d.getDate()).padStart(2,'0');
+                    if (produkt_ajax.blocked_days.includes(ds)) {
+                        hasBlocked = true;
+                        break;
+                    }
+                    d.setDate(d.getDate() + 1);
+                }
+            }
+
+            if (hasBlocked) {
+                startDate = dateStr;
+                endDate = null;
+            } else {
+                endDate = dateStr;
+            }
         }
+
         renderCalendar(calendarMonth);
         updateSelectedDays();
         updatePriceAndButton();

--- a/assets/style.css
+++ b/assets/style.css
@@ -2079,6 +2079,17 @@ body.shop-filter-open {
     color: #ccc;
     cursor: not-allowed;
 }
+#booking-calendar .calendar-day.blocked {
+    position: relative;
+}
+#booking-calendar .calendar-day.blocked::after {
+    content: '✖';
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    font-size: 10px;
+    color: #dc3545;
+}
 
 #booking-calendar .calendar-day.start,
 #booking-calendar .calendar-day.end {

--- a/assets/style.css
+++ b/assets/style.css
@@ -2081,6 +2081,8 @@ body.shop-filter-open {
 }
 #booking-calendar .calendar-day.blocked {
     position: relative;
+    background: #eee;
+    color: #999;
 }
 #booking-calendar .calendar-day.blocked::after {
     content: '✖';

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -306,6 +306,7 @@ class Admin {
 
         if ($load_script) {
             $modus = get_option('produkt_betriebsmodus', 'miete');
+            $blocked_days = $wpdb->get_col("SELECT day FROM {$wpdb->prefix}produkt_blocked_days");
             wp_localize_script('produkt-script', 'produkt_ajax', [
                 'ajax_url' => admin_url('admin-ajax.php'),
                 'nonce' => wp_create_nonce('produkt_nonce'),
@@ -315,6 +316,7 @@ class Admin {
                 'price_label' => $category->price_label ?? ($modus === 'kauf' ? 'Einmaliger Kaufpreis' : 'Monatlicher Mietpreis'),
                 'vat_included' => isset($category->vat_included) ? intval($category->vat_included) : 0,
                 'betriebsmodus' => $modus,
+                'blocked_days' => $blocked_days,
                 'popup_settings' => [
                     'enabled' => $popup_enabled,
                     'days'    => $popup_days,

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -122,6 +122,17 @@ class Admin {
             array($this, 'orders_page')
         );
 
+        if ($is_sale) {
+            add_submenu_page(
+                'produkt-verleih',
+                'Kalender',
+                'Kalender',
+                'manage_options',
+                'produkt-calendar',
+                array($this, 'calendar_page')
+            );
+        }
+
         // Global shipping settings
         add_submenu_page(
             'produkt-verleih',
@@ -932,6 +943,9 @@ class Admin {
         include PRODUKT_PLUGIN_PATH . 'admin/filters-page.php';
     }
 
+    public function calendar_page() {
+        include PRODUKT_PLUGIN_PATH . 'admin/calendar-page.php';
+    }
 
     public function settings_page() {
         include PRODUKT_PLUGIN_PATH . 'admin/settings-page.php';

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -88,8 +88,9 @@ class Ajax {
 
             $extras_price = 0;
             foreach ($extras as $ex) {
-                if (!empty($ex->stripe_price_id)) {
-                    $pr = StripeService::get_price_amount($ex->stripe_price_id);
+                $pid = ($modus === 'kauf') ? ($ex->stripe_price_id_sale ?? '') : ($ex->stripe_price_id_rent ?? $ex->stripe_price_id);
+                if (!empty($pid)) {
+                    $pr = StripeService::get_price_amount($pid);
                     if (is_wp_error($pr)) {
                         wp_send_json_error('Price fetch failed');
                     }
@@ -210,8 +211,10 @@ class Ajax {
     
     public function ajax_get_variant_options() {
         check_ajax_referer('produkt_nonce', 'nonce');
-        
+
         $variant_id = intval($_POST['variant_id']);
+
+        $modus = get_option('produkt_betriebsmodus', 'miete');
         
         global $wpdb;
         

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -1382,3 +1382,30 @@ function produkt_get_checkout_session_status() {
         wp_send_json_error(['message' => $e->getMessage()]);
     }
 }
+
+add_action('wp_ajax_produkt_block_day', __NAMESPACE__ . '\\produkt_block_day');
+add_action('wp_ajax_produkt_unblock_day', __NAMESPACE__ . '\\produkt_unblock_day');
+
+function produkt_block_day() {
+    check_ajax_referer('produkt_nonce', 'nonce');
+    $date = sanitize_text_field($_POST['date'] ?? '');
+    if (!$date) {
+        wp_send_json_error('no date');
+    }
+    global $wpdb;
+    $table = $wpdb->prefix . 'produkt_blocked_days';
+    $wpdb->replace($table, ['day' => $date], ['%s']);
+    wp_send_json_success();
+}
+
+function produkt_unblock_day() {
+    check_ajax_referer('produkt_nonce', 'nonce');
+    $date = sanitize_text_field($_POST['date'] ?? '');
+    if (!$date) {
+        wp_send_json_error('no date');
+    }
+    global $wpdb;
+    $table = $wpdb->prefix . 'produkt_blocked_days';
+    $wpdb->delete($table, ['day' => $date], ['%s']);
+    wp_send_json_success();
+}

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -1134,7 +1134,10 @@ function produkt_create_checkout_session() {
                 'produktfarbe_text'=> $metadata['produktfarbe'],
                 'gestellfarbe_text'=> $metadata['gestellfarbe'],
                 'extra_text'       => $metadata['extra'],
-                'dauer_text'       => $metadata['dauer_name'],
+                'dauer_text'       => $modus === 'kauf' && empty($metadata['dauer_name'])
+                    ? ($days . ' Tag' . ($days > 1 ? 'e' : '')
+                        . ($start_date && $end_date ? ' (' . $start_date . ' - ' . $end_date . ')' : ''))
+                    : $metadata['dauer_name'],
                 'customer_name'    => '',
                 'customer_email'   => $customer_email,
                 'user_ip'          => $_SERVER['REMOTE_ADDR'] ?? '',
@@ -1308,7 +1311,10 @@ function produkt_create_embedded_checkout_session() {
                 'produktfarbe_text'=> $metadata['produktfarbe'],
                 'gestellfarbe_text'=> $metadata['gestellfarbe'],
                 'extra_text'       => $metadata['extra'],
-                'dauer_text'       => $metadata['dauer_name'],
+                'dauer_text'       => $modus === 'kauf' && empty($metadata['dauer_name'])
+                    ? ($days . ' Tag' . ($days > 1 ? 'e' : '')
+                        . ($start_date && $end_date ? ' (' . $start_date . ' - ' . $end_date . ')' : ''))
+                    : $metadata['dauer_name'],
                 'customer_name'    => '',
                 'customer_email'   => $customer_email,
                 'user_ip'          => $_SERVER['REMOTE_ADDR'] ?? '',

--- a/includes/Database.php
+++ b/includes/Database.php
@@ -103,6 +103,16 @@ class Database {
             $after = $product_id_exists ? 'stripe_product_id' : 'name';
             $wpdb->query("ALTER TABLE $table_extras ADD COLUMN stripe_price_id VARCHAR(255) DEFAULT NULL AFTER $after");
         }
+        $rent_id_exists = $wpdb->get_results("SHOW COLUMNS FROM $table_extras LIKE 'stripe_price_id_rent'");
+        if (empty($rent_id_exists)) {
+            $after = !empty($price_id_exists) ? 'stripe_price_id' : ($product_id_exists ? 'stripe_product_id' : 'name');
+            $wpdb->query("ALTER TABLE $table_extras ADD COLUMN stripe_price_id_rent VARCHAR(255) DEFAULT NULL AFTER $after");
+        }
+        $sale_id_exists = $wpdb->get_results("SHOW COLUMNS FROM $table_extras LIKE 'stripe_price_id_sale'");
+        if (empty($sale_id_exists)) {
+            $after = !empty($rent_id_exists) ? 'stripe_price_id_rent' : (!empty($price_id_exists) ? 'stripe_price_id' : ($product_id_exists ? 'stripe_product_id' : 'name'));
+            $wpdb->query("ALTER TABLE $table_extras ADD COLUMN stripe_price_id_sale VARCHAR(255) DEFAULT NULL AFTER $after");
+        }
 
         // Ensure stripe_archived column exists
         $archived_exists = $wpdb->get_results("SHOW COLUMNS FROM $table_extras LIKE 'stripe_archived'");
@@ -923,6 +933,8 @@ class Database {
             name varchar(255) NOT NULL,
             stripe_product_id varchar(255) DEFAULT NULL,
             stripe_price_id varchar(255) DEFAULT NULL,
+            stripe_price_id_rent varchar(255) DEFAULT NULL,
+            stripe_price_id_sale varchar(255) DEFAULT NULL,
             stripe_archived tinyint(1) DEFAULT 0,
             price decimal(10,2) NOT NULL,
             image_url text,

--- a/includes/Database.php
+++ b/includes/Database.php
@@ -759,6 +759,23 @@ class Database {
             }
         }
 
+        // Create blocked days table if it doesn't exist
+        $table_blocked = $wpdb->prefix . 'produkt_blocked_days';
+        $blocked_exists = $wpdb->get_var("SHOW TABLES LIKE '$table_blocked'");
+        if (!$blocked_exists) {
+            $charset_collate = $wpdb->get_charset_collate();
+            $sql = "CREATE TABLE $table_blocked (
+                id mediumint(9) NOT NULL AUTO_INCREMENT,
+                day date NOT NULL,
+                created_at datetime DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (id),
+                UNIQUE KEY day (day)
+            ) $charset_collate;";
+
+            require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
+            dbDelta($sql);
+        }
+
         // Create filter groups table
         $table_filter_groups = $wpdb->prefix . 'produkt_filter_groups';
         $groups_exists      = $wpdb->get_var("SHOW TABLES LIKE '$table_filter_groups'");
@@ -1161,6 +1178,17 @@ class Database {
             PRIMARY KEY (id)
         ) $charset_collate;";
         dbDelta($sql_shipping);
+
+        // Blocked days table
+        $table_blocked = $wpdb->prefix . 'produkt_blocked_days';
+        $sql_blocked    = "CREATE TABLE $table_blocked (
+            id mediumint(9) NOT NULL AUTO_INCREMENT,
+            day date NOT NULL,
+            created_at datetime DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (id),
+            UNIQUE KEY day (day)
+        ) $charset_collate;";
+        dbDelta($sql_blocked);
 
         // Filter groups table
         $table_filter_groups = $wpdb->prefix . 'produkt_filter_groups';

--- a/includes/StripeService.php
+++ b/includes/StripeService.php
@@ -534,7 +534,7 @@ class StripeService {
      * @param string $related_product_name Related product name
      * @return array|\WP_Error
      */
-    public static function create_extra_price($name, $price, $related_product_name = '') {
+    public static function create_extra_price($name, $price, $related_product_name = '', $mode = 'miete') {
         $init = self::init();
         if (is_wp_error($init)) {
             return $init;
@@ -560,12 +560,17 @@ class StripeService {
                 ]);
             }
 
-            $price_obj = \Stripe\Price::create([
+            $price_params = [
                 'unit_amount' => intval(round($price * 100)),
                 'currency'    => 'eur',
-                'recurring'   => ['interval' => 'month'],
                 'product'     => $product->id,
-            ]);
+            ];
+
+            if ($mode === 'miete') {
+                $price_params['recurring'] = ['interval' => 'month'];
+            }
+
+            $price_obj = \Stripe\Price::create($price_params);
 
             return [
                 'product_id' => $product->id,

--- a/includes/StripeService.php
+++ b/includes/StripeService.php
@@ -557,7 +557,11 @@ class StripeService {
                 $product = \Stripe\Product::create([
                     'name'        => $full_name,
                     'description' => 'Extra für Produkt: ' . $related_product_name,
+                    'type'        => 'service',
+                    'active'      => true,
                 ]);
+            } elseif (!$product->active) {
+                \Stripe\Product::update($product->id, ['active' => true]);
             }
 
             $price_params = [

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -333,7 +333,9 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
                     <h3>Wählen Sie Ihre Extras</h3>
                     <div class="produkt-options extras layout-<?php echo esc_attr($layout_style); ?>" id="extras-container">
                         <?php foreach ($extras as $extra):
-                            $pid = ($modus === 'kauf') ? ($extra->stripe_price_id_sale ?? '') : ($extra->stripe_price_id_rent ?? '');
+                            $pid = $modus === 'kauf'
+                                ? ($extra->stripe_price_id_sale ?: ($extra->stripe_price_id ?? ''))
+                                : ($extra->stripe_price_id_rent ?: ($extra->stripe_price_id ?? ''));
                         ?>
                         <div class="produkt-option" data-type="extra" data-id="<?php echo esc_attr($extra->id); ?>"
                              data-extra-image="<?php echo esc_attr($extra->image_url ?? ''); ?>"

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -52,6 +52,9 @@ $durations = $wpdb->get_results($wpdb->prepare(
     $category_id
 ));
 
+// Get blocked days for booking calendar
+$blocked_days = $wpdb->get_col("SELECT day FROM {$wpdb->prefix}produkt_blocked_days");
+
 // Determine lowest price across all variants and durations
 $variant_ids  = array_map(fn($v) => (int) $v->id, $variants);
 $duration_ids = array_map(fn($d) => (int) $d->id, $durations);
@@ -707,4 +710,9 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
         <button id="produkt-exit-send" style="display:none;">Senden</button>
     </div>
 </div>
+<script>
+if (typeof produkt_ajax !== 'undefined') {
+    produkt_ajax.blocked_days = <?php echo json_encode($blocked_days); ?>;
+}
+</script>
 <?php get_footer(); ?>

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -332,15 +332,17 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
                 <div class="produkt-section" id="extras-section">
                     <h3>Wählen Sie Ihre Extras</h3>
                     <div class="produkt-options extras layout-<?php echo esc_attr($layout_style); ?>" id="extras-container">
-                        <?php foreach ($extras as $extra): ?>
+                        <?php foreach ($extras as $extra):
+                            $pid = ($modus === 'kauf') ? ($extra->stripe_price_id_sale ?? '') : ($extra->stripe_price_id_rent ?? '');
+                        ?>
                         <div class="produkt-option" data-type="extra" data-id="<?php echo esc_attr($extra->id); ?>"
                              data-extra-image="<?php echo esc_attr($extra->image_url ?? ''); ?>"
-                             data-price-id="<?php echo esc_attr($extra->stripe_price_id ?? ''); ?>"
+                             data-price-id="<?php echo esc_attr($pid); ?>"
                              data-available="true">
                             <div class="produkt-option-content">
                                 <span class="produkt-extra-name"><?php echo esc_html($extra->name); ?></span>
-                                <?php if (!empty($extra->stripe_price_id)) {
-                                    $p = \ProduktVerleih\StripeService::get_price_amount($extra->stripe_price_id);
+                                <?php if (!empty($pid)) {
+                                    $p = \ProduktVerleih\StripeService::get_price_amount($pid);
                                     if (!is_wp_error($p) && $p > 0) {
                                         echo '<div class="produkt-extra-price">+' . number_format($p, 2, ',', '.') . '€' . ($price_period === 'month' ? '/Monat' : '') . '</div>';
                                     }


### PR DESCRIPTION
## Summary
- add optional one-time price input when operating mode is "Einmalverkauf"
- make subscription price optional for one-time mode
- create one-time Stripe prices for extras when needed

## Testing
- `php -l includes/StripeService.php`
- `php -l admin/extras-page.php`
- `php -l admin/tabs/extras-tab.php`
- `php -l admin/tabs/extras-add-tab.php`
- `php -l admin/tabs/extras-edit-tab.php`


------
https://chatgpt.com/codex/tasks/task_b_687f8eda80bc83308b01b9ca0ee08ee6