### PR TITLE
Add Stripe customer upsert functionality

### DIFF
--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -1513,12 +1513,6 @@ function produkt_create_embedded_checkout_session() {
             'custom_text' => $custom_text,
         ];
 
-        if (
-            !empty($session_params['automatic_tax']['enabled']) &&
-            !empty($session_params['customer'])
-        ) {
-            $session_params['customer_update'] = ['shipping' => 'auto'];
-        }
         if ($modus !== 'kauf') {
             $session_params['subscription_data'] = [ 'metadata' => $metadata ];
         } else {
@@ -1556,6 +1550,10 @@ function produkt_create_embedded_checkout_session() {
             if (empty($session_params['customer'])) {
                 $session_params['customer_creation'] = 'always';
             }
+        }
+
+        if (!empty($session_params['automatic_tax']['enabled'])) {
+            $session_params['customer_update'] = ['shipping' => 'auto'];
         }
 
         $session = \Stripe\Checkout\Session::create($session_params);

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -1513,7 +1513,10 @@ function produkt_create_embedded_checkout_session() {
             'custom_text' => $custom_text,
         ];
 
-        if (!empty($session_params['automatic_tax']) && !empty($session_params['automatic_tax']['enabled'])) {
+        if (
+            !empty($session_params['automatic_tax']['enabled']) &&
+            !empty($session_params['customer'])
+        ) {
             $session_params['customer_update'] = ['shipping' => 'auto'];
         }
         if ($modus !== 'kauf') {

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -973,6 +973,10 @@ function produkt_create_subscription() {
                 'city'        => $body['city'] ?? '',
             ]
         );
+        $user = get_user_by('email', sanitize_email($body['email'] ?? ''));
+        if ($user) {
+            update_user_meta($user->ID, 'stripe_customer_id', $customer->id);
+        }
 
         global $wpdb;
         $shipping_price_id = $wpdb->get_var("SELECT stripe_price_id FROM {$wpdb->prefix}produkt_shipping_methods WHERE is_default = 1 LIMIT 1");
@@ -1018,6 +1022,10 @@ function produkt_create_subscription() {
         $mode = get_option('produkt_betriebsmodus', 'miete');
         if ($mode === 'kauf') {
             $cust_email = sanitize_email($body['email'] ?? '');
+            $current_user = wp_get_current_user();
+            if ($current_user && $current_user->exists()) {
+                $cust_email = $current_user->user_email;
+            }
             $fullname   = sanitize_text_field($body['fullname'] ?? '');
             $stripe_customer_id = Database::get_stripe_customer_id_by_email($cust_email);
             if (!$stripe_customer_id) {
@@ -1038,6 +1046,10 @@ function produkt_create_subscription() {
                         'city'        => $body['city'] ?? '',
                     ]
                 );
+                $user = get_user_by('email', $cust_email);
+                if ($user) {
+                    update_user_meta($user->ID, 'stripe_customer_id', $stripe_customer_id);
+                }
             }
 
             $session = StripeService::create_checkout_session_for_sale([
@@ -1107,6 +1119,10 @@ function produkt_create_checkout_session() {
         $frame_color_id    = intval($body['frame_color_id'] ?? 0);
         $final_price       = floatval($body['final_price'] ?? 0);
         $customer_email    = sanitize_email($body['email'] ?? '');
+        $current_user = wp_get_current_user();
+        if ($current_user && $current_user->exists()) {
+            $customer_email = $current_user->user_email;
+        }
         $fullname          = sanitize_text_field($body['fullname'] ?? '');
         $phone             = sanitize_text_field($body['phone'] ?? '');
 
@@ -1159,6 +1175,10 @@ function produkt_create_checkout_session() {
                         'city'        => $body['city'] ?? '',
                     ]
                 );
+                $user = get_user_by('email', $customer_email);
+                if ($user) {
+                    update_user_meta($user->ID, 'stripe_customer_id', $stripe_customer_id);
+                }
             }
             }
             $session = StripeService::create_checkout_session_for_sale([
@@ -1277,6 +1297,10 @@ function produkt_create_checkout_session() {
                         'city'        => $body['city'] ?? '',
                     ]
                 );
+                $user = get_user_by('email', $customer_email);
+                if ($user) {
+                    update_user_meta($user->ID, 'stripe_customer_id', $stripe_customer_id);
+                }
             }
 
             // Verwende den Stripe-Kunden für die Checkout Session
@@ -1388,6 +1412,10 @@ function produkt_create_embedded_checkout_session() {
         $frame_color_id   = intval($body['frame_color_id'] ?? 0);
         $final_price      = floatval($body['final_price'] ?? 0);
         $customer_email   = sanitize_email($body['email'] ?? '');
+        $current_user = wp_get_current_user();
+        if ($current_user && $current_user->exists()) {
+            $customer_email = $current_user->user_email;
+        }
         $fullname         = sanitize_text_field($body['fullname'] ?? '');
         $phone            = sanitize_text_field($body['phone'] ?? '');
 
@@ -1505,6 +1533,10 @@ function produkt_create_embedded_checkout_session() {
                             'city'        => $body['city'] ?? '',
                         ]
                     );
+                    $user = get_user_by('email', $customer_email);
+                    if ($user) {
+                        update_user_meta($user->ID, 'stripe_customer_id', $stripe_customer_id);
+                    }
                 }
                 $session_params['customer'] = $stripe_customer_id;
             }

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -962,16 +962,16 @@ function produkt_create_subscription() {
             throw new \Exception($customer->get_error_message());
         }
 
-        Database::upsert_customer(
+        Database::upsert_customer_record_by_email(
             sanitize_email($body['email'] ?? ''),
             $customer->id,
-            $body['first_name'] ?? '',
-            $body['last_name'] ?? '',
-            $body['phone'] ?? '',
-            $body['street'] ?? '',
-            $body['postal'] ?? '',
-            $body['city'] ?? '',
-            $body['country'] ?? ''
+            sanitize_text_field($body['fullname'] ?? ''),
+            sanitize_text_field($body['phone'] ?? ''),
+            [
+                'street'      => $body['street'] ?? '',
+                'postal_code' => $body['postal'] ?? '',
+                'city'        => $body['city'] ?? '',
+            ]
         );
 
         global $wpdb;
@@ -1027,16 +1027,16 @@ function produkt_create_subscription() {
                 ]);
                 $stripe_customer_id = $customer->id;
                 Database::update_stripe_customer_id_by_email($cust_email, $stripe_customer_id);
-                Database::upsert_customer(
+                Database::upsert_customer_record_by_email(
                     $cust_email,
                     $stripe_customer_id,
-                    $body['first_name'] ?? '',
-                    $body['last_name'] ?? '',
-                    $body['phone'] ?? '',
-                    $body['street'] ?? '',
-                    $body['postal'] ?? '',
-                    $body['city'] ?? '',
-                    $body['country'] ?? ''
+                    $fullname,
+                    $phone,
+                    [
+                        'street'      => $body['street'] ?? '',
+                        'postal_code' => $body['postal'] ?? '',
+                        'city'        => $body['city'] ?? '',
+                    ]
                 );
             }
 
@@ -1148,16 +1148,16 @@ function produkt_create_checkout_session() {
                 ]);
                 $stripe_customer_id = $customer->id;
                 Database::update_stripe_customer_id_by_email($customer_email, $stripe_customer_id);
-                Database::upsert_customer(
+                Database::upsert_customer_record_by_email(
                     $customer_email,
                     $stripe_customer_id,
-                    $body['first_name'] ?? '',
-                    $body['last_name'] ?? '',
-                    $body['phone'] ?? '',
-                    $body['street'] ?? '',
-                    $body['postal'] ?? '',
-                    $body['city'] ?? '',
-                    $body['country'] ?? ''
+                    $fullname,
+                    $phone,
+                    [
+                        'street'      => $body['street'] ?? '',
+                        'postal_code' => $body['postal'] ?? '',
+                        'city'        => $body['city'] ?? '',
+                    ]
                 );
             }
             }
@@ -1266,16 +1266,16 @@ function produkt_create_checkout_session() {
 
                 // Speichere die ID in deiner Kundentabelle
                 Database::update_stripe_customer_id_by_email($customer_email, $stripe_customer_id);
-                Database::upsert_customer(
+                Database::upsert_customer_record_by_email(
                     $customer_email,
                     $stripe_customer_id,
-                    $body['first_name'] ?? '',
-                    $body['last_name'] ?? '',
-                    $body['phone'] ?? '',
-                    $body['street'] ?? '',
-                    $body['postal'] ?? '',
-                    $body['city'] ?? '',
-                    $body['country'] ?? ''
+                    $fullname,
+                    $phone,
+                    [
+                        'street'      => $body['street'] ?? '',
+                        'postal_code' => $body['postal'] ?? '',
+                        'city'        => $body['city'] ?? '',
+                    ]
                 );
             }
 
@@ -1494,16 +1494,16 @@ function produkt_create_embedded_checkout_session() {
                     ]);
                     $stripe_customer_id = $customer->id;
                     Database::update_stripe_customer_id_by_email($customer_email, $stripe_customer_id);
-                    Database::upsert_customer(
+                    Database::upsert_customer_record_by_email(
                         $customer_email,
                         $stripe_customer_id,
-                        $body['first_name'] ?? '',
-                        $body['last_name'] ?? '',
-                        $body['phone'] ?? '',
-                        $body['street'] ?? '',
-                        $body['postal'] ?? '',
-                        $body['city'] ?? '',
-                        $body['country'] ?? ''
+                        $fullname,
+                        $phone,
+                        [
+                            'street'      => $body['street'] ?? '',
+                            'postal_code' => $body['postal'] ?? '',
+                            'city'        => $body['city'] ?? '',
+                        ]
                     );
                 }
                 $session_params['customer'] = $stripe_customer_id;

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -962,6 +962,18 @@ function produkt_create_subscription() {
             throw new \Exception($customer->get_error_message());
         }
 
+        Database::upsert_customer(
+            sanitize_email($body['email'] ?? ''),
+            $customer->id,
+            $body['first_name'] ?? '',
+            $body['last_name'] ?? '',
+            $body['phone'] ?? '',
+            $body['street'] ?? '',
+            $body['postal'] ?? '',
+            $body['city'] ?? '',
+            $body['country'] ?? ''
+        );
+
         global $wpdb;
         $shipping_price_id = $wpdb->get_var("SELECT stripe_price_id FROM {$wpdb->prefix}produkt_shipping_methods WHERE is_default = 1 LIMIT 1");
         $extra_ids_raw = sanitize_text_field($body['extra_ids'] ?? '');
@@ -1015,6 +1027,17 @@ function produkt_create_subscription() {
                 ]);
                 $stripe_customer_id = $customer->id;
                 Database::update_stripe_customer_id_by_email($cust_email, $stripe_customer_id);
+                Database::upsert_customer(
+                    $cust_email,
+                    $stripe_customer_id,
+                    $body['first_name'] ?? '',
+                    $body['last_name'] ?? '',
+                    $body['phone'] ?? '',
+                    $body['street'] ?? '',
+                    $body['postal'] ?? '',
+                    $body['city'] ?? '',
+                    $body['country'] ?? ''
+                );
             }
 
             $session = StripeService::create_checkout_session_for_sale([
@@ -1118,14 +1141,25 @@ function produkt_create_checkout_session() {
                 $stripe_customer_id = Database::get_stripe_customer_id_by_email($customer_email);
                 $fullname = sanitize_text_field($body['fullname'] ?? '');
                 if (!$stripe_customer_id) {
-                    $customer = \Stripe\Customer::create([
-                        'email' => $customer_email,
-                        'name'  => $fullname,
-                        'phone' => $phone,
-                    ]);
-                    $stripe_customer_id = $customer->id;
-                    Database::update_stripe_customer_id_by_email($customer_email, $stripe_customer_id);
-                }
+                $customer = \Stripe\Customer::create([
+                    'email' => $customer_email,
+                    'name'  => $fullname,
+                    'phone' => $phone,
+                ]);
+                $stripe_customer_id = $customer->id;
+                Database::update_stripe_customer_id_by_email($customer_email, $stripe_customer_id);
+                Database::upsert_customer(
+                    $customer_email,
+                    $stripe_customer_id,
+                    $body['first_name'] ?? '',
+                    $body['last_name'] ?? '',
+                    $body['phone'] ?? '',
+                    $body['street'] ?? '',
+                    $body['postal'] ?? '',
+                    $body['city'] ?? '',
+                    $body['country'] ?? ''
+                );
+            }
             }
             $session = StripeService::create_checkout_session_for_sale([
                 'price_id'    => $price_id,
@@ -1232,6 +1266,17 @@ function produkt_create_checkout_session() {
 
                 // Speichere die ID in deiner Kundentabelle
                 Database::update_stripe_customer_id_by_email($customer_email, $stripe_customer_id);
+                Database::upsert_customer(
+                    $customer_email,
+                    $stripe_customer_id,
+                    $body['first_name'] ?? '',
+                    $body['last_name'] ?? '',
+                    $body['phone'] ?? '',
+                    $body['street'] ?? '',
+                    $body['postal'] ?? '',
+                    $body['city'] ?? '',
+                    $body['country'] ?? ''
+                );
             }
 
             // Verwende den Stripe-Kunden für die Checkout Session
@@ -1449,6 +1494,17 @@ function produkt_create_embedded_checkout_session() {
                     ]);
                     $stripe_customer_id = $customer->id;
                     Database::update_stripe_customer_id_by_email($customer_email, $stripe_customer_id);
+                    Database::upsert_customer(
+                        $customer_email,
+                        $stripe_customer_id,
+                        $body['first_name'] ?? '',
+                        $body['last_name'] ?? '',
+                        $body['phone'] ?? '',
+                        $body['street'] ?? '',
+                        $body['postal'] ?? '',
+                        $body['city'] ?? '',
+                        $body['country'] ?? ''
+                    );
                 }
                 $session_params['customer'] = $stripe_customer_id;
             }

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -1260,7 +1260,6 @@ function produkt_create_checkout_session() {
             'phone_number_collection'     => [
                 'enabled' => true,
             ],
-            'customer_creation'        => 'always',
             'success_url'              => add_query_arg('session_id', '{CHECKOUT_SESSION_ID}', get_option('produkt_success_url', home_url('/danke'))),
             'cancel_url'               => get_option('produkt_cancel_url', home_url('/abbrechen')),
             'consent_collection'       => [
@@ -1303,8 +1302,13 @@ function produkt_create_checkout_session() {
                 }
             }
 
-            // Verwende den Stripe-Kunden für die Checkout Session
-            $session_args['customer'] = $stripe_customer_id;
+            if ($stripe_customer_id) {
+                $session_args['customer'] = $stripe_customer_id;
+            }
+        }
+
+        if (empty($session_args['customer'])) {
+            $session_args['customer_creation'] = 'always';
         }
 
         $session = \Stripe\Checkout\Session::create($session_args);
@@ -1503,7 +1507,6 @@ function produkt_create_embedded_checkout_session() {
             'phone_number_collection' => [
                 'enabled' => true,
             ],
-            'customer_creation' => 'always',
             'consent_collection' => [
                 'terms_of_service' => 'required',
             ],
@@ -1538,7 +1541,13 @@ function produkt_create_embedded_checkout_session() {
                         update_user_meta($user->ID, 'stripe_customer_id', $stripe_customer_id);
                     }
                 }
-                $session_params['customer'] = $stripe_customer_id;
+                if ($stripe_customer_id) {
+                    $session_params['customer'] = $stripe_customer_id;
+                }
+            }
+
+            if (empty($session_params['customer'])) {
+                $session_params['customer_creation'] = 'always';
             }
         }
 

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -1512,6 +1512,10 @@ function produkt_create_embedded_checkout_session() {
             ],
             'custom_text' => $custom_text,
         ];
+
+        if (!empty($session_params['automatic_tax']) && !empty($session_params['automatic_tax']['enabled'])) {
+            $session_params['customer_update'] = ['shipping' => 'auto'];
+        }
         if ($modus !== 'kauf') {
             $session_params['subscription_data'] = [ 'metadata' => $metadata ];
         } else {

--- a/includes/Database.php
+++ b/includes/Database.php
@@ -1713,12 +1713,31 @@ class Database {
      * @param string $email User email
      * @return string Customer ID or empty string when none found
      */
-    public static function get_stripe_customer_id_by_email($email) {
-        $user = get_user_by('email', sanitize_email($email));
-        if (!$user) {
-            return '';
+    public static function get_stripe_customer_id_from_usermeta($email) {
+        global $wpdb;
+
+        $user_id = $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT ID FROM {$wpdb->users} WHERE user_email = %s",
+                $email
+            )
+        );
+
+        if (!$user_id) {
+            return null;
         }
-        return get_user_meta($user->ID, 'stripe_customer_id', true);
+
+        return $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT meta_value FROM {$wpdb->usermeta} WHERE user_id = %d AND meta_key = 'stripe_customer_id'",
+                $user_id
+            )
+        );
+    }
+
+    public static function get_stripe_customer_id_by_email($email) {
+        $customer_id = self::get_stripe_customer_id_from_usermeta(sanitize_email($email));
+        return $customer_id ? $customer_id : '';
     }
 
     /**

--- a/includes/Database.php
+++ b/includes/Database.php
@@ -635,7 +635,8 @@ class Database {
                 phone varchar(50) DEFAULT '',
                 street varchar(255) DEFAULT '',
                 postal_code varchar(20) DEFAULT '',
-                city_country varchar(255) DEFAULT '',
+                city varchar(255) DEFAULT '',
+                country varchar(50) DEFAULT '',
                 PRIMARY KEY (id),
                 UNIQUE KEY email (email)
             ) $charset_collate;";
@@ -1252,7 +1253,8 @@ class Database {
             phone varchar(50) DEFAULT '',
             street varchar(255) DEFAULT '',
             postal_code varchar(20) DEFAULT '',
-            city_country varchar(255) DEFAULT '',
+            city varchar(255) DEFAULT '',
+            country varchar(50) DEFAULT '',
             PRIMARY KEY (id),
             UNIQUE KEY email (email)
         ) $charset_collate;";
@@ -1782,9 +1784,10 @@ class Database {
                     'phone'              => $phone,
                     'street'             => $street,
                     'postal_code'        => $postal,
-                    'city_country'       => $city . ' - ' . $country,
+                    'city'               => $city,
+                    'country'            => $country,
                 ],
-                ['%s','%s','%s','%s','%s','%s','%s','%s']
+                ['%s','%s','%s','%s','%s','%s','%s','%s','%s']
             );
         }
     }
@@ -1817,7 +1820,8 @@ class Database {
         if (!empty($address)) {
             $data['street']       = $address['street'] ?? '';
             $data['postal_code']  = $address['postal_code'] ?? '';
-            $data['city_country'] = $address['city'] ?? '';
+            $data['city']         = $address['city'] ?? '';
+            $data['country']      = $address['country'] ?? '';
         }
 
         if ($existing) {

--- a/includes/Database.php
+++ b/includes/Database.php
@@ -1770,6 +1770,44 @@ class Database {
         }
     }
 
+    /**
+     * Insert or update a record in the produkt_customers table using the email
+     * as unique identifier.
+     *
+     * @param string $email
+     * @param string $stripe_customer_id
+     * @param string $fullname
+     * @param string $phone
+     * @param array  $address
+     * @return void
+     */
+    public static function upsert_customer_record_by_email($email, $stripe_customer_id, $fullname = '', $phone = '', $address = []) {
+        global $wpdb;
+
+        // Check if email already exists
+        $table = $wpdb->prefix . 'produkt_customers';
+        $existing = $wpdb->get_var($wpdb->prepare("SELECT id FROM $table WHERE email = %s", $email));
+
+        $data = [
+            'stripe_customer_id' => $stripe_customer_id,
+            'first_name'        => $fullname,
+            'phone'             => $phone,
+            'email'             => $email,
+        ];
+
+        if (!empty($address)) {
+            $data['street']       = $address['street'] ?? '';
+            $data['postal_code']  = $address['postal_code'] ?? '';
+            $data['city_country'] = $address['city'] ?? '';
+        }
+
+        if ($existing) {
+            $wpdb->update($table, $data, ['email' => $email]);
+        } else {
+            $wpdb->insert($table, $data);
+        }
+    }
+
 
     /**
      * Retrieve all product categories sorted hierarchically.

--- a/includes/StripeService.php
+++ b/includes/StripeService.php
@@ -70,20 +70,27 @@ class StripeService {
         $cancel_url  = $args['cancel_url'] ?? home_url('/abbrechen');
 
         try {
-            $session = \Stripe\Checkout\Session::create([
+            $session_data = [
                 'mode' => 'payment',
                 'payment_method_types' => ['card'],
                 'line_items' => [[
                     'price'    => $args['price_id'],
                     'quantity' => $args['quantity'] ?? 1,
                 ]],
-                'customer' => $args['customer'] ?? null,
-                'customer_creation' => 'always',
                 'client_reference_id' => $args['reference'] ?? null,
                 'metadata' => $args['metadata'] ?? [],
                 'success_url' => $success_url . '?session_id={CHECKOUT_SESSION_ID}',
                 'cancel_url'  => $cancel_url,
-            ]);
+            ];
+
+            $customer_id = $args['customer'] ?? null;
+            if ($customer_id) {
+                $session_data['customer'] = $customer_id;
+            } else {
+                $session_data['customer_creation'] = 'always';
+            }
+
+            $session = \Stripe\Checkout\Session::create($session_data);
 
             return $session;
         } catch (\Exception $e) {

--- a/includes/Webhook.php
+++ b/includes/Webhook.php
@@ -108,25 +108,23 @@ function handle_stripe_webhook(WP_REST_Request $request) {
         $user_ip       = sanitize_text_field($metadata['user_ip'] ?? '');
         $user_agent    = sanitize_text_field($metadata['user_agent'] ?? '');
 
-        $email  = sanitize_email($session->customer_details->email ?? '');
-        $phone  = sanitize_text_field($session->customer_details->phone ?? '');
-        $addr   = $session->customer_details->address ?? null;
-        $street = sanitize_text_field($addr->line1 ?? '');
-        $postal = sanitize_text_field($addr->postal_code ?? '');
-        $city   = sanitize_text_field($addr->city ?? '');
-        $country = sanitize_text_field($addr->country ?? '');
+        $email    = sanitize_email($session->customer_details->email ?? '');
+        $phone    = sanitize_text_field($session->customer_details->phone ?? '');
+
+        $address = $session->customer_details->address ?? null;
 
         // Persist customer information in custom table
-        Database::upsert_customer(
+        Database::upsert_customer_record_by_email(
             $email,
             $stripe_customer_id,
-            $first_name,
-            $last_name,
+            $full_name,
             $phone,
-            $street,
-            $postal,
-            $city,
-            $country
+            [
+                'street'      => $address->line1 ?? '',
+                'postal_code' => $address->postal_code ?? '',
+                'city'        => $address->city ?? '',
+                'country'     => $address->country ?? '',
+            ]
         );
 
         global $wpdb;

--- a/includes/Webhook.php
+++ b/includes/Webhook.php
@@ -116,6 +116,19 @@ function handle_stripe_webhook(WP_REST_Request $request) {
         $city   = sanitize_text_field($addr->city ?? '');
         $country = sanitize_text_field($addr->country ?? '');
 
+        // Persist customer information in custom table
+        Database::upsert_customer(
+            $email,
+            $stripe_customer_id,
+            $first_name,
+            $last_name,
+            $phone,
+            $street,
+            $postal,
+            $city,
+            $country
+        );
+
         global $wpdb;
         $existing_order = $wpdb->get_row($wpdb->prepare(
             "SELECT id, status, created_at, category_id, shipping_cost, variant_id FROM {$wpdb->prefix}produkt_orders WHERE stripe_session_id = %s",


### PR DESCRIPTION
## Summary
- create new `produkt_customers` table on install/update
- add `Database::upsert_customer` helper
- store customer details when creating a Stripe customer

## Testing
- `php -l includes/Database.php`
- `php -l includes/Ajax.php`


------
https://chatgpt.com/codex/tasks/task_b_68816059bba08330951ffcb9dfa002d8