### PR TITLE
Enable automatic Stripe invoice creation

### DIFF
--- a/includes/StripeService.php
+++ b/includes/StripeService.php
@@ -81,6 +81,15 @@ class StripeService {
                 'customer_creation'=> 'always',
                 'client_reference_id' => $args['reference'] ?? null,
                 'metadata' => $args['metadata'] ?? [],
+                'invoice_creation' => [
+                    'enabled' => true,
+                    'invoice_data' => [
+                        'description' => 'Automatische Rechnung zur Bestellung',
+                        'metadata' => [
+                            'order_id' => $args['order_id'] ?? '',
+                        ],
+                    ],
+                ],
                 'success_url' => $success_url . '?session_id={CHECKOUT_SESSION_ID}',
                 'cancel_url'  => $cancel_url,
             ]);

--- a/includes/Webhook.php
+++ b/includes/Webhook.php
@@ -225,10 +225,6 @@ function handle_stripe_webhook(WP_REST_Request $request) {
             }
         }
 
-        if ($data['mode'] === 'kauf') {
-            error_log('Checkout-Mode: ' . $data['mode']);
-            produkt_generate_invoice($existing_id, $stripe_customer_id, $session->amount_total ?? 0, $produkt_name);
-        }
         }
     }
     elseif ($event->type === 'payment_intent.succeeded') {


### PR DESCRIPTION
## Summary
- add invoice creation parameters when creating a sale checkout session
- remove manual invoice generation after checkout session completion

## Testing
- `php -l includes/StripeService.php`
- `php -l includes/Webhook.php`


------
https://chatgpt.com/codex/tasks/task_b_6880f07bd3d48330816df541b9f6fbed