### PR TITLE
Show inventory tab only when variants exist

### DIFF
--- a/admin/products-page.php
+++ b/admin/products-page.php
@@ -28,10 +28,7 @@ $category_column = $wpdb->get_results("SHOW COLUMNS FROM $variants_table LIKE 'c
 if (empty($category_column)) {
     $wpdb->query("ALTER TABLE $variants_table ADD COLUMN category_id mediumint(9) DEFAULT 1 AFTER id");
 }
-$has_variants = (int) $wpdb->get_var($wpdb->prepare(
-    "SELECT COUNT(*) FROM {$wpdb->prefix}produkt_variants WHERE category_id = %d",
-    $selected_category
-));
+$has_variants = \ProduktVerleih\Database::has_variants($selected_category);
 
 // Get active tab
 $active_tab = isset($_GET['tab']) ? sanitize_text_field($_GET['tab']) : 'variants';

--- a/includes/Database.php
+++ b/includes/Database.php
@@ -1725,4 +1725,22 @@ class Database {
         $table = $wpdb->prefix . 'produkt_product_categories';
         return (bool) $wpdb->get_var("SHOW COLUMNS FROM $table LIKE 'parent_id'");
     }
+
+    /**
+     * Check if a product has at least one variant.
+     *
+     * @param int $produkt_id ID of the product/category
+     * @return bool True if variants exist, false otherwise
+     */
+    public static function has_variants($produkt_id) {
+        global $wpdb;
+        $table = $wpdb->prefix . 'produkt_variants';
+        $count = $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT COUNT(*) FROM $table WHERE category_id = %d",
+                $produkt_id
+            )
+        );
+        return $count > 0;
+    }
 }


### PR DESCRIPTION
## Summary
- add `Database::has_variants()` helper
- use the helper in the products admin page to show "Lagerverwaltung" only when variants exist

## Testing
- `php -l includes/Database.php`
- `php -l admin/products-page.php`


------
https://chatgpt.com/codex/tasks/task_b_68800d52aa4483309f027ca55911761f