### PR TITLE
Update account layout

### DIFF
--- a/admin/customers-page.php
+++ b/admin/customers-page.php
@@ -120,6 +120,23 @@ foreach ($results as $r) {
             <p><strong>Nachname:</strong> <?php echo esc_html($last); ?></p>
             <p><strong>E-Mail:</strong> <?php echo esc_html($user->user_email); ?></p>
             <p><strong>Telefon:</strong> <?php echo esc_html($phone ?: '–'); ?></p>
+            <?php
+                $addr_row = $wpdb->get_row($wpdb->prepare(
+                    "SELECT street, postal_code, city, country FROM {$wpdb->prefix}produkt_customers WHERE email = %s",
+                    $user->user_email
+                ));
+                $addr = '';
+                if ($addr_row) {
+                    $addr = trim($addr_row->street . ', ' . $addr_row->postal_code . ' ' . $addr_row->city);
+                    if ($addr_row->country) {
+                        $addr .= ', ' . $addr_row->country;
+                    }
+                }
+            ?>
+            <h3>Versandadresse</h3>
+            <p><?php echo esc_html($addr); ?></p>
+            <h3>Rechnungsadresse</h3>
+            <p><?php echo esc_html($addr); ?></p>
 
             <h2>Bestellungen</h2>
             <table class="wp-list-table widefat striped">
@@ -157,10 +174,16 @@ foreach ($results as $r) {
                 <p><strong>Dauer:</strong> <?php echo esc_html($o->dauer_text); ?></p>
                 <?php endif; ?>
                 <p><strong>Preis:</strong> <?php echo number_format((float)$o->final_price, 2, ',', '.'); ?>€</p>
+                <?php
+                    $addr_o = trim($o->customer_street . ', ' . $o->customer_postal . ' ' . $o->customer_city);
+                    if (!empty($o->customer_country)) {
+                        $addr_o .= ', ' . $o->customer_country;
+                    }
+                ?>
                 <h4>Versandadresse</h4>
-                <p><?php echo esc_html(trim($o->customer_street . ', ' . $o->customer_postal . ' ' . $o->customer_city)); ?></p>
+                <p><?php echo esc_html($addr_o); ?></p>
                 <h4>Rechnungsadresse</h4>
-                <p><?php echo esc_html(trim($o->customer_street . ', ' . $o->customer_postal . ' ' . $o->customer_city)); ?></p>
+                <p><?php echo esc_html($addr_o); ?></p>
             </div>
             <?php endforeach; ?>
         </div>

--- a/admin/orders-page.php
+++ b/admin/orders-page.php
@@ -139,7 +139,8 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
                         <th style="width: 120px;">Datum</th>
                         <th>Kunde</th>
                         <th>Telefon</th>
-                        <th>Adresse</th>
+                        <th>Versandadresse</th>
+                        <th>Rechnungsadresse</th>
                         <th style="width: 80px;">Produkttyp</th>
                         <th>Produktdetails</th>
                         <th style="width: 100px;">Preis</th>
@@ -168,6 +169,14 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
                         </td>
                         <td>
                             <?php echo esc_html($order->customer_phone); ?>
+                        </td>
+                        <td>
+                            <?php
+                                $addr = trim($order->customer_street . ', ' . $order->customer_postal . ' ' . $order->customer_city);
+                                if ($addr || $order->customer_country) {
+                                    echo esc_html(trim($addr . ', ' . $order->customer_country));
+                                }
+                            ?>
                         </td>
                         <td>
                             <?php

--- a/admin/orders-page.php
+++ b/admin/orders-page.php
@@ -352,7 +352,8 @@ function showOrderDetails(orderId) {
                 <p><strong>Name:</strong> ${order.customer_name || 'Nicht angegeben'}</p>
                 <p><strong>E-Mail:</strong> ${order.customer_email || 'Nicht angegeben'}</p>
                 <p><strong>Telefon:</strong> ${order.customer_phone || 'Nicht angegeben'}</p>
-                <p><strong>Adresse:</strong> ${order.customer_street ? order.customer_street + ', ' + order.customer_postal + ' ' + order.customer_city + ', ' + order.customer_country : 'Nicht angegeben'}</p>
+                <p><strong>Versandadresse:</strong> ${order.customer_street ? order.customer_street + ', ' + order.customer_postal + ' ' + order.customer_city + ', ' + order.customer_country : 'Nicht angegeben'}</p>
+                <p><strong>Rechnungsadresse:</strong> ${order.customer_street ? order.customer_street + ', ' + order.customer_postal + ' ' + order.customer_city + ', ' + order.customer_country : 'Nicht angegeben'}</p>
                 <p><strong>IP-Adresse:</strong> ${order.user_ip}</p>
             </div>
         </div>

--- a/assets/account-style.css
+++ b/assets/account-style.css
@@ -57,6 +57,7 @@ img.wp-smiley, img.emoji {
     grid-template-columns: repeat(2, 1fr);
     gap: 24px;
     margin-bottom: 40px;
+    align-items: start;
 }
 
 .orders-column {
@@ -203,6 +204,7 @@ img.wp-smiley, img.emoji {
     }
     .abo-row {
         grid-template-columns: 1fr;
+        align-items: start;
     }
 }
 

--- a/assets/account-style.css
+++ b/assets/account-style.css
@@ -59,6 +59,12 @@ img.wp-smiley, img.emoji {
     margin-bottom: 40px;
 }
 
+.orders-column {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
 .abo-box,
 .order-box {
     background: #f4f4f4;

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -971,6 +971,7 @@ function produkt_create_subscription() {
                 'street'      => $body['street'] ?? '',
                 'postal_code' => $body['postal'] ?? '',
                 'city'        => $body['city'] ?? '',
+                'country'     => $body['country'] ?? '',
             ]
         );
         $user = get_user_by('email', sanitize_email($body['email'] ?? ''));
@@ -1044,6 +1045,7 @@ function produkt_create_subscription() {
                         'street'      => $body['street'] ?? '',
                         'postal_code' => $body['postal'] ?? '',
                         'city'        => $body['city'] ?? '',
+                        'country'     => $body['country'] ?? '',
                     ]
                 );
                 $user = get_user_by('email', $cust_email);
@@ -1173,6 +1175,7 @@ function produkt_create_checkout_session() {
                         'street'      => $body['street'] ?? '',
                         'postal_code' => $body['postal'] ?? '',
                         'city'        => $body['city'] ?? '',
+                        'country'     => $body['country'] ?? '',
                     ]
                 );
                 $user = get_user_by('email', $customer_email);
@@ -1294,6 +1297,7 @@ function produkt_create_checkout_session() {
                         'street'      => $body['street'] ?? '',
                         'postal_code' => $body['postal'] ?? '',
                         'city'        => $body['city'] ?? '',
+                        'country'     => $body['country'] ?? '',
                     ]
                 );
                 $user = get_user_by('email', $customer_email);
@@ -1535,6 +1539,7 @@ function produkt_create_embedded_checkout_session() {
                             'street'      => $body['street'] ?? '',
                             'postal_code' => $body['postal'] ?? '',
                             'city'        => $body['city'] ?? '',
+                            'country'     => $body['country'] ?? '',
                         ]
                     );
                     $user = get_user_by('email', $customer_email);
@@ -1546,9 +1551,14 @@ function produkt_create_embedded_checkout_session() {
 
             if (!empty($stripe_customer_id)) {
                 $session_params['customer'] = $stripe_customer_id;
-                $session_params['customer_update'] = ['shipping' => 'auto'];
             } else {
                 $session_params['customer_creation'] = 'always';
+            }
+        }
+
+        if (!empty($session_params['automatic_tax']['enabled'])) {
+            if (!empty($session_params['customer']) || !empty($session_params['customer_creation'])) {
+                $session_params['customer_update'] = ['shipping' => 'auto'];
             }
         }
 

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -1304,10 +1304,10 @@ function produkt_create_checkout_session() {
 
             if ($stripe_customer_id) {
                 $session_args['customer'] = $stripe_customer_id;
+            } else {
+                $session_args['customer_creation'] = 'always';
             }
-        }
-
-        if (empty($session_args['customer'])) {
+        } else {
             $session_args['customer_creation'] = 'always';
         }
 
@@ -1544,16 +1544,19 @@ function produkt_create_embedded_checkout_session() {
                 }
                 if ($stripe_customer_id) {
                     $session_params['customer'] = $stripe_customer_id;
+                } else {
+                    $session_params['customer_creation'] = 'always';
                 }
-            }
-
-            if (empty($session_params['customer'])) {
+            } else {
                 $session_params['customer_creation'] = 'always';
             }
         }
 
         if (!empty($session_params['automatic_tax']['enabled'])) {
-            if (!empty($session_params['customer']) || !empty($session_params['customer_creation'])) {
+            if (
+                !empty($session_params['customer']) ||
+                (isset($session_params['customer_creation']) && $session_params['customer_creation'] === 'always')
+            ) {
                 $session_params['customer_update'] = ['shipping' => 'auto'];
             }
         }

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -1553,7 +1553,9 @@ function produkt_create_embedded_checkout_session() {
         }
 
         if (!empty($session_params['automatic_tax']['enabled'])) {
-            $session_params['customer_update'] = ['shipping' => 'auto'];
+            if (!empty($session_params['customer']) || !empty($session_params['customer_creation'])) {
+                $session_params['customer_update'] = ['shipping' => 'auto'];
+            }
         }
 
         $session = \Stripe\Checkout\Session::create($session_params);

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -1542,19 +1542,13 @@ function produkt_create_embedded_checkout_session() {
                         update_user_meta($user->ID, 'stripe_customer_id', $stripe_customer_id);
                     }
                 }
-                if ($stripe_customer_id) {
-                    $session_params['customer'] = $stripe_customer_id;
-                } else {
-                    $session_params['customer_creation'] = 'always';
-                }
+            }
+
+            if (!empty($stripe_customer_id)) {
+                $session_params['customer'] = $stripe_customer_id;
+                $session_params['customer_update'] = ['shipping' => 'auto'];
             } else {
                 $session_params['customer_creation'] = 'always';
-            }
-        }
-
-        if (!empty($session_params['automatic_tax']['enabled'])) {
-            if (!empty($session_params['customer']) || !empty($session_params['customer_creation'])) {
-                $session_params['customer_update'] = ['shipping' => 'auto'];
             }
         }
 

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -1557,7 +1557,7 @@ function produkt_create_embedded_checkout_session() {
         }
 
         if (!empty($session_params['automatic_tax']['enabled'])) {
-            if (!empty($session_params['customer']) || !empty($session_params['customer_creation'])) {
+            if (!empty($session_params['customer'])) {
                 $session_params['customer_update'] = ['shipping' => 'auto'];
             }
         }

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -1552,14 +1552,10 @@ function produkt_create_embedded_checkout_session() {
             }
         }
 
-        if (
-            !empty($session_params['automatic_tax']['enabled']) &&
-            (
-                (!empty($session_params['customer']) && $session_params['mode'] === 'subscription') ||
-                (!empty($session_params['customer_creation']) && $session_params['mode'] === 'subscription')
-            )
-        ) {
-            $session_params['customer_update'] = ['shipping' => 'auto'];
+        if (!empty($session_params['automatic_tax']['enabled'])) {
+            if (!empty($session_params['customer']) || !empty($session_params['customer_creation'])) {
+                $session_params['customer_update'] = ['shipping' => 'auto'];
+            }
         }
 
         $session = \Stripe\Checkout\Session::create($session_params);

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -1552,13 +1552,14 @@ function produkt_create_embedded_checkout_session() {
             }
         }
 
-        if (!empty($session_params['automatic_tax']['enabled'])) {
-            if (
-                !empty($session_params['customer']) ||
-                (isset($session_params['customer_creation']) && $session_params['customer_creation'] === 'always')
-            ) {
-                $session_params['customer_update'] = ['shipping' => 'auto'];
-            }
+        if (
+            !empty($session_params['automatic_tax']['enabled']) &&
+            (
+                (!empty($session_params['customer']) && $session_params['mode'] === 'subscription') ||
+                (!empty($session_params['customer_creation']) && $session_params['mode'] === 'subscription')
+            )
+        ) {
+            $session_params['customer_update'] = ['shipping' => 'auto'];
         }
 
         $session = \Stripe\Checkout\Session::create($session_params);

--- a/includes/Webhook.php
+++ b/includes/Webhook.php
@@ -111,7 +111,13 @@ function handle_stripe_webhook(WP_REST_Request $request) {
         $email    = sanitize_email($session->customer_details->email ?? '');
         $phone    = sanitize_text_field($session->customer_details->phone ?? '');
 
-        $address = $session->customer_details->address ?? null;
+        $shipping_details = $session->shipping_details ? $session->shipping_details->toArray() : [];
+        $customer_details = $session->customer_details ? $session->customer_details->toArray() : [];
+        $address = $shipping_details['address'] ?? $customer_details['address'] ?? null;
+        $street  = $address['line1'] ?? '';
+        $postal  = $address['postal_code'] ?? '';
+        $city    = $address['city'] ?? '';
+        $country = $address['country'] ?? '';
 
         // Persist customer information in custom table
         Database::upsert_customer_record_by_email(
@@ -120,10 +126,10 @@ function handle_stripe_webhook(WP_REST_Request $request) {
             $full_name,
             $phone,
             [
-                'street'      => $address->line1 ?? '',
-                'postal_code' => $address->postal_code ?? '',
-                'city'        => $address->city ?? '',
-                'country'     => $address->country ?? '',
+                'street'      => $street,
+                'postal_code' => $postal,
+                'city'        => $city,
+                'country'     => $country,
             ]
         );
 

--- a/includes/render-order-details.php
+++ b/includes/render-order-details.php
@@ -1,0 +1,30 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+?>
+<div class="order-box">
+    <?php if (!empty($image_url)) : ?>
+        <img class="order-product-image" src="<?php echo esc_url($image_url); ?>" alt="">
+    <?php endif; ?>
+    <h3>Bestellung #<?php echo esc_html($order->id); ?></h3>
+    <p><strong>Datum:</strong> <?php echo esc_html(date_i18n('d.m.Y', strtotime($order->created_at))); ?></p>
+    <p><strong>Produkt:</strong> <?php echo esc_html($order->produkt_name); ?></p>
+    <p><strong>Preis:</strong> <?php echo esc_html(number_format((float) $order->final_price, 2, ',', '.')); ?>€</p>
+    <?php if ($order->shipping_cost > 0) : ?>
+        <p><strong>Versand:</strong> <?php echo esc_html(number_format((float) $order->shipping_cost, 2, ',', '.')); ?>€</p>
+    <?php endif; ?>
+    <?php if (!empty($order->extra_text)) : ?>
+        <p><strong>Extras:</strong> <?php echo esc_html($order->extra_text); ?></p>
+    <?php endif; ?>
+    <?php if (!empty($order->produktfarbe_text)) : ?>
+        <p><strong>Farbe:</strong> <?php echo esc_html($order->produktfarbe_text); ?></p>
+    <?php endif; ?>
+    <?php if (!empty($order->gestellfarbe_text)) : ?>
+        <p><strong>Gestellfarbe:</strong> <?php echo esc_html($order->gestellfarbe_text); ?></p>
+    <?php endif; ?>
+    <?php if (!empty($order->zustand_text)) : ?>
+        <p><strong>Zustand:</strong> <?php echo esc_html($order->zustand_text); ?></p>
+    <?php endif; ?>
+    <?php if (!empty($order->dauer_text)) : ?>
+        <p><strong>Miettage:</strong> <?php echo esc_html($order->dauer_text); ?></p>
+    <?php endif; ?>
+</div>

--- a/templates/account-page.php
+++ b/templates/account-page.php
@@ -28,10 +28,24 @@ $sale_orders   = [];
 $order_map     = [];
 $subscriptions = [];
 $full_name     = '';
+$customer_addr = '';
 
 if (is_user_logged_in()) {
     $user_id = get_current_user_id();
     $orders  = Database::get_orders_for_user($user_id);
+
+    $current_user = wp_get_current_user();
+    global $wpdb;
+    $addr_row = $wpdb->get_row($wpdb->prepare(
+        "SELECT street, postal_code, city, country FROM {$wpdb->prefix}produkt_customers WHERE email = %s",
+        $current_user->user_email
+    ));
+    if ($addr_row) {
+        $customer_addr = trim($addr_row->street . ', ' . $addr_row->postal_code . ' ' . $addr_row->city);
+        if ($addr_row->country) {
+            $customer_addr .= ', ' . $addr_row->country;
+        }
+    }
 
     foreach ($orders as $o) {
         if (!empty($o->subscription_id)) {

--- a/views/account/dashboard.php
+++ b/views/account/dashboard.php
@@ -53,13 +53,18 @@
                             <p><strong>Telefon:</strong> <?php echo esc_html($first->customer_phone); ?></p>
                         <?php endif; ?>
                         <?php
-                            $addr = trim($first->customer_street . ', ' . $first->customer_postal . ' ' . $first->customer_city);
-                            $country = $first->customer_country ? ', ' . $first->customer_country : '';
+                            $addr = $customer_addr;
+                            if (!$addr) {
+                                $addr = trim($first->customer_street . ', ' . $first->customer_postal . ' ' . $first->customer_city);
+                                if ($first->customer_country) {
+                                    $addr .= ', ' . $first->customer_country;
+                                }
+                            }
                         ?>
                         <h4>Versandadresse</h4>
-                        <p><?php echo esc_html($addr . $country); ?></p>
+                        <p><?php echo esc_html($addr ?: 'Nicht angegeben'); ?></p>
                         <h4>Rechnungsadresse</h4>
-                        <p><?php echo esc_html($addr . $country); ?></p>
+                        <p><?php echo esc_html($addr ?: 'Nicht angegeben'); ?></p>
                     </div>
                     <div class="orders-column">
                         <?php foreach ($sale_orders as $order) : ?>

--- a/views/account/dashboard.php
+++ b/views/account/dashboard.php
@@ -52,10 +52,14 @@
                         <?php if (!empty($first->customer_phone)) : ?>
                             <p><strong>Telefon:</strong> <?php echo esc_html($first->customer_phone); ?></p>
                         <?php endif; ?>
+                        <?php
+                            $addr = trim($first->customer_street . ', ' . $first->customer_postal . ' ' . $first->customer_city);
+                            $country = $first->customer_country ? ', ' . $first->customer_country : '';
+                        ?>
                         <h4>Versandadresse</h4>
-                        <p><?php echo esc_html(trim($first->customer_street . ', ' . $first->customer_postal . ' ' . $first->customer_city)); ?></p>
+                        <p><?php echo esc_html($addr . $country); ?></p>
                         <h4>Rechnungsadresse</h4>
-                        <p><?php echo esc_html(trim($first->customer_street . ', ' . $first->customer_postal . ' ' . $first->customer_city)); ?></p>
+                        <p><?php echo esc_html($addr . $country); ?></p>
                     </div>
                     <div class="orders-column">
                         <?php foreach ($sale_orders as $order) : ?>

--- a/views/account/dashboard.php
+++ b/views/account/dashboard.php
@@ -39,13 +39,34 @@
             <div>
         <?php if ($is_sale) : ?>
             <?php if (!empty($sale_orders)) : ?>
-                <?php foreach ($sale_orders as $order) : ?>
-                    <?php
-                        $variant_id = $order->variant_id ?? 0;
-                        $image_url  = pv_get_image_url_by_variant_or_category($variant_id, $order->category_id ?? 0);
-                    ?>
-                    <?php include PRODUKT_PLUGIN_PATH . 'includes/render-order.php'; ?>
-                <?php endforeach; ?>
+                <?php $first = $sale_orders[0]; ?>
+                <div class="abo-row">
+                    <div class="order-box">
+                        <h3>Kundendaten</h3>
+                        <?php if (!empty($first->customer_name)) : ?>
+                            <p><strong>Name:</strong> <?php echo esc_html($first->customer_name); ?></p>
+                        <?php endif; ?>
+                        <?php if (!empty($first->customer_email)) : ?>
+                            <p><strong>E-Mail:</strong> <?php echo esc_html($first->customer_email); ?></p>
+                        <?php endif; ?>
+                        <?php if (!empty($first->customer_phone)) : ?>
+                            <p><strong>Telefon:</strong> <?php echo esc_html($first->customer_phone); ?></p>
+                        <?php endif; ?>
+                        <h4>Versandadresse</h4>
+                        <p><?php echo esc_html(trim($first->customer_street . ', ' . $first->customer_postal . ' ' . $first->customer_city)); ?></p>
+                        <h4>Rechnungsadresse</h4>
+                        <p><?php echo esc_html(trim($first->customer_street . ', ' . $first->customer_postal . ' ' . $first->customer_city)); ?></p>
+                    </div>
+                    <div class="orders-column">
+                        <?php foreach ($sale_orders as $order) : ?>
+                            <?php
+                                $variant_id = $order->variant_id ?? 0;
+                                $image_url  = pv_get_image_url_by_variant_or_category($variant_id, $order->category_id ?? 0);
+                            ?>
+                            <?php include PRODUKT_PLUGIN_PATH . 'includes/render-order-details.php'; ?>
+                        <?php endforeach; ?>
+                    </div>
+                </div>
             <?php else : ?>
                 <p>Keine Bestellungen.</p>
             <?php endif; ?>


### PR DESCRIPTION
## Summary
- show customer details only once in account dashboard
- list orders on the right and include billing/shipping address
- add layout helper style

## Testing
- `php -l includes/render-order-details.php`
- `php -l views/account/dashboard.php`


------
https://chatgpt.com/codex/tasks/task_b_6881f188890c8330a5a01c1170d8ed7b