### PR TITLE
Ensure sale mode requires date before enabling purchase

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -711,7 +711,7 @@ jQuery(document).ready(function($) {
             requiredSelections.push(selectedFrameColor);
         }
         
-        const allSelected = requiredSelections.every(selection => selection !== null);
+        const allSelected = requiredSelections.every(selection => selection !== null && selection !== false);
         
         if (allSelected) {
             // Show loading state


### PR DESCRIPTION
## Summary
- tighten option check in `updatePriceAndButton`

## Testing
- `node --check assets/script.js`

------
https://chatgpt.com/codex/tasks/task_b_68812eb360748330b3f4a2b3a8889314