### PR TITLE
Fix Stripe customer creation during checkout

### DIFF
--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -1206,6 +1206,7 @@ function produkt_create_checkout_session() {
             'phone_number_collection'     => [
                 'enabled' => true,
             ],
+            'customer_creation'        => 'always',
             'success_url'              => add_query_arg('session_id', '{CHECKOUT_SESSION_ID}', get_option('produkt_success_url', home_url('/danke'))),
             'cancel_url'               => get_option('produkt_cancel_url', home_url('/abbrechen')),
             'consent_collection'       => [
@@ -1429,6 +1430,7 @@ function produkt_create_embedded_checkout_session() {
             'phone_number_collection' => [
                 'enabled' => true,
             ],
+            'customer_creation' => 'always',
             'consent_collection' => [
                 'terms_of_service' => 'required',
             ],

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -1009,6 +1009,12 @@ function produkt_create_subscription() {
             $fullname   = sanitize_text_field($body['fullname'] ?? '');
             $stripe_customer_id = Database::get_stripe_customer_id_by_email($cust_email);
             if (!$stripe_customer_id) {
+                $stripe_customer_id = Database::get_stripe_customer_id_from_usermeta($cust_email);
+                if ($stripe_customer_id) {
+                    Database::update_stripe_customer_id_by_email($cust_email, $stripe_customer_id);
+                }
+            }
+            if (!$stripe_customer_id) {
                 $customer = \Stripe\Customer::create([
                     'email' => $cust_email,
                     'name'  => $fullname,
@@ -1122,6 +1128,12 @@ function produkt_create_checkout_session() {
             $stripe_customer_id = null;
             if ($customer_email) {
                 $stripe_customer_id = Database::get_stripe_customer_id_by_email($customer_email);
+                if (!$stripe_customer_id) {
+                    $stripe_customer_id = Database::get_stripe_customer_id_from_usermeta($customer_email);
+                    if ($stripe_customer_id) {
+                        Database::update_stripe_customer_id_by_email($customer_email, $stripe_customer_id);
+                    }
+                }
                 $fullname = sanitize_text_field($body['fullname'] ?? '');
                 if (!$stripe_customer_id) {
                     $customer = \Stripe\Customer::create([
@@ -1230,6 +1242,13 @@ function produkt_create_checkout_session() {
         if (!empty($customer_email)) {
             // Prüfe, ob Stripe-Kunde mit dieser E-Mail bereits existiert
             $stripe_customer_id = Database::get_stripe_customer_id_by_email($customer_email);
+
+            if (!$stripe_customer_id) {
+                $stripe_customer_id = Database::get_stripe_customer_id_from_usermeta($customer_email);
+                if ($stripe_customer_id) {
+                    Database::update_stripe_customer_id_by_email($customer_email, $stripe_customer_id);
+                }
+            }
 
             if (!$stripe_customer_id) {
                 // Erstelle neuen Stripe-Kunden
@@ -1454,6 +1473,12 @@ function produkt_create_embedded_checkout_session() {
         } else {
             if (!empty($customer_email)) {
                 $stripe_customer_id = Database::get_stripe_customer_id_by_email($customer_email);
+                if (!$stripe_customer_id) {
+                    $stripe_customer_id = Database::get_stripe_customer_id_from_usermeta($customer_email);
+                    if ($stripe_customer_id) {
+                        Database::update_stripe_customer_id_by_email($customer_email, $stripe_customer_id);
+                    }
+                }
                 if (!$stripe_customer_id) {
                     $customer = \Stripe\Customer::create([
                         'email' => $customer_email,

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -1017,6 +1017,8 @@ function produkt_create_subscription() {
                 Database::update_stripe_customer_id_by_email($cust_email, $stripe_customer_id);
             }
 
+            error_log('Stripe Customer ID used: ' . $stripe_customer_id);
+
             $session_args = [
                 'price_id'    => $price_id,
                 'quantity'    => $days,
@@ -1130,6 +1132,7 @@ function produkt_create_checkout_session() {
                     $stripe_customer_id = $customer->id;
                     Database::update_stripe_customer_id_by_email($customer_email, $stripe_customer_id);
                 }
+                error_log('Stripe Customer ID used: ' . $stripe_customer_id);
             }
             $session_data = [
                 'price_id'    => $price_id,
@@ -1240,6 +1243,8 @@ function produkt_create_checkout_session() {
                 // Speichere die ID in deiner Kundentabelle
                 Database::update_stripe_customer_id_by_email($customer_email, $stripe_customer_id);
             }
+
+            error_log('Stripe Customer ID used: ' . $stripe_customer_id);
 
             if (!empty($stripe_customer_id)) {
                 // Verwende den Stripe-Kunden für die Checkout Session
@@ -1458,6 +1463,9 @@ function produkt_create_embedded_checkout_session() {
                     $stripe_customer_id = $customer->id;
                     Database::update_stripe_customer_id_by_email($customer_email, $stripe_customer_id);
                 }
+
+                error_log('Stripe Customer ID used: ' . $stripe_customer_id);
+
                 if (!empty($stripe_customer_id)) {
                     $session_params['customer'] = $stripe_customer_id;
                 }

--- a/includes/Database.php
+++ b/includes/Database.php
@@ -1703,30 +1703,32 @@ class Database {
      * @param string $customer_id Stripe customer ID
      * @return void
      */
-    public static function update_stripe_customer_id_by_email($email, $customer_id) {
-        $user = get_user_by('email', sanitize_email($email));
-        if ($user) {
-            update_user_meta($user->ID, 'stripe_customer_id', $customer_id);
-        }
-
+    public static function update_stripe_customer_id_by_email($email, $stripe_customer_id) {
         global $wpdb;
         $table = $wpdb->prefix . 'produkt_customers';
-        $email  = sanitize_email($email);
-        $exists = $wpdb->get_var(
-            $wpdb->prepare("SELECT COUNT(*) FROM $table WHERE email = %s", $email)
-        );
+
+        $exists = $wpdb->get_var($wpdb->prepare(
+            "SELECT COUNT(*) FROM $table WHERE email = %s",
+            $email
+        ));
+
         if ($exists) {
+            // Update bestehender Eintrag
             $wpdb->update(
                 $table,
-                ['stripe_customer_id' => $customer_id],
+                ['stripe_customer_id' => $stripe_customer_id],
                 ['email' => $email],
                 ['%s'],
                 ['%s']
             );
         } else {
+            // Fallback: neuer Eintrag mit minimalen Infos
             $wpdb->insert(
                 $table,
-                ['email' => $email, 'stripe_customer_id' => $customer_id],
+                [
+                    'email' => $email,
+                    'stripe_customer_id' => $stripe_customer_id,
+                ],
                 ['%s', '%s']
             );
         }

--- a/includes/Database.php
+++ b/includes/Database.php
@@ -1732,6 +1732,11 @@ class Database {
                 ['%s', '%s']
             );
         }
+
+        $user = get_user_by('email', sanitize_email($email));
+        if ($user) {
+            update_user_meta($user->ID, 'stripe_customer_id', $stripe_customer_id);
+        }
     }
 
     public static function get_stripe_customer_id_from_usermeta($email) {

--- a/includes/StripeService.php
+++ b/includes/StripeService.php
@@ -85,6 +85,7 @@ class StripeService {
 
             if (!empty($args['customer'])) {
                 $session_data['customer'] = $args['customer'];
+                error_log('StripeService customer for sale: ' . $args['customer']);
             }
 
             $session = \Stripe\Checkout\Session::create($session_data);

--- a/includes/StripeService.php
+++ b/includes/StripeService.php
@@ -70,20 +70,24 @@ class StripeService {
         $cancel_url  = $args['cancel_url'] ?? home_url('/abbrechen');
 
         try {
-            $session = \Stripe\Checkout\Session::create([
+            $session_data = [
                 'mode' => 'payment',
                 'payment_method_types' => ['card'],
                 'line_items' => [[
                     'price'    => $args['price_id'],
                     'quantity' => $args['quantity'] ?? 1,
                 ]],
-                'customer' => $args['customer'] ?? null,
-                'customer_creation' => 'always',
                 'client_reference_id' => $args['reference'] ?? null,
                 'metadata' => $args['metadata'] ?? [],
                 'success_url' => $success_url . '?session_id={CHECKOUT_SESSION_ID}',
                 'cancel_url'  => $cancel_url,
-            ]);
+            ];
+
+            if (!empty($args['customer'])) {
+                $session_data['customer'] = $args['customer'];
+            }
+
+            $session = \Stripe\Checkout\Session::create($session_data);
 
             return $session;
         } catch (\Exception $e) {

--- a/includes/StripeService.php
+++ b/includes/StripeService.php
@@ -78,6 +78,7 @@ class StripeService {
                     'quantity' => $args['quantity'] ?? 1,
                 ]],
                 'customer' => $args['customer'] ?? null,
+                'customer_creation' => 'always',
                 'client_reference_id' => $args['reference'] ?? null,
                 'metadata' => $args['metadata'] ?? [],
                 'success_url' => $success_url . '?session_id={CHECKOUT_SESSION_ID}',

--- a/includes/StripeService.php
+++ b/includes/StripeService.php
@@ -86,6 +86,8 @@ class StripeService {
             if (!empty($args['customer'])) {
                 $session_data['customer'] = $args['customer'];
                 error_log('StripeService customer for sale: ' . $args['customer']);
+            } else {
+                $session_data['customer_creation'] = 'always';
             }
 
             $session = \Stripe\Checkout\Session::create($session_data);


### PR DESCRIPTION
## Summary
- ensure embedded checkout sessions always create a Stripe customer
- enforce Stripe customer creation for one-time sales

## Testing
- `php -l includes/Ajax.php`
- `php -l includes/StripeService.php`


------
https://chatgpt.com/codex/tasks/task_b_6881493473788330b88bb4599b900812