### PR TITLE
Add login prompt before checkout

### DIFF
--- a/admin/customers-page.php
+++ b/admin/customers-page.php
@@ -120,6 +120,23 @@ foreach ($results as $r) {
             <p><strong>Nachname:</strong> <?php echo esc_html($last); ?></p>
             <p><strong>E-Mail:</strong> <?php echo esc_html($user->user_email); ?></p>
             <p><strong>Telefon:</strong> <?php echo esc_html($phone ?: '–'); ?></p>
+            <?php
+                $addr_row = $wpdb->get_row($wpdb->prepare(
+                    "SELECT street, postal_code, city, country FROM {$wpdb->prefix}produkt_customers WHERE email = %s",
+                    $user->user_email
+                ));
+                $addr = '';
+                if ($addr_row) {
+                    $addr = trim($addr_row->street . ', ' . $addr_row->postal_code . ' ' . $addr_row->city);
+                    if ($addr_row->country) {
+                        $addr .= ', ' . $addr_row->country;
+                    }
+                }
+            ?>
+            <h3>Versandadresse</h3>
+            <p><?php echo esc_html($addr); ?></p>
+            <h3>Rechnungsadresse</h3>
+            <p><?php echo esc_html($addr); ?></p>
 
             <h2>Bestellungen</h2>
             <table class="wp-list-table widefat striped">
@@ -157,10 +174,16 @@ foreach ($results as $r) {
                 <p><strong>Dauer:</strong> <?php echo esc_html($o->dauer_text); ?></p>
                 <?php endif; ?>
                 <p><strong>Preis:</strong> <?php echo number_format((float)$o->final_price, 2, ',', '.'); ?>€</p>
+                <?php
+                    $addr_o = trim($o->customer_street . ', ' . $o->customer_postal . ' ' . $o->customer_city);
+                    if (!empty($o->customer_country)) {
+                        $addr_o .= ', ' . $o->customer_country;
+                    }
+                ?>
                 <h4>Versandadresse</h4>
-                <p><?php echo esc_html(trim($o->customer_street . ', ' . $o->customer_postal . ' ' . $o->customer_city)); ?></p>
+                <p><?php echo esc_html($addr_o); ?></p>
                 <h4>Rechnungsadresse</h4>
-                <p><?php echo esc_html(trim($o->customer_street . ', ' . $o->customer_postal . ' ' . $o->customer_city)); ?></p>
+                <p><?php echo esc_html($addr_o); ?></p>
             </div>
             <?php endforeach; ?>
         </div>

--- a/admin/orders-page.php
+++ b/admin/orders-page.php
@@ -139,7 +139,8 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
                         <th style="width: 120px;">Datum</th>
                         <th>Kunde</th>
                         <th>Telefon</th>
-                        <th>Adresse</th>
+                        <th>Versandadresse</th>
+                        <th>Rechnungsadresse</th>
                         <th style="width: 80px;">Produkttyp</th>
                         <th>Produktdetails</th>
                         <th style="width: 100px;">Preis</th>
@@ -168,6 +169,14 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
                         </td>
                         <td>
                             <?php echo esc_html($order->customer_phone); ?>
+                        </td>
+                        <td>
+                            <?php
+                                $addr = trim($order->customer_street . ', ' . $order->customer_postal . ' ' . $order->customer_city);
+                                if ($addr || $order->customer_country) {
+                                    echo esc_html(trim($addr . ', ' . $order->customer_country));
+                                }
+                            ?>
                         </td>
                         <td>
                             <?php
@@ -352,7 +361,8 @@ function showOrderDetails(orderId) {
                 <p><strong>Name:</strong> ${order.customer_name || 'Nicht angegeben'}</p>
                 <p><strong>E-Mail:</strong> ${order.customer_email || 'Nicht angegeben'}</p>
                 <p><strong>Telefon:</strong> ${order.customer_phone || 'Nicht angegeben'}</p>
-                <p><strong>Adresse:</strong> ${order.customer_street ? order.customer_street + ', ' + order.customer_postal + ' ' + order.customer_city + ', ' + order.customer_country : 'Nicht angegeben'}</p>
+                <p><strong>Versandadresse:</strong> ${order.customer_street ? order.customer_street + ', ' + order.customer_postal + ' ' + order.customer_city + ', ' + order.customer_country : 'Nicht angegeben'}</p>
+                <p><strong>Rechnungsadresse:</strong> ${order.customer_street ? order.customer_street + ', ' + order.customer_postal + ' ' + order.customer_city + ', ' + order.customer_country : 'Nicht angegeben'}</p>
                 <p><strong>IP-Adresse:</strong> ${order.user_ip}</p>
             </div>
         </div>

--- a/admin/orders-page.php
+++ b/admin/orders-page.php
@@ -39,14 +39,14 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
     
     
     <!-- Filter Section -->
-    <div style="background: #f0f8ff; border: 1px solid #b3d9ff; padding: 15px; border-radius: 4px; margin-bottom: 20px;">
+    <div class="orders-filter-box">
         <h3>🔍 Filter & Zeitraum</h3>
-        <form method="get" action="" style="display: flex; align-items: center; gap: 15px; flex-wrap: wrap;">
+        <form method="get" action="" class="orders-filter-form">
             <input type="hidden" name="page" value="produkt-orders">
             
             <div>
                 <label for="category-select"><strong>Produkt:</strong></label>
-                <select name="category" id="category-select" style="min-width: 200px;">
+                <select name="category" id="category-select">
                     <option value="0" <?php selected($selected_category, 0); ?>>Alle Produkte</option>
                     <?php foreach ($categories as $category): ?>
                     <option value="<?php echo $category->id; ?>" <?php selected($selected_category, $category->id); ?>>
@@ -70,7 +70,7 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
         </form>
         
         <?php if ($current_category): ?>
-        <div style="margin-top: 10px; padding: 10px; background: white; border-radius: 4px;">
+        <div class="current-category-box">
             <strong>📝 Aktuelle Produkt:</strong> <?php echo esc_html($current_category->name); ?>
             <code>[produkt_product category="<?php echo esc_html($current_category->shortcode); ?>"]</code>
         </div>
@@ -81,7 +81,7 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
     <div class="produkt-summary-grid">
         <div class="produkt-summary-card">
             <h3>📋 Gesamt-Bestellungen</h3>
-            <div class="produkt-summary-value" style="color:#2a372a;">
+            <div class="produkt-summary-value summary-green">
                 <?php echo number_format($total_orders); ?>
             </div>
             <p class="produkt-summary-note">Im gewählten Zeitraum</p>
@@ -89,7 +89,7 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
 
         <div class="produkt-summary-card">
             <h3>💰 Gesamt-Umsatz</h3>
-            <div class="produkt-summary-value" style="color: #666666;">
+            <div class="produkt-summary-value summary-gray">
                 <?php echo number_format($total_revenue, 2, ',', '.'); ?>€
             </div>
             <p class="produkt-summary-note">Monatlicher Mietumsatz</p>
@@ -97,7 +97,7 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
 
         <div class="produkt-summary-card">
             <h3>📊 Durchschnittswert</h3>
-            <div class="produkt-summary-value" style="color:#dc3232;">
+            <div class="produkt-summary-value summary-red">
                 <?php echo number_format($avg_order_value, 2, ',', '.'); ?>€
             </div>
             <p class="produkt-summary-note">Pro Bestellung</p>
@@ -114,18 +114,18 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
     </div>
     
     <!-- Orders Table -->
-    <div style="background: white; border: 1px solid #ddd; border-radius: 8px; padding: 20px; margin-bottom: 30px;">
+    <div class="orders-table-container">
         <h3>📋 Bestellübersicht</h3>
         <?php if (!empty($orders)): ?>
-        <div style="margin:10px 0;">
+        <div class="orders-bulk-actions">
             <button type="button" class="button" onclick="toggleSelectAll()">Alle auswählen</button>
-            <button type="button" class="button" onclick="deleteSelected()" style="color:#dc3232;">Ausgewählte löschen</button>
+            <button type="button" class="button" onclick="deleteSelected()" class="text-red">Ausgewählte löschen</button>
         </div>
         <?php endif; ?>
         
         <?php if (empty($orders)): ?>
-        <div style="text-align: center; padding: 40px;">
-            <p style="font-size: 18px; color: #666;">Keine Bestellungen im gewählten Zeitraum gefunden.</p>
+        <div class="orders-empty">
+            <p class="orders-empty-message">Keine Bestellungen im gewählten Zeitraum gefunden.</p>
             <p>Versuchen Sie einen anderen Zeitraum oder eine andere Produkt.</p>
         </div>
         <?php else: ?>
@@ -134,19 +134,19 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
             <table class="wp-list-table widefat fixed striped">
                 <thead>
                     <tr>
-                        <th style="width:40px;"><input type="checkbox" id="select-all-orders"></th>
-                        <th style="width: 80px;">ID</th>
-                        <th style="width: 120px;">Datum</th>
+                        <th class="col-checkbox"><input type="checkbox" id="select-all-orders"></th>
+                        <th class="col-id">ID</th>
+                        <th class="col-date">Datum</th>
                         <th>Kunde</th>
                         <th>Telefon</th>
                         <th>Versandadresse</th>
                         <th>Rechnungsadresse</th>
-                        <th style="width: 80px;">Produkttyp</th>
+                        <th class="col-type">Produkttyp</th>
                         <th>Produktdetails</th>
-                        <th style="width: 100px;">Preis</th>
-                        <th style="width: 80px;">Rabatt</th>
-                        <th style="width: 100px;">Status</th>
-                        <th style="width: 120px;">Aktionen</th>
+                        <th class="col-price">Preis</th>
+                        <th class="col-discount">Rabatt</th>
+                        <th class="col-status">Status</th>
+                        <th class="col-actions">Aktionen</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -156,7 +156,7 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
                         <td><strong>#<?php echo $order->id; ?></strong></td>
                         <td>
                             <?php echo date('d.m.Y', strtotime($order->created_at)); ?><br>
-                            <small style="color: #666;"><?php echo date('H:i', strtotime($order->created_at)); ?> Uhr</small>
+                            <small class="text-gray"><?php echo date('H:i', strtotime($order->created_at)); ?> Uhr</small>
                         </td>
                         <td>
                             <?php if (!empty($order->customer_name)): ?>
@@ -165,7 +165,7 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
                             <?php if (!empty($order->customer_email)): ?>
                                 <a href="mailto:<?php echo esc_attr($order->customer_email); ?>"><?php echo esc_html($order->customer_email); ?></a><br>
                             <?php endif; ?>
-                            <small style="color: #666;">IP: <?php echo esc_html($order->user_ip); ?></small>
+                            <small class="text-gray">IP: <?php echo esc_html($order->user_ip); ?></small>
                         </td>
                         <td>
                             <?php echo esc_html($order->customer_phone); ?>
@@ -196,45 +196,45 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
                         ?>
                         <td><?php echo esc_html($type); ?></td>
                         <td>
-                            <div style="line-height: 1.4;">
+                            <div class="order-details-info">
                                 <strong><?php echo esc_html($order->category_name); ?></strong><br>
-                                <span style="color: #666;">📦 <?php echo esc_html($order->variant_name); ?></span><br>
-                                <span style="color: #666;">🎁 <?php echo esc_html($order->extra_names); ?></span><br>
+                                <span class="text-gray">📦 <?php echo esc_html($order->variant_name); ?></span><br>
+                                <span class="text-gray">🎁 <?php echo esc_html($order->extra_names); ?></span><br>
                                 <?php if ($type === 'Verkauf'): ?>
-                                    <span style="color: #666;">⏰ Miettage: <?php echo esc_html($order->duration_name); ?></span><br>
+                                    <span class="text-gray">⏰ Miettage: <?php echo esc_html($order->duration_name); ?></span><br>
                                 <?php else: ?>
-                                    <span style="color: #666;">⏰ Mietdauer: <?php echo esc_html($order->duration_name); ?></span><br>
+                                    <span class="text-gray">⏰ Mietdauer: <?php echo esc_html($order->duration_name); ?></span><br>
                                 <?php endif; ?>
                                 
                                 <?php if ($order->condition_name): ?>
-                                    <span style="color: #666;">🔄 <?php echo esc_html($order->condition_name); ?></span><br>
+                                    <span class="text-gray">🔄 <?php echo esc_html($order->condition_name); ?></span><br>
                                 <?php endif; ?>
                                 
                                 <?php if ($order->product_color_name): ?>
-                                    <span style="color: #666;">🎨 Produkt: <?php echo esc_html($order->product_color_name); ?></span><br>
+                                    <span class="text-gray">🎨 Produkt: <?php echo esc_html($order->product_color_name); ?></span><br>
                                 <?php endif; ?>
                                 
                                 <?php if ($order->frame_color_name): ?>
-                                    <span style="color: #666;">🖼️ Gestell: <?php echo esc_html($order->frame_color_name); ?></span><br>
+                                    <span class="text-gray">🖼️ Gestell: <?php echo esc_html($order->frame_color_name); ?></span><br>
                                 <?php endif; ?>
                             </div>
                         </td>
                         <td>
-                            <strong style="color: #666666; font-size: 16px;">
+                            <strong class="order-price">
                                 <?php echo number_format($order->final_price, 2, ',', '.'); ?>€
                             </strong><br>
                             <?php if ($type !== 'Verkauf'): ?>
-                                <small style="color: #666;">/Monat</small>
+                                <small class="text-gray">/Monat</small>
                             <?php endif; ?>
                             <?php if ($order->shipping_cost > 0): ?>
-                                <br><span style="color:#666;">+ <?php echo number_format($order->shipping_cost, 2, ',', '.'); ?>€ einmalig</span>
+                                <br><span class="text-gray">+ <?php echo number_format($order->shipping_cost, 2, ',', '.'); ?>€ einmalig</span>
                             <?php endif; ?>
                         </td>
                         <td>
                             <?php if ($order->discount_amount > 0): ?>
-                                <span style="color:#0073aa; font-weight:bold;">-<?php echo number_format($order->discount_amount, 2, ',', '.'); ?>€</span>
+                                <span class="text-blue">-<?php echo number_format($order->discount_amount, 2, ',', '.'); ?>€</span>
                             <?php else: ?>
-                                <span style="color:#666;">–</span>
+                                <span class="text-gray">–</span>
                             <?php endif; ?>
                         </td>
                         <td>
@@ -253,7 +253,7 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
                              <br><br>
                             <a href="<?php echo admin_url('admin.php?page=produkt-orders&category=' . $selected_category . '&delete_order=' . $order->id . '&date_from=' . $date_from . '&date_to=' . $date_to); ?>"
                                class="button button-small"
-                               style="color: #dc3232;"
+                               class="text-red"
                                onclick="return confirm('Sind Sie sicher, dass Sie diese Bestellung löschen möchten?\n\nBestellung #<?php echo $order->id; ?> wird unwiderruflich gelöscht!')">
                                 🗑️ Löschen
                             </a>
@@ -268,9 +268,9 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
     </div>
     
     <!-- Export Section -->
-    <div style="background: #f8f9fa; border: 1px solid #e9ecef; border-radius: 8px; padding: 20px; margin-bottom: 30px;">
+    <div class="orders-export-box">
         <h3>📤 Export & Aktionen</h3>
-        <div style="display: flex; gap: 15px; flex-wrap: wrap;">
+        <div class="orders-export-actions">
             <button type="button" class="button" onclick="exportOrders('csv')">
                 📊 Als CSV exportieren
             </button>
@@ -281,15 +281,15 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
                 🖨️ Drucken
             </button>
         </div>
-        <p style="margin-top: 10px; color: #666; font-size: 13px;">
+        <p class="orders-export-note">
             Exportiert werden alle Bestellungen im aktuell gewählten Filter-Zeitraum und der ausgewählten Produkt.
         </p>
     </div>
     
     <!-- Info Box -->
-    <div style="background: #d1ecf1; border: 1px solid #bee5eb; padding: 20px; border-radius: 8px;">
+    <div class="info-box">
         <h3>📋 Bestellungen-System</h3>
-        <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px;">
+        <div class="info-box-grid">
             <div>
                 <h4>🎯 Was wird erfasst:</h4>
                 <ul>
@@ -313,11 +313,11 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
             </div>
         </div>
         
-        <div style="margin-top: 15px; padding: 15px; background: #d4edda; border: 1px solid #c3e6cb; border-radius: 4px;">
+        <div class="tip-box">
             <strong>💡 Tipp:</strong> Nutzen Sie die Filterfunktionen um spezifische Zeiträume oder Produkte zu analysieren. Die Export-Funktion hilft bei der weiteren Datenverarbeitung in Excel oder anderen Tools.
         </div>
         
-        <div style="margin-top: 10px; padding: 15px; background: #fff3cd; border: 1px solid #ffeaa7; border-radius: 4px;">
+        <div class="privacy-box">
             <strong>🔒 Datenschutz:</strong> Alle Kundendaten werden sicher gespeichert und nur für die Bestellabwicklung verwendet. IP-Adressen dienen der Fraud-Prevention und werden nach 30 Tagen anonymisiert.
         </div>
     </div>
@@ -327,9 +327,9 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
 <div id="order-details-modal" class="modal-overlay">
     <div class="modal-content">
         <button type="button" class="modal-close" onclick="closeOrderDetails()">&times;</button>
-        <h3 style="margin-top: 0;">📋 Bestelldetails</h3>
+        <h3 class="modal-heading">📋 Bestelldetails</h3>
         <div id="order-details-content"></div>
-        <div style="text-align: right; margin-top: 20px;">
+        <div class="order-modal-footer">
             <button type="button" class="button-primary" onclick="closeOrderDetails()">Schließen</button>
         </div>
     </div>
@@ -347,7 +347,7 @@ function showOrderDetails(orderId) {
     if (!order) return;
     
     let detailsHtml = `
-        <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px;">
+        <div class="details-grid">
             <div>
                 <h4>📋 Bestellinformationen</h4>
                 <p><strong>Bestellnummer:</strong> #${order.id}</p>

--- a/admin/orders-page.php
+++ b/admin/orders-page.php
@@ -89,7 +89,7 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
 
         <div class="produkt-summary-card">
             <h3>💰 Gesamt-Umsatz</h3>
-            <div class="produkt-summary-value" style="color: <?php echo esc_attr($branding['admin_color_secondary'] ?? '#4a674a'); ?>;">
+            <div class="produkt-summary-value" style="color: #666666;">
                 <?php echo number_format($total_revenue, 2, ',', '.'); ?>€
             </div>
             <p class="produkt-summary-note">Monatlicher Mietumsatz</p>
@@ -220,7 +220,7 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
                             </div>
                         </td>
                         <td>
-                            <strong style="color: <?php echo esc_attr($branding['admin_color_secondary'] ?? '#4a674a'); ?>; font-size: 16px;">
+                            <strong style="color: #666666; font-size: 16px;">
                                 <?php echo number_format($order->final_price, 2, ',', '.'); ?>€
                             </strong><br>
                             <?php if ($type !== 'Verkauf'): ?>

--- a/admin/shipping-page.php
+++ b/admin/shipping-page.php
@@ -119,7 +119,14 @@ if (isset($_GET['delete']) && isset($_GET['fw_nonce']) &&
 }
 
 $rows      = $wpdb->get_results("SELECT * FROM $table ORDER BY id DESC");
-$providers = ['dhl' => 'DHL', 'hermes' => 'Hermes', 'ups' => 'UPS', 'dpd' => 'DPD'];
+$providers = [
+    'none'   => 'Ohne',
+    'pickup' => 'Abholung',
+    'dhl'    => 'DHL',
+    'hermes' => 'Hermes',
+    'ups'    => 'UPS',
+    'dpd'    => 'DPD'
+];
 ?>
 <div class="wrap">
     <h1>Versandarten verwalten</h1>
@@ -169,7 +176,7 @@ $providers = ['dhl' => 'DHL', 'hermes' => 'Hermes', 'ups' => 'UPS', 'dpd' => 'DP
                     <tr>
                         <td><?= esc_html($r->name) ?><?= $r->is_default ? ' (Standard)' : '' ?></td>
                         <td><?= number_format($r->price, 2, ',', '.') ?> €</td>
-                        <td><span class="icon-<?= esc_attr($r->service_provider) ?>"><?= esc_html(ucfirst($r->service_provider)) ?></span></td>
+                        <td><span class="icon-<?= esc_attr($r->service_provider) ?>"><?= esc_html($providers[$r->service_provider] ?? ucfirst($r->service_provider)) ?></span></td>
                         <td><?= esc_html($r->stripe_price_id) ?></td>
                         <td>
                             <a href="<?php echo admin_url('admin.php?page=produkt-shipping&edit=' . $r->id); ?>">Bearbeiten</a>

--- a/admin/tabs/buttons-tab.php
+++ b/admin/tabs/buttons-tab.php
@@ -8,6 +8,7 @@ if (isset($_POST['submit_buttons'])) {
         'button_icon'       => esc_url_raw($_POST['button_icon'] ?? ''),
         'payment_icons'     => isset($_POST['payment_icons']) ? array_map('sanitize_text_field', (array) $_POST['payment_icons']) : [],
         'price_label'       => sanitize_text_field($_POST['price_label'] ?? ''),
+        'shipping_label'    => sanitize_text_field($_POST['shipping_label'] ?? ''),
         'price_period'      => sanitize_text_field($_POST['price_period'] ?? 'month'),
         'vat_included'      => isset($_POST['vat_included']) ? 1 : 0,
         'duration_tooltip'  => sanitize_textarea_field($_POST['duration_tooltip'] ?? ''),
@@ -23,6 +24,7 @@ $ui = get_option('produkt_ui_settings', [
     'button_icon' => '',
     'payment_icons' => [],
     'price_label' => '',
+    'shipping_label' => '',
     'price_period' => 'month',
     'vat_included' => 0,
     'duration_tooltip' => '',
@@ -57,6 +59,10 @@ $ui = get_option('produkt_ui_settings', [
                 <div class="produkt-form-group">
                     <label>Preis-Label</label>
                     <input type="text" name="price_label" value="<?php echo esc_attr($ui['price_label']); ?>" placeholder="Monatlicher Mietpreis">
+                </div>
+                <div class="produkt-form-group">
+                    <label>Versand-Label</label>
+                    <input type="text" name="shipping_label" value="<?php echo esc_attr($ui['shipping_label']); ?>" placeholder="Einmalige Versandkosten">
                 </div>
                 <div class="produkt-form-group">
                     <label>Preiszeitraum</label>

--- a/assets/account-style.css
+++ b/assets/account-style.css
@@ -57,6 +57,13 @@ img.wp-smiley, img.emoji {
     grid-template-columns: repeat(2, 1fr);
     gap: 24px;
     margin-bottom: 40px;
+    align-items: start;
+}
+
+.orders-column {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
 }
 
 .abo-box,
@@ -197,6 +204,7 @@ img.wp-smiley, img.emoji {
     }
     .abo-row {
         grid-template-columns: 1fr;
+        align-items: start;
     }
 }
 

--- a/assets/admin-style.css
+++ b/assets/admin-style.css
@@ -2716,3 +2716,88 @@
     line-height: 1;
 }
 
+
+/* Orders page custom styles */
+.orders-filter-box {
+    background: #f0f8ff;
+    border: 1px solid #b3d9ff;
+    padding: 15px;
+    border-radius: 4px;
+    margin-bottom: 20px;
+}
+.orders-filter-form {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+    flex-wrap: wrap;
+}
+.orders-filter-form select {
+    min-width: 200px;
+}
+.current-category-box {
+    margin-top: 10px;
+    padding: 10px;
+    background: #fff;
+    border-radius: 4px;
+}
+.orders-table-container {
+    background: #fff;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    padding: 20px;
+    margin-bottom: 30px;
+}
+.orders-bulk-actions { margin:10px 0; }
+.orders-empty { text-align:center; padding:40px; }
+.orders-empty-message { font-size:18px; color:#666; }
+.text-gray { color:#666; }
+.text-red { color:#dc3232; }
+.text-green-dark { color:#2a372a; }
+.text-blue { color:#0073aa; font-weight:bold; }
+.order-details-info { line-height:1.4; }
+.order-price { color:#666666; font-size:16px; }
+.orders-export-box {
+    background: #f8f9fa;
+    border: 1px solid #e9ecef;
+    border-radius: 8px;
+    padding: 20px;
+    margin-bottom: 30px;
+}
+.orders-export-actions { display:flex; gap:15px; flex-wrap:wrap; }
+.orders-export-note { margin-top:10px; color:#666; font-size:13px; }
+.info-box {
+    background: #d1ecf1;
+    border: 1px solid #bee5eb;
+    padding: 20px;
+    border-radius: 8px;
+}
+.info-box-grid { display:grid; grid-template-columns:1fr 1fr; gap:20px; }
+.tip-box {
+    margin-top: 15px;
+    padding: 15px;
+    background: #d4edda;
+    border: 1px solid #c3e6cb;
+    border-radius: 4px;
+}
+.privacy-box {
+    margin-top: 10px;
+    padding: 15px;
+    background: #fff3cd;
+    border: 1px solid #ffeaa7;
+    border-radius: 4px;
+}
+.modal-heading { margin-top:0; }
+.order-modal-footer { text-align:right; margin-top:20px; }
+.details-grid { display:grid; grid-template-columns:1fr 1fr; gap:20px; }
+.summary-green { color:#2a372a; }
+.summary-red { color:#dc3232; }
+.summary-gray { color:#666666; }
+.col-checkbox{width:40px;}
+.col-id{width:80px;}
+.col-date{width:120px;}
+.col-type{width:80px;}
+.col-price{width:100px;}
+.col-discount{width:80px;}
+.col-status{width:100px;}
+.col-actions{width:120px;}
+

--- a/assets/script.js
+++ b/assets/script.js
@@ -797,17 +797,16 @@ jQuery(document).ready(function($) {
                         // Update mobile sticky price
                         updateMobileStickyPrice(data.final_price, data.original_price, data.discount, isAvailable);
 
+                        const label = produkt_ajax.button_text || (produkt_ajax.betriebsmodus === 'kauf' ? 'Jetzt kaufen' : 'Jetzt mieten');
                         if (produkt_ajax.betriebsmodus === 'kauf') {
                             $('.produkt-price-period').hide();
                             $('.produkt-mobile-price-period').hide();
-                            $('#produkt-rent-button span').text('Jetzt kaufen');
-                            $('.produkt-mobile-button span').text('Jetzt kaufen');
                         } else {
                             $('.produkt-price-period').show().text('/Monat');
                             $('.produkt-mobile-price-period').show().text('/Monat');
-                            $('#produkt-rent-button span').text('Jetzt mieten');
-                            $('.produkt-mobile-button span').text('Jetzt mieten');
                         }
+                        $('#produkt-rent-button span').text(label);
+                        $('.produkt-mobile-button span').text(label);
                     }
                 },
                 error: function() {
@@ -831,17 +830,16 @@ jQuery(document).ready(function($) {
             // Hide mobile sticky price
             hideMobileStickyPrice();
 
+            const label = produkt_ajax.button_text || (produkt_ajax.betriebsmodus === 'kauf' ? 'Jetzt kaufen' : 'Jetzt mieten');
             if (produkt_ajax.betriebsmodus === 'kauf') {
                 $('.produkt-price-period').hide();
                 $('.produkt-mobile-price-period').hide();
-                $('#produkt-rent-button span').text('Jetzt kaufen');
-                $('.produkt-mobile-button span').text('Jetzt kaufen');
             } else {
                 $('.produkt-price-period').show().text('/Monat');
                 $('.produkt-mobile-price-period').show().text('/Monat');
-                $('#produkt-rent-button span').text('Jetzt mieten');
-                $('.produkt-mobile-button span').text('Jetzt mieten');
             }
+            $('#produkt-rent-button span').text(label);
+            $('.produkt-mobile-button span').text(label);
         }
     }
 
@@ -849,10 +847,7 @@ jQuery(document).ready(function($) {
         if (window.innerWidth <= 768) {
             // Determine button label and icon from main button
             const mainButton = $('#produkt-rent-button');
-            let mainLabel = mainButton.find('span').text().trim() || 'Jetzt Mieten';
-            if (produkt_ajax.betriebsmodus === 'kauf') {
-                mainLabel = 'Jetzt kaufen';
-            }
+            let mainLabel = produkt_ajax.button_text || mainButton.find('span').text().trim() || (produkt_ajax.betriebsmodus === 'kauf' ? 'Jetzt kaufen' : 'Jetzt mieten');
             const mainIcon = mainButton.data('icon') ? `<img src="${mainButton.data('icon')}" class="produkt-button-icon-img" alt="Button Icon">` : '';
 
             // Create mobile sticky price bar

--- a/assets/script.js
+++ b/assets/script.js
@@ -1257,15 +1257,24 @@ jQuery(document).ready(function($) {
 });
 
 jQuery(function($) {
-    $('#checkout-login-btn').on('click', function(){
-        $('#checkout-login-modal').hide();
-        $('body').removeClass('produkt-popup-open');
-        if (pendingCheckoutUrl) {
-            window.location.href = produkt_ajax.account_url + '?redirect_to=' + encodeURIComponent(pendingCheckoutUrl);
+    $('#checkout-login-btn').on('click', function(e){
+        e.preventDefault();
+        const email = $('#checkout-login-email').val().trim();
+        if (!email) {
+            alert('Bitte E-Mail eingeben');
+            return;
         }
+        const form = $('<form>', {method: 'POST', action: produkt_ajax.account_url});
+        form.append($('<input>', {type: 'hidden', name: 'request_login_code_nonce', value: produkt_ajax.login_nonce}));
+        form.append($('<input>', {type: 'hidden', name: 'request_login_code', value: '1'}));
+        form.append($('<input>', {type: 'hidden', name: 'email', value: email}));
+        form.append($('<input>', {type: 'hidden', name: 'redirect_to', value: pendingCheckoutUrl}));
+        $('body').append(form);
+        form.submit();
     });
 
-    $('#checkout-guest-btn').on('click', function(){
+    $('#checkout-guest-link').on('click', function(e){
+        e.preventDefault();
         $('#checkout-login-modal').hide();
         $('body').removeClass('produkt-popup-open');
         if (pendingCheckoutUrl) {

--- a/assets/script.js
+++ b/assets/script.js
@@ -5,6 +5,7 @@ jQuery(document).ready(function($) {
     let selectedCondition = null;
     let selectedProductColor = null;
     let selectedFrameColor = null;
+    let pendingCheckoutUrl = '';
     let currentVariantImages = [];
     let currentMainImageIndex = 0;
     let currentProductColorImage = null;
@@ -241,8 +242,15 @@ jQuery(document).ready(function($) {
             if (zustandName) params.set('zustand', zustandName);
             if (produktfarbeName) params.set('produktfarbe', produktfarbeName);
             if (gestellfarbeName) params.set('gestellfarbe', gestellfarbeName);
+            const targetUrl = produkt_ajax.checkout_url + '?' + params.toString();
 
-            window.location.href = produkt_ajax.checkout_url + '?' + params.toString();
+            if (produkt_ajax.is_logged_in) {
+                window.location.href = targetUrl;
+            } else {
+                pendingCheckoutUrl = targetUrl;
+                $('#checkout-login-modal').css('display', 'flex');
+                $('body').addClass('produkt-popup-open');
+            }
         }
     });
 
@@ -1246,6 +1254,24 @@ jQuery(document).ready(function($) {
         });
 
     }
+});
+
+jQuery(function($) {
+    $('#checkout-login-btn').on('click', function(){
+        $('#checkout-login-modal').hide();
+        $('body').removeClass('produkt-popup-open');
+        if (pendingCheckoutUrl) {
+            window.location.href = produkt_ajax.account_url + '?redirect_to=' + encodeURIComponent(pendingCheckoutUrl);
+        }
+    });
+
+    $('#checkout-guest-btn').on('click', function(){
+        $('#checkout-login-modal').hide();
+        $('body').removeClass('produkt-popup-open');
+        if (pendingCheckoutUrl) {
+            window.location.href = pendingCheckoutUrl;
+        }
+    });
 });
 
 document.addEventListener("DOMContentLoaded", function () {

--- a/assets/script.js
+++ b/assets/script.js
@@ -34,6 +34,15 @@ jQuery(document).ready(function($) {
         if (spid) {
             shippingPriceId = spid.toString();
         }
+        const firstShip = $('.shipping-options .produkt-option.selected').first();
+        if (firstShip.length) {
+            shippingPriceId = firstShip.data('price-id').toString();
+            const cost = parseFloat(firstShip.data('price'));
+            if (!isNaN(cost)) {
+                currentShippingCost = cost;
+            }
+        }
+        $('#produkt-field-shipping').val(shippingPriceId);
     }
 
     if (produkt_ajax.betriebsmodus === 'kauf') {
@@ -162,6 +171,13 @@ jQuery(document).ready(function($) {
             }
             updateExtraImage($(this));
             updateExtraBookings(selectedExtras);
+        } else if (type === 'shipping') {
+            shippingPriceId = $(this).data('price-id') ? $(this).data('price-id').toString() : '';
+            const cost = parseFloat($(this).data('price'));
+            if (!isNaN(cost)) {
+                currentShippingCost = cost;
+            }
+            $('#produkt-field-shipping').val(shippingPriceId);
         } else if (type === 'duration') {
             selectedDuration = id;
         } else if (type === 'condition') {

--- a/assets/script.js
+++ b/assets/script.js
@@ -23,6 +23,31 @@ jQuery(document).ready(function($) {
     let selectedDays = 0;
     let calendarMonth = new Date();
     let colorNotificationTimeout = null;
+
+    // Tooltip modal setup
+    const tooltipModal = $('<div>', {id: 'produkt-tooltip-modal', class: 'produkt-tooltip-modal'}).append(
+        $('<div>', {class: 'modal-content'}).append(
+            $('<button>', {class: 'modal-close', 'aria-label': 'Schließen'}).text('×'),
+            $('<div>', {class: 'modal-text'})
+        )
+    );
+    $('body').append(tooltipModal);
+
+    $(document).on('click', '.produkt-tooltip', function(e){
+        e.preventDefault();
+        const text = $(this).find('.produkt-tooltiptext').text().trim();
+        if (!text) return;
+        $('#produkt-tooltip-modal .modal-text').text(text);
+        $('#produkt-tooltip-modal').css('display', 'flex');
+        $('body').addClass('produkt-popup-open');
+    });
+
+    $(document).on('click', '#produkt-tooltip-modal', function(e){
+        if (e.target === this || $(e.target).hasClass('modal-close')) {
+            $('#produkt-tooltip-modal').hide();
+            $('body').removeClass('produkt-popup-open');
+        }
+    });
     // Get category ID from container
     const container = $('.produkt-container');
     if (container.length) {

--- a/assets/script.js
+++ b/assets/script.js
@@ -1,3 +1,4 @@
+var pendingCheckoutUrl = '';
 jQuery(document).ready(function($) {
     let selectedVariant = null;
     let selectedExtras = [];
@@ -5,7 +6,6 @@ jQuery(document).ready(function($) {
     let selectedCondition = null;
     let selectedProductColor = null;
     let selectedFrameColor = null;
-    let pendingCheckoutUrl = '';
     let currentVariantImages = [];
     let currentMainImageIndex = 0;
     let currentProductColorImage = null;

--- a/assets/script.js
+++ b/assets/script.js
@@ -17,6 +17,7 @@ jQuery(document).ready(function($) {
     let currentShippingCost = 0;
     let currentPriceId = '';
     let shippingPriceId = '';
+    let shippingProvider = '';
     let startDate = null;
     let endDate = null;
     let selectedDays = 0;
@@ -34,6 +35,7 @@ jQuery(document).ready(function($) {
         if (spid) {
             shippingPriceId = spid.toString();
         }
+        shippingProvider = container.data('shipping-provider') || '';
         const firstShip = $('.shipping-options .produkt-option.selected').first();
         if (firstShip.length) {
             shippingPriceId = firstShip.data('price-id').toString();
@@ -41,6 +43,7 @@ jQuery(document).ready(function($) {
             if (!isNaN(cost)) {
                 currentShippingCost = cost;
             }
+            shippingProvider = firstShip.data('provider') || shippingProvider;
         }
         $('#produkt-field-shipping').val(shippingPriceId);
     }
@@ -177,6 +180,7 @@ jQuery(document).ready(function($) {
             if (!isNaN(cost)) {
                 currentShippingCost = cost;
             }
+            shippingProvider = $(this).data('provider') || '';
             $('#produkt-field-shipping').val(shippingPriceId);
         } else if (type === 'duration') {
             selectedDuration = id;
@@ -784,8 +788,11 @@ jQuery(document).ready(function($) {
                         if (isAvailable) {
                             $('#produkt-availability-status').removeClass('unavailable').addClass('available');
                             $('#produkt-availability-status .status-text').text('Sofort verfügbar');
-                            $('#produkt-delivery-time').text(data.delivery_time || '');
-                            $('#produkt-delivery-box').show();
+                            if (shippingProvider === 'pickup') {
+                                $('#produkt-delivery-box').text('Abholung').show();
+                            } else {
+                                $('#produkt-delivery-box').html('Lieferung in <span id="produkt-delivery-time">' + (data.delivery_time || '') + '</span>').show();
+                            }
                         } else {
                             $('#produkt-availability-status').addClass('unavailable').removeClass('available');
                             $('#produkt-availability-status .status-text').text('Nicht auf Lager');

--- a/assets/style.css
+++ b/assets/style.css
@@ -341,7 +341,7 @@ img.wp-smiley, img.emoji {
 .produkt-tooltip {
     position: relative;
     display: inline-block;
-    cursor: help;
+    cursor: pointer;
     margin-left: 5px;
 }
 
@@ -352,40 +352,19 @@ img.wp-smiley, img.emoji {
     fill: currentColor;
 }
 
+/* hide default tooltip text; handled via modal */
 .produkt-tooltiptext {
-    visibility: hidden;
-    width: 300px;
-    background-color: #333;
-    color: var(--produkt-button-text);
-    text-align: left;
-    border-radius: 6px;
-    padding: 10px;
-    position: absolute;
-    z-index: 1000;
-    bottom: 125%;
-    left: 50%;
-    margin-left: -150px;
-    opacity: 0;
-    transition: opacity 0.3s;
-    font-size: 12px;
-    line-height: 1.4;
-    white-space: pre-line;
+    display: none;
 }
 
+/* arrow not needed when using modal */
 .produkt-tooltiptext::after {
-    content: "";
-    position: absolute;
-    top: 100%;
-    left: 50%;
-    margin-left: -5px;
-    border-width: 5px;
-    border-style: solid;
-    border-color: #333 transparent transparent transparent;
+    display: none;
 }
 
+/* disable hover tooltip */
 .produkt-tooltip:hover .produkt-tooltiptext {
-    visibility: visible;
-    opacity: 1;
+    display: none;
 }
 
 /* Layout Options */
@@ -1411,6 +1390,42 @@ img.wp-smiley, img.emoji {
 .checkout-login-modal .guest-text a {
     color: var(--produkt-button-bg);
     text-decoration: underline;
+    cursor: pointer;
+}
+
+/* Tooltip Modal */
+.produkt-tooltip-modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.6);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 9999;
+    padding: 20px;
+    box-sizing: border-box;
+}
+
+.produkt-tooltip-modal .modal-content {
+    position: relative;
+    background: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    max-width: 400px;
+    width: 90%;
+    text-align: left;
+}
+
+.produkt-tooltip-modal .modal-close {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: none;
+    border: none;
+    font-size: 1.5rem;
     cursor: pointer;
 }
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -1380,6 +1380,24 @@ img.wp-smiley, img.emoji {
     cursor: pointer;
 }
 
+.checkout-login-modal input[type="email"] {
+    width: 100%;
+    padding: 8px;
+    margin: 10px 0;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
+.checkout-login-modal .guest-text {
+    margin-top: 10px;
+}
+
+.checkout-login-modal .guest-text a {
+    color: var(--produkt-button-bg);
+    text-decoration: underline;
+    cursor: pointer;
+}
+
 .produkt-exit-popup-close {
     position: absolute;
     top: 10px;

--- a/assets/style.css
+++ b/assets/style.css
@@ -1413,6 +1413,7 @@ img.wp-smiley, img.emoji {
     position: relative;
     background: #fff;
     padding: 20px;
+    padding-right: 3rem;
     border-radius: 8px;
     max-width: 400px;
     width: 90%;
@@ -1427,6 +1428,12 @@ img.wp-smiley, img.emoji {
     border: none;
     font-size: 1.5rem;
     cursor: pointer;
+    color: #000000;
+    box-shadow: none;
+}
+
+.produkt-tooltip-modal .modal-text {
+    word-break: break-word;
 }
 
 .produkt-exit-popup-close {

--- a/assets/style.css
+++ b/assets/style.css
@@ -1345,6 +1345,41 @@ img.wp-smiley, img.emoji {
     text-align: center;
 }
 
+/* Checkout Login Modal */
+.checkout-login-modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0,0,0,0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 9999;
+    padding: 20px;
+    box-sizing: border-box;
+}
+
+.checkout-login-modal .modal-content {
+    background: #fff;
+    padding: 30px;
+    border-radius: 8px;
+    text-align: center;
+    max-width: 400px;
+    width: 90%;
+}
+
+.checkout-login-modal button {
+    background: var(--produkt-button-bg);
+    color: var(--produkt-button-text);
+    border: none;
+    padding: 10px 20px;
+    margin: 5px;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
 .produkt-exit-popup-close {
     position: absolute;
     top: 10px;

--- a/assets/style.css
+++ b/assets/style.css
@@ -232,6 +232,16 @@ img.wp-smiley, img.emoji {
     flex-direction: column;
 }
 
+.produkt-price-display.no-default-shipping {
+    background-color: #f6f7f6;
+    border: 1px solid var(--produkt-button-bg);
+}
+
+.produkt-price-display.no-default-shipping .produkt-price-box {
+    background: none;
+    border: none;
+}
+
 .produkt-price-content {
     display: flex;
     flex-direction: column;

--- a/assets/style.css
+++ b/assets/style.css
@@ -1393,6 +1393,57 @@ img.wp-smiley, img.emoji {
     cursor: pointer;
 }
 
+/* Cart Panel */
+.produkt-cart-panel {
+    position: fixed;
+    top: 0;
+    right: 0;
+    width: 320px;
+    max-width: 90%;
+    height: 100%;
+    background: #fff;
+    box-shadow: -2px 0 6px rgba(0,0,0,0.2);
+    transform: translateX(100%);
+    transition: transform 0.3s ease;
+    z-index: 10000;
+    display: flex;
+    flex-direction: column;
+}
+.produkt-cart-panel.open {
+    transform: translateX(0);
+}
+.produkt-cart-panel .cart-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem;
+    border-bottom: 1px solid #ddd;
+}
+.produkt-cart-panel .cart-items {
+    flex: 1;
+    overflow-y: auto;
+    padding: 1rem;
+}
+.produkt-cart-panel .cart-item {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 0.5rem;
+}
+.produkt-cart-panel .cart-item-remove {
+    cursor: pointer;
+    color: #dc3545;
+    margin-left: 0.5rem;
+}
+.produkt-cart-panel #produkt-cart-checkout {
+    margin: 1rem;
+    padding: 10px;
+    background: var(--produkt-button-bg);
+    color: var(--produkt-button-text);
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
 /* Tooltip Modal */
 .produkt-tooltip-modal {
     position: fixed;

--- a/assets/style.css
+++ b/assets/style.css
@@ -2108,6 +2108,8 @@ body.shop-filter-open {
     border: none;
     cursor: pointer;
     font-size: 1rem;
+    color: #000000;
+    box-shadow: none;
 }
 
 #booking-calendar .calendar-grid {
@@ -2148,7 +2150,7 @@ body.shop-filter-open {
 
 #booking-calendar .calendar-day.start,
 #booking-calendar .calendar-day.end {
-    background: var(--produkt-button-bg);
+    background: var(--produkt-button-bg) !important;
     color: var(--produkt-button-text);
 }
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -398,6 +398,12 @@ img.wp-smiley, img.emoji {
     gap: 0.75rem;
 }
 
+.produkt-options.shipping-options {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
 .produkt-options.layout-default.durations {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -322,6 +322,7 @@ class Admin {
                 'publishable_key' => StripeService::get_publishable_key(),
                 'checkout_url' => Plugin::get_checkout_page_url(),
                 'account_url' => Plugin::get_customer_page_url(),
+                'login_nonce' => wp_create_nonce('request_login_code_action'),
                 'is_logged_in' => is_user_logged_in(),
                 'price_period' => $category->price_period ?? 'month',
                 'price_label' => $category->price_label ?? ($modus === 'kauf' ? 'Einmaliger Kaufpreis' : 'Monatlicher Mietpreis'),

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -267,12 +267,14 @@ class Admin {
         $product_padding = $branding['product_padding'] ?? '1';
         $inline_css = ":root{--produkt-button-bg:{$button_color};--produkt-text-color:{$text_color};--produkt-border-color:{$border_color};--produkt-button-text:{$button_text_color};--produkt-filter-button-bg:{$filter_button_color};}";
         if ($product_padding !== '1') {
-            $inline_css .= "\n.produkt-product-info,.produkt-right{padding:0;}\n.produkt-content{gap:4rem;}";
+        $inline_css .= "\n.produkt-product-info,.produkt-right{padding:0;}\n.produkt-content{gap:4rem;}";
         }
         if (!empty($custom_css)) {
             $inline_css .= "\n" . $custom_css;
         }
         wp_add_inline_style('produkt-style', $inline_css);
+
+        $ui = get_option('produkt_ui_settings', []);
 
         $category = null;
         if ($slug) {
@@ -328,6 +330,7 @@ class Admin {
                 'price_label' => $category->price_label ?? ($modus === 'kauf' ? 'Einmaliger Kaufpreis' : 'Monatlicher Mietpreis'),
                 'vat_included' => isset($category->vat_included) ? intval($category->vat_included) : 0,
                 'betriebsmodus' => $modus,
+                'button_text' => $category->button_text ?? ($ui['button_text'] ?? ''),
                 'blocked_days' => $blocked_days,
                 'variant_blocked_days' => [],
                 'popup_settings' => [

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -321,6 +321,8 @@ class Admin {
                 'nonce' => wp_create_nonce('produkt_nonce'),
                 'publishable_key' => StripeService::get_publishable_key(),
                 'checkout_url' => Plugin::get_checkout_page_url(),
+                'account_url' => Plugin::get_customer_page_url(),
+                'is_logged_in' => is_user_logged_in(),
                 'price_period' => $category->price_period ?? 'month',
                 'price_label' => $category->price_label ?? ($modus === 'kauf' ? 'Einmaliger Kaufpreis' : 'Monatlicher Mietpreis'),
                 'vat_included' => isset($category->vat_included) ? intval($category->vat_included) : 0,

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -971,6 +971,7 @@ function produkt_create_subscription() {
                 'street'      => $body['street'] ?? '',
                 'postal_code' => $body['postal'] ?? '',
                 'city'        => $body['city'] ?? '',
+                'country'     => $body['country'] ?? '',
             ]
         );
         $user = get_user_by('email', sanitize_email($body['email'] ?? ''));
@@ -1044,6 +1045,7 @@ function produkt_create_subscription() {
                         'street'      => $body['street'] ?? '',
                         'postal_code' => $body['postal'] ?? '',
                         'city'        => $body['city'] ?? '',
+                        'country'     => $body['country'] ?? '',
                     ]
                 );
                 $user = get_user_by('email', $cust_email);
@@ -1173,6 +1175,7 @@ function produkt_create_checkout_session() {
                         'street'      => $body['street'] ?? '',
                         'postal_code' => $body['postal'] ?? '',
                         'city'        => $body['city'] ?? '',
+                        'country'     => $body['country'] ?? '',
                     ]
                 );
                 $user = get_user_by('email', $customer_email);
@@ -1294,6 +1297,7 @@ function produkt_create_checkout_session() {
                         'street'      => $body['street'] ?? '',
                         'postal_code' => $body['postal'] ?? '',
                         'city'        => $body['city'] ?? '',
+                        'country'     => $body['country'] ?? '',
                     ]
                 );
                 $user = get_user_by('email', $customer_email);
@@ -1304,10 +1308,10 @@ function produkt_create_checkout_session() {
 
             if ($stripe_customer_id) {
                 $session_args['customer'] = $stripe_customer_id;
+            } else {
+                $session_args['customer_creation'] = 'always';
             }
-        }
-
-        if (empty($session_args['customer'])) {
+        } else {
             $session_args['customer_creation'] = 'always';
         }
 
@@ -1535,6 +1539,7 @@ function produkt_create_embedded_checkout_session() {
                             'street'      => $body['street'] ?? '',
                             'postal_code' => $body['postal'] ?? '',
                             'city'        => $body['city'] ?? '',
+                            'country'     => $body['country'] ?? '',
                         ]
                     );
                     $user = get_user_by('email', $customer_email);
@@ -1542,18 +1547,19 @@ function produkt_create_embedded_checkout_session() {
                         update_user_meta($user->ID, 'stripe_customer_id', $stripe_customer_id);
                     }
                 }
-                if ($stripe_customer_id) {
-                    $session_params['customer'] = $stripe_customer_id;
-                }
             }
 
-            if (empty($session_params['customer'])) {
+            if (!empty($stripe_customer_id)) {
+                $session_params['customer'] = $stripe_customer_id;
+            } else {
                 $session_params['customer_creation'] = 'always';
             }
         }
 
         if (!empty($session_params['automatic_tax']['enabled'])) {
-            $session_params['customer_update'] = ['shipping' => 'auto'];
+            if (!empty($session_params['customer'])) {
+                $session_params['customer_update'] = ['shipping' => 'auto'];
+            }
         }
 
         $session = \Stripe\Checkout\Session::create($session_params);

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -135,9 +135,17 @@ class Ajax {
                 $final_price = $duration_price + $extras_price;
             }
             $shipping_cost = 0;
-            $shipping = $wpdb->get_row("SELECT price FROM {$wpdb->prefix}produkt_shipping_methods WHERE is_default = 1 LIMIT 1");
-            if ($shipping) {
-                $shipping_cost = floatval($shipping->price);
+            if (!empty($_POST['shipping_price_id'])) {
+                $spid = sanitize_text_field($_POST['shipping_price_id']);
+                $amt = StripeService::get_price_amount($spid);
+                if (!is_wp_error($amt)) {
+                    $shipping_cost = floatval($amt);
+                }
+            } else {
+                $shipping = $wpdb->get_row("SELECT price FROM {$wpdb->prefix}produkt_shipping_methods WHERE is_default = 1 LIMIT 1");
+                if ($shipping) {
+                    $shipping_cost = floatval($shipping->price);
+                }
             }
             
             wp_send_json_success(array(

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -1382,51 +1382,13 @@ function produkt_create_embedded_checkout_session() {
 
         $body = json_decode(file_get_contents('php://input'), true);
         $modus      = get_option('produkt_betriebsmodus', 'miete');
-        $days       = isset($body['days']) ? max(1, intval($body['days'])) : 1;
-        $start_date = sanitize_text_field($body['start_date'] ?? '');
-        $end_date   = sanitize_text_field($body['end_date'] ?? '');
-        $price_id   = sanitize_text_field($body['price_id'] ?? '');
-        if (!$price_id) {
-            wp_send_json_error(['message' => 'Keine Preis-ID vorhanden']);
+        $cart_items = [];
+        if (!empty($body['cart_items']) && is_array($body['cart_items'])) {
+            $cart_items = $body['cart_items'];
+        } else {
+            $cart_items[] = $body;
         }
 
-        $extra_price_ids = [];
-        if (!empty($body['extra_price_ids'])) {
-            if (is_array($body['extra_price_ids'])) {
-                $extra_price_ids = array_map('sanitize_text_field', $body['extra_price_ids']);
-            } elseif (is_string($body['extra_price_ids'])) {
-                $extra_price_ids = array_map('sanitize_text_field', explode(',', $body['extra_price_ids']));
-            }
-            $extra_price_ids = array_filter($extra_price_ids);
-        }
-
-        $extra_ids_raw = sanitize_text_field($body['extra_ids'] ?? '');
-        $extra_ids = array_filter(array_map('intval', explode(',', $extra_ids_raw)));
-        if (empty($extra_price_ids) && !empty($extra_ids)) {
-            global $wpdb;
-            $placeholders = implode(',', array_fill(0, count($extra_ids), '%d'));
-            $rows = $wpdb->get_results(
-                $wpdb->prepare(
-                    "SELECT stripe_price_id, stripe_price_id_sale, stripe_price_id_rent FROM {$wpdb->prefix}produkt_extras WHERE id IN ($placeholders)",
-                    ...$extra_ids
-                )
-            );
-            foreach ($rows as $row) {
-                $pid = $modus === 'kauf'
-                    ? ($row->stripe_price_id_sale ?: $row->stripe_price_id)
-                    : ($row->stripe_price_id_rent ?: $row->stripe_price_id);
-                if (!empty($pid)) {
-                    $extra_price_ids[] = $pid;
-                }
-            }
-        }
-        $category_id      = intval($body['category_id'] ?? 0);
-        $variant_id       = intval($body['variant_id'] ?? 0);
-        $duration_id      = intval($body['duration_id'] ?? 0);
-        $condition_id     = intval($body['condition_id'] ?? 0);
-        $product_color_id = intval($body['product_color_id'] ?? 0);
-        $frame_color_id   = intval($body['frame_color_id'] ?? 0);
-        $final_price      = floatval($body['final_price'] ?? 0);
         $customer_email   = sanitize_email($body['email'] ?? '');
         $current_user = wp_get_current_user();
         if ($current_user && $current_user->exists()) {
@@ -1445,42 +1407,91 @@ function produkt_create_embedded_checkout_session() {
             }
         }
 
-        $metadata = [
-            'produkt'       => sanitize_text_field($body['produkt'] ?? ''),
-            'extra'         => sanitize_text_field($body['extra'] ?? ''),
-            'dauer'         => sanitize_text_field($body['dauer'] ?? ''),
-            'dauer_name'    => sanitize_text_field($body['dauer_name'] ?? ''),
-            'zustand'       => sanitize_text_field($body['zustand'] ?? ''),
-            'produktfarbe'  => sanitize_text_field($body['produktfarbe'] ?? ''),
-            'gestellfarbe'  => sanitize_text_field($body['gestellfarbe'] ?? ''),
-            'email'         => $customer_email,
-            'user_ip'       => $_SERVER['REMOTE_ADDR'] ?? '',
-            'user_agent'    => substr($_SERVER['HTTP_USER_AGENT'] ?? '', 0, 255),
-            'start_date'    => $start_date,
-            'end_date'      => $end_date,
-            'days'          => $days,
-        ];
-        if ($shipping_price_id) {
-            $metadata['shipping_price_id'] = $shipping_price_id;
-        }
+        $line_items = [];
+        $orders = [];
+        foreach ($cart_items as $it) {
+            $it_days = isset($it['days']) ? max(1, intval($it['days'])) : 1;
+            $it_start = sanitize_text_field($it['start_date'] ?? '');
+            $it_end   = sanitize_text_field($it['end_date'] ?? '');
+            $pid      = sanitize_text_field($it['price_id'] ?? '');
+            if (!$pid) { continue; }
+            $line_items[] = [ 'price' => $pid, 'quantity' => $it_days ];
 
-        $line_items = [[
-            'price'    => $price_id,
-            'quantity' => $days,
-        ]];
+            $extra_price_ids = [];
+            if (!empty($it['extra_price_ids'])) {
+                if (is_array($it['extra_price_ids'])) {
+                    $extra_price_ids = array_map('sanitize_text_field', $it['extra_price_ids']);
+                } elseif (is_string($it['extra_price_ids'])) {
+                    $extra_price_ids = array_map('sanitize_text_field', explode(',', $it['extra_price_ids']));
+                }
+                $extra_price_ids = array_filter($extra_price_ids);
+            }
 
-        foreach ($extra_price_ids as $extra_price_id) {
-            $line_items[] = [
-                'price'    => $extra_price_id,
-                'quantity' => ($modus === 'kauf') ? $days : 1,
+            $extra_ids_raw = sanitize_text_field($it['extra_ids'] ?? '');
+            $extra_ids = array_filter(array_map('intval', explode(',', $extra_ids_raw)));
+            if (empty($extra_price_ids) && !empty($extra_ids)) {
+                global $wpdb;
+                $placeholders = implode(',', array_fill(0, count($extra_ids), '%d'));
+                $rows = $wpdb->get_results(
+                    $wpdb->prepare(
+                        "SELECT stripe_price_id, stripe_price_id_sale, stripe_price_id_rent FROM {$wpdb->prefix}produkt_extras WHERE id IN ($placeholders)",
+                        ...$extra_ids
+                    )
+                );
+                foreach ($rows as $row) {
+                    $eid = $modus === 'kauf'
+                        ? ($row->stripe_price_id_sale ?: $row->stripe_price_id)
+                        : ($row->stripe_price_id_rent ?: $row->stripe_price_id);
+                    if (!empty($eid)) {
+                        $extra_price_ids[] = $eid;
+                    }
+                }
+            }
+
+            foreach ($extra_price_ids as $extra_price_id) {
+                $line_items[] = [
+                    'price'    => $extra_price_id,
+                    'quantity' => ($modus === 'kauf') ? $it_days : 1,
+                ];
+            }
+
+            $orders[] = [
+                'category_id'      => intval($it['category_id'] ?? 0),
+                'variant_id'       => intval($it['variant_id'] ?? 0),
+                'extra_id'         => !empty($extra_ids) ? $extra_ids[0] : 0,
+                'extra_ids'        => $extra_ids_raw,
+                'duration_id'      => intval($it['duration_id'] ?? 0),
+                'condition_id'     => intval($it['condition_id'] ?? 0) ?: null,
+                'product_color_id' => intval($it['product_color_id'] ?? 0) ?: null,
+                'frame_color_id'   => intval($it['frame_color_id'] ?? 0) ?: null,
+                'final_price'      => floatval($it['final_price'] ?? 0),
+                'start_date'       => $it_start ?: null,
+                'end_date'         => $it_end ?: null,
+                'days'             => $it_days,
+                'metadata' => [
+                    'produkt'       => sanitize_text_field($it['produkt'] ?? ''),
+                    'extra'         => sanitize_text_field($it['extra'] ?? ''),
+                    'dauer_name'    => sanitize_text_field($it['dauer_name'] ?? ''),
+                    'zustand'       => sanitize_text_field($it['zustand'] ?? ''),
+                    'produktfarbe'  => sanitize_text_field($it['produktfarbe'] ?? ''),
+                    'gestellfarbe'  => sanitize_text_field($it['gestellfarbe'] ?? '')
+                ]
             ];
         }
-
         if ($shipping_price_id) {
             $line_items[] = [
                 'price'    => $shipping_price_id,
                 'quantity' => 1,
             ];
+        }
+        $metadata = [
+            'cart_count' => count($orders),
+            'email'      => $customer_email,
+            'user_ip'    => $_SERVER['REMOTE_ADDR'] ?? '',
+            'user_agent' => substr($_SERVER['HTTP_USER_AGENT'] ?? '', 0, 255),
+        ];
+        if ($shipping_price_id) {
+            $metadata['shipping_price_id'] = $shipping_price_id;
         }
 
         $tos_url = get_option('produkt_tos_url', home_url('/agb'));
@@ -1565,7 +1576,7 @@ function produkt_create_embedded_checkout_session() {
         }
 
         if (!empty($session_params['automatic_tax']['enabled'])) {
-            if (!empty($session_params['customer'])) {
+            if (!empty($session_params['customer']) || !empty($session_params['customer_creation'])) {
                 $session_params['customer_update'] = ['shipping' => 'auto'];
             }
         }
@@ -1573,44 +1584,45 @@ function produkt_create_embedded_checkout_session() {
         $session = \Stripe\Checkout\Session::create($session_params);
 
         global $wpdb;
-        $extra_id = !empty($extra_ids) ? $extra_ids[0] : 0;
-        $wpdb->insert(
-            $wpdb->prefix . 'produkt_orders',
-            [
-                'category_id'      => $category_id,
-                'variant_id'       => $variant_id,
-                'extra_id'         => $extra_id,
-                'extra_ids'        => $extra_ids_raw,
-                'duration_id'      => $duration_id,
-                'condition_id'     => $condition_id ?: null,
-                'product_color_id' => $product_color_id ?: null,
-                'frame_color_id'   => $frame_color_id ?: null,
-                'final_price'      => $final_price,
-                'shipping_cost'    => $shipping_cost,
-                'mode'             => $modus,
-                'start_date'       => $start_date ?: null,
-                'end_date'         => $end_date ?: null,
-                'inventory_reverted' => 0,
-                'stripe_session_id'=> $session->id,
-                'amount_total'     => 0,
-                'produkt_name'     => $metadata['produkt'],
-                'zustand_text'     => $metadata['zustand'],
-                'produktfarbe_text'=> $metadata['produktfarbe'],
-                'gestellfarbe_text'=> $metadata['gestellfarbe'],
-                'extra_text'       => $metadata['extra'],
-                'dauer_text'       => $modus === 'kauf' && empty($metadata['dauer_name'])
-                    ? ($days . ' Tag' . ($days > 1 ? 'e' : '')
-                        . ($start_date && $end_date ? ' (' . $start_date . ' - ' . $end_date . ')' : ''))
-                    : $metadata['dauer_name'],
-                'customer_name'    => '',
-                'customer_email'   => $customer_email,
-                'user_ip'          => $_SERVER['REMOTE_ADDR'] ?? '',
-                'user_agent'       => substr($_SERVER['HTTP_USER_AGENT'] ?? '', 0, 255),
-                'discount_amount'  => 0,
-                'status'           => 'offen',
-                'created_at'       => current_time('mysql', 1)
-            ]
-        );
+        foreach ($orders as $o) {
+            $wpdb->insert(
+                $wpdb->prefix . 'produkt_orders',
+                [
+                    'category_id'      => $o['category_id'],
+                    'variant_id'       => $o['variant_id'],
+                    'extra_id'         => $o['extra_id'],
+                    'extra_ids'        => $o['extra_ids'],
+                    'duration_id'      => $o['duration_id'],
+                    'condition_id'     => $o['condition_id'],
+                    'product_color_id' => $o['product_color_id'],
+                    'frame_color_id'   => $o['frame_color_id'],
+                    'final_price'      => $o['final_price'],
+                    'shipping_cost'    => $shipping_cost,
+                    'mode'             => $modus,
+                    'start_date'       => $o['start_date'],
+                    'end_date'         => $o['end_date'],
+                    'inventory_reverted' => 0,
+                    'stripe_session_id'=> $session->id,
+                    'amount_total'     => 0,
+                    'produkt_name'     => $o['metadata']['produkt'],
+                    'zustand_text'     => $o['metadata']['zustand'],
+                    'produktfarbe_text'=> $o['metadata']['produktfarbe'],
+                    'gestellfarbe_text'=> $o['metadata']['gestellfarbe'],
+                    'extra_text'       => $o['metadata']['extra'],
+                    'dauer_text'       => $modus === 'kauf' && empty($o['metadata']['dauer_name'])
+                        ? ($o['days'] . ' Tag' . ($o['days'] > 1 ? 'e' : '')
+                            . ($o['start_date'] && $o['end_date'] ? ' (' . $o['start_date'] . ' - ' . $o['end_date'] . ')' : ''))
+                        : $o['metadata']['dauer_name'],
+                    'customer_name'    => '',
+                    'customer_email'   => $customer_email,
+                    'user_ip'          => $_SERVER['REMOTE_ADDR'] ?? '',
+                    'user_agent'       => substr($_SERVER['HTTP_USER_AGENT'] ?? '', 0, 255),
+                    'discount_amount'  => 0,
+                    'status'           => 'offen',
+                    'created_at'       => current_time('mysql', 1)
+                ]
+            );
+        }
 
         wp_send_json(['client_secret' => $session->client_secret]);
     } catch (\Exception $e) {

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -288,6 +288,7 @@ class Plugin {
         $message        = $this->login_error;
         $show_code_form = isset($_POST['verify_login_code']);
         $email_value    = '';
+        $redirect_to    = isset($_REQUEST['redirect_to']) ? esc_url_raw($_REQUEST['redirect_to']) : '';
 
         if (
             isset($_POST['verify_login_code_nonce'], $_POST['verify_login_code']) &&
@@ -509,8 +510,12 @@ class Plugin {
 
                 wp_set_current_user($user->ID);
                 wp_set_auth_cookie($user->ID, true);
-                $page_id = get_option(PRODUKT_CUSTOMER_PAGE_OPTION);
-                wp_safe_redirect(get_permalink($page_id));
+                $redirect = isset($_POST['redirect_to']) ? esc_url_raw($_POST['redirect_to']) : '';
+                if (empty($redirect)) {
+                    $page_id  = get_option(PRODUKT_CUSTOMER_PAGE_OPTION);
+                    $redirect = get_permalink($page_id);
+                }
+                wp_safe_redirect($redirect);
                 exit;
             }
         }
@@ -641,6 +646,17 @@ class Plugin {
         }
 
         return null;
+    }
+
+    /**
+     * Return the URL of the customer account page.
+     */
+    public static function get_customer_page_url() {
+        $page_id = get_option(PRODUKT_CUSTOMER_PAGE_OPTION);
+        if ($page_id) {
+            return get_permalink($page_id);
+        }
+        return home_url('/kundenkonto');
     }
 
     public function register_customer_role() {

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -431,7 +431,11 @@ class Plugin {
 
         $price_id = sanitize_text_field($_POST['price_id'] ?? '');
         global $wpdb;
-        $shipping_price_id = $wpdb->get_var("SELECT stripe_price_id FROM {$wpdb->prefix}produkt_shipping_methods WHERE is_default = 1 LIMIT 1");
+        if (!empty($_POST['shipping_price_id'])) {
+            $shipping_price_id = sanitize_text_field($_POST['shipping_price_id']);
+        } else {
+            $shipping_price_id = $wpdb->get_var("SELECT stripe_price_id FROM {$wpdb->prefix}produkt_shipping_methods WHERE is_default = 1 LIMIT 1");
+        }
 
         $init = StripeService::init();
         if (is_wp_error($init)) {

--- a/includes/Webhook.php
+++ b/includes/Webhook.php
@@ -111,7 +111,13 @@ function handle_stripe_webhook(WP_REST_Request $request) {
         $email    = sanitize_email($session->customer_details->email ?? '');
         $phone    = sanitize_text_field($session->customer_details->phone ?? '');
 
-        $address = $session->customer_details->address ?? null;
+        $shipping_details = $session->shipping_details ? $session->shipping_details->toArray() : [];
+        $customer_details = $session->customer_details ? $session->customer_details->toArray() : [];
+        $address = $shipping_details['address'] ?? $customer_details['address'] ?? null;
+        $street  = $address['line1'] ?? '';
+        $postal  = $address['postal_code'] ?? '';
+        $city    = $address['city'] ?? '';
+        $country = $address['country'] ?? '';
 
         // Persist customer information in custom table
         Database::upsert_customer_record_by_email(
@@ -120,10 +126,10 @@ function handle_stripe_webhook(WP_REST_Request $request) {
             $full_name,
             $phone,
             [
-                'street'      => $address->line1 ?? '',
-                'postal_code' => $address->postal_code ?? '',
-                'city'        => $address->city ?? '',
-                'country'     => $address->country ?? '',
+                'street'      => $street,
+                'postal_code' => $postal,
+                'city'        => $city,
+                'country'     => $country,
             ]
         );
 

--- a/includes/Webhook.php
+++ b/includes/Webhook.php
@@ -135,7 +135,7 @@ function handle_stripe_webhook(WP_REST_Request $request) {
 
         global $wpdb;
         $existing_order = $wpdb->get_row($wpdb->prepare(
-            "SELECT id, status, created_at, category_id, shipping_cost, variant_id FROM {$wpdb->prefix}produkt_orders WHERE stripe_session_id = %s",
+            "SELECT id, status, created_at, category_id, shipping_cost, variant_id, extra_ids FROM {$wpdb->prefix}produkt_orders WHERE stripe_session_id = %s",
             $session->id
         ));
         $existing_id = $existing_order->id ?? 0;

--- a/includes/render-order-details.php
+++ b/includes/render-order-details.php
@@ -1,0 +1,30 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+?>
+<div class="order-box">
+    <?php if (!empty($image_url)) : ?>
+        <img class="order-product-image" src="<?php echo esc_url($image_url); ?>" alt="">
+    <?php endif; ?>
+    <h3>Bestellung #<?php echo esc_html($order->id); ?></h3>
+    <p><strong>Datum:</strong> <?php echo esc_html(date_i18n('d.m.Y', strtotime($order->created_at))); ?></p>
+    <p><strong>Produkt:</strong> <?php echo esc_html($order->produkt_name); ?></p>
+    <p><strong>Preis:</strong> <?php echo esc_html(number_format((float) $order->final_price, 2, ',', '.')); ?>€</p>
+    <?php if ($order->shipping_cost > 0) : ?>
+        <p><strong>Versand:</strong> <?php echo esc_html(number_format((float) $order->shipping_cost, 2, ',', '.')); ?>€</p>
+    <?php endif; ?>
+    <?php if (!empty($order->extra_text)) : ?>
+        <p><strong>Extras:</strong> <?php echo esc_html($order->extra_text); ?></p>
+    <?php endif; ?>
+    <?php if (!empty($order->produktfarbe_text)) : ?>
+        <p><strong>Farbe:</strong> <?php echo esc_html($order->produktfarbe_text); ?></p>
+    <?php endif; ?>
+    <?php if (!empty($order->gestellfarbe_text)) : ?>
+        <p><strong>Gestellfarbe:</strong> <?php echo esc_html($order->gestellfarbe_text); ?></p>
+    <?php endif; ?>
+    <?php if (!empty($order->zustand_text)) : ?>
+        <p><strong>Zustand:</strong> <?php echo esc_html($order->zustand_text); ?></p>
+    <?php endif; ?>
+    <?php if (!empty($order->dauer_text)) : ?>
+        <p><strong>Miettage:</strong> <?php echo esc_html($order->dauer_text); ?></p>
+    <?php endif; ?>
+</div>

--- a/templates/account-page.php
+++ b/templates/account-page.php
@@ -28,10 +28,24 @@ $sale_orders   = [];
 $order_map     = [];
 $subscriptions = [];
 $full_name     = '';
+$customer_addr = '';
 
 if (is_user_logged_in()) {
     $user_id = get_current_user_id();
     $orders  = Database::get_orders_for_user($user_id);
+
+    $current_user = wp_get_current_user();
+    global $wpdb;
+    $addr_row = $wpdb->get_row($wpdb->prepare(
+        "SELECT street, postal_code, city, country FROM {$wpdb->prefix}produkt_customers WHERE email = %s",
+        $current_user->user_email
+    ));
+    if ($addr_row) {
+        $customer_addr = trim($addr_row->street . ', ' . $addr_row->postal_code . ' ' . $addr_row->city);
+        if ($addr_row->country) {
+            $customer_addr .= ', ' . $addr_row->country;
+        }
+    }
 
     foreach ($orders as $o) {
         if (!empty($o->subscription_id)) {

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -706,9 +706,11 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
 
 <div id="checkout-login-modal" class="checkout-login-modal" style="display:none;">
     <div class="modal-content">
-        <p>Sind Sie bereits Kunde?</p>
-        <button id="checkout-login-btn">Login</button>
-        <button id="checkout-guest-btn">Als Gast bestellen</button>
+        <h3>Login</h3>
+        <p>Zum Einloggen bitte Ihre Email Adresse verwenden</p>
+        <input type="email" id="checkout-login-email" placeholder="Ihre E-Mail">
+        <button id="checkout-login-btn">Code zum einloggen anfordern</button>
+        <p class="guest-text"><a href="#" id="checkout-guest-link">Als Gast fortfahren</a></p>
     </div>
 </div>
 

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -704,6 +704,14 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
     <?php endif; ?>
 </div>
 
+<div id="checkout-login-modal" class="checkout-login-modal" style="display:none;">
+    <div class="modal-content">
+        <p>Sind Sie bereits Kunde?</p>
+        <button id="checkout-login-btn">Login</button>
+        <button id="checkout-guest-btn">Als Gast bestellen</button>
+    </div>
+</div>
+
 
 <div id="produkt-exit-popup" class="produkt-exit-popup" style="display:none;">
     <div class="produkt-exit-popup-content">

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -256,7 +256,7 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
                 </div>
             </div>
 
-             <div class="produkt-price-display" id="produkt-price-display" style="display: none;">
+            <div class="produkt-price-display<?php echo $select_shipping ? ' no-default-shipping' : ''; ?>" id="produkt-price-display" style="display: none;">
                 <div class="produkt-price-box produkt-monthly-box">
                     <div class="produkt-price-content">
                         <p class="produkt-price-label"><?php echo esc_html($price_label); ?></p>

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -286,7 +286,17 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
                                 <div class="produkt-extra-price"><?php echo number_format($method->price, 2, ',', '.'); ?>€</div>
                             </div>
                             <?php if (!empty($method->service_provider) && $method->service_provider !== 'none' && $method->service_provider !== 'pickup'): ?>
-                                <img class="produkt-shipping-provider-icon" src="<?php echo esc_url(PRODUKT_PLUGIN_URL . 'assets/shipping-icons/' . $method->service_provider . '.svg'); ?>" alt="<?php echo esc_attr(strtoupper($method->service_provider)); ?>">
+                                <span class="produkt-tooltip">
+                                    <img class="produkt-shipping-provider-icon" src="<?php echo esc_url(PRODUKT_PLUGIN_URL . 'assets/shipping-icons/' . $method->service_provider . '.svg'); ?>" alt="<?php echo esc_attr(strtoupper($method->service_provider)); ?>">
+                                    <?php if (!empty($method->description)): ?>
+                                    <span class="produkt-tooltiptext"><?php echo esc_html($method->description); ?></span>
+                                    <?php endif; ?>
+                                </span>
+                            <?php elseif (!empty($method->description)): ?>
+                                <span class="produkt-tooltip">
+                                    <?php echo $tooltip_icon; ?>
+                                    <span class="produkt-tooltiptext"><?php echo esc_html($method->description); ?></span>
+                                </span>
                             <?php endif; ?>
                             <div class="produkt-option-check">✓</div>
                         </div>
@@ -297,7 +307,17 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
                         <span class="produkt-final-price"><?php echo number_format($shipping_cost, 2, ',', '.'); ?>€</span>
                     </div>
                     <?php if (!empty($shipping_provider) && $shipping_provider !== 'none' && $shipping_provider !== 'pickup'): ?>
-                        <img class="produkt-shipping-provider-icon" src="<?php echo esc_url(PRODUKT_PLUGIN_URL . 'assets/shipping-icons/' . $shipping_provider . '.svg'); ?>" alt="<?php echo esc_attr(strtoupper($shipping_provider)); ?>">
+                        <span class="produkt-tooltip">
+                            <img class="produkt-shipping-provider-icon" src="<?php echo esc_url(PRODUKT_PLUGIN_URL . 'assets/shipping-icons/' . $shipping_provider . '.svg'); ?>" alt="<?php echo esc_attr(strtoupper($shipping_provider)); ?>">
+                            <?php if (!empty($shipping->description)): ?>
+                            <span class="produkt-tooltiptext"><?php echo esc_html($shipping->description); ?></span>
+                            <?php endif; ?>
+                        </span>
+                    <?php elseif (!empty($shipping->description)): ?>
+                        <span class="produkt-tooltip">
+                            <?php echo $tooltip_icon; ?>
+                            <span class="produkt-tooltiptext"><?php echo esc_html($shipping->description); ?></span>
+                        </span>
                     <?php endif; ?>
                     <?php endif; ?>
                 </div>

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -196,7 +196,7 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
 ));
 ?>
 
-<div class="produkt-container" data-category-id="<?php echo esc_attr($category_id); ?>" data-layout="<?php echo esc_attr($layout_style); ?>" data-shipping-cost="<?php echo esc_attr($shipping_cost); ?>" data-shipping-price-id="<?php echo esc_attr($shipping_price_id); ?>">
+<div class="produkt-container" data-category-id="<?php echo esc_attr($category_id); ?>" data-layout="<?php echo esc_attr($layout_style); ?>" data-shipping-cost="<?php echo esc_attr($shipping_cost); ?>" data-shipping-price-id="<?php echo esc_attr($shipping_price_id); ?>" data-shipping-provider="<?php echo esc_attr($shipping_provider); ?>">
 
     <div class="produkt-content">
         <div class="produkt-left">
@@ -280,7 +280,7 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
                     <?php if ($select_shipping && !empty($shipping_methods)): ?>
                     <div class="produkt-options shipping-options layout-list">
                         <?php foreach ($shipping_methods as $index => $method): ?>
-                        <div class="produkt-option<?php echo $index === 0 ? ' selected' : ''; ?>" data-type="shipping" data-id="<?php echo esc_attr($method->id); ?>" data-price-id="<?php echo esc_attr($method->stripe_price_id); ?>" data-price="<?php echo esc_attr($method->price); ?>" data-available="true">
+                        <div class="produkt-option<?php echo $index === 0 ? ' selected' : ''; ?>" data-type="shipping" data-id="<?php echo esc_attr($method->id); ?>" data-price-id="<?php echo esc_attr($method->stripe_price_id); ?>" data-price="<?php echo esc_attr($method->price); ?>" data-provider="<?php echo esc_attr($method->service_provider); ?>" data-available="true">
                             <div class="produkt-option-content">
                                 <span class="produkt-extra-name"><?php echo esc_html($method->name); ?></span>
                                 <div class="produkt-extra-price"><?php echo number_format($method->price, 2, ',', '.'); ?>€</div>

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -162,7 +162,7 @@ $shipping_provider = $shipping->service_provider ?? '';
 $modus = get_option('produkt_betriebsmodus', 'miete');
 $button_text = $button_text !== '' ? $button_text : ($modus === 'kauf' ? 'Jetzt kaufen' : 'Jetzt mieten');
 $price_label = $ui['price_label'] ?? ($modus === 'kauf' ? 'Einmaliger Kaufpreis' : 'Monatlicher Mietpreis');
-$shipping_label = 'Einmalige Versandkosten:';
+$shipping_label = $ui['shipping_label'] ?? 'Einmalige Versandkosten:';
 $price_period = $ui['price_period'] ?? 'month';
 $vat_included = isset($ui['vat_included']) ? intval($ui['vat_included']) : 0;
 

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -754,6 +754,16 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
     <?php endif; ?>
 </div>
 
+<!-- Sliding Cart Panel -->
+<div id="produkt-cart-panel" class="produkt-cart-panel">
+    <div class="cart-header">
+        <h3>Warenkorb</h3>
+        <button type="button" class="cart-close">&times;</button>
+    </div>
+    <div class="cart-items"></div>
+    <button id="produkt-cart-checkout">Jetzt bestellen</button>
+</div>
+
 <div id="checkout-login-modal" class="checkout-login-modal" style="display:none;">
     <div class="modal-content">
         <h3>Login</h3>

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -286,12 +286,13 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
                                 <div class="produkt-extra-price"><?php echo number_format($method->price, 2, ',', '.'); ?>€</div>
                             </div>
                             <?php if (!empty($method->service_provider) && $method->service_provider !== 'none' && $method->service_provider !== 'pickup'): ?>
-                                <span class="produkt-tooltip">
-                                    <img class="produkt-shipping-provider-icon" src="<?php echo esc_url(PRODUKT_PLUGIN_URL . 'assets/shipping-icons/' . $method->service_provider . '.svg'); ?>" alt="<?php echo esc_attr(strtoupper($method->service_provider)); ?>">
-                                    <?php if (!empty($method->description)): ?>
-                                    <span class="produkt-tooltiptext"><?php echo esc_html($method->description); ?></span>
-                                    <?php endif; ?>
-                                </span>
+                                <img class="produkt-shipping-provider-icon" src="<?php echo esc_url(PRODUKT_PLUGIN_URL . 'assets/shipping-icons/' . $method->service_provider . '.svg'); ?>" alt="<?php echo esc_attr(strtoupper($method->service_provider)); ?>">
+                                <?php if (!empty($method->description)): ?>
+                                    <span class="produkt-tooltip">
+                                        <?php echo $tooltip_icon; ?>
+                                        <span class="produkt-tooltiptext"><?php echo esc_html($method->description); ?></span>
+                                    </span>
+                                <?php endif; ?>
                             <?php elseif (!empty($method->description)): ?>
                                 <span class="produkt-tooltip">
                                     <?php echo $tooltip_icon; ?>
@@ -307,12 +308,13 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
                         <span class="produkt-final-price"><?php echo number_format($shipping_cost, 2, ',', '.'); ?>€</span>
                     </div>
                     <?php if (!empty($shipping_provider) && $shipping_provider !== 'none' && $shipping_provider !== 'pickup'): ?>
-                        <span class="produkt-tooltip">
-                            <img class="produkt-shipping-provider-icon" src="<?php echo esc_url(PRODUKT_PLUGIN_URL . 'assets/shipping-icons/' . $shipping_provider . '.svg'); ?>" alt="<?php echo esc_attr(strtoupper($shipping_provider)); ?>">
-                            <?php if (!empty($shipping->description)): ?>
-                            <span class="produkt-tooltiptext"><?php echo esc_html($shipping->description); ?></span>
-                            <?php endif; ?>
-                        </span>
+                        <img class="produkt-shipping-provider-icon" src="<?php echo esc_url(PRODUKT_PLUGIN_URL . 'assets/shipping-icons/' . $shipping_provider . '.svg'); ?>" alt="<?php echo esc_attr(strtoupper($shipping_provider)); ?>">
+                        <?php if (!empty($shipping->description)): ?>
+                            <span class="produkt-tooltip">
+                                <?php echo $tooltip_icon; ?>
+                                <span class="produkt-tooltiptext"><?php echo esc_html($shipping->description); ?></span>
+                            </span>
+                        <?php endif; ?>
                     <?php elseif (!empty($shipping->description)): ?>
                         <span class="produkt-tooltip">
                             <?php echo $tooltip_icon; ?>

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -271,7 +271,7 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
                     <div class="produkt-price-wrapper">
                         <span class="produkt-final-price"><?php echo number_format($shipping_cost, 2, ',', '.'); ?>€</span>
                     </div>
-                    <?php if (!empty($shipping_provider)): ?>
+                    <?php if (!empty($shipping_provider) && $shipping_provider !== 'none' && $shipping_provider !== 'pickup'): ?>
                         <img class="produkt-shipping-provider-icon" src="<?php echo esc_url(PRODUKT_PLUGIN_URL . 'assets/shipping-icons/' . $shipping_provider . '.svg'); ?>" alt="<?php echo esc_attr(strtoupper($shipping_provider)); ?>">
                     <?php endif; ?>
                 </div>

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -131,7 +131,8 @@ $show_features = isset($category) ? ($category->show_features ?? 1) : 1;
 $default_feature_svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 81.5 81.9"><path d="M56.5,26.8l-21.7,21.7-9.7-9.7c-1.2-1.2-3.3-1.2-4.5,0s-1.2,3.3,0,4.5l12,12c.6.6,1.5.9,2.3.9s1.6-.3,2.3-.9l24-23.9c1.2-1.2,1.2-3.3,0-4.5-1.3-1.3-3.3-1.3-4.5,0Z"/><path d="M40.8,1C18.7,1,.8,18.9.8,41s17.9,40,40,40,40-17.9,40-40S62.8,1,40.8,1ZM40.8,74.6c-18.5,0-33.6-15.1-33.6-33.6S22.3,7.4,40.8,7.4s33.6,15.1,33.6,33.6-15.1,33.6-33.6,33.6Z"/></svg>';
 // Button
 $ui = get_option('produkt_ui_settings', []);
-$button_text = $ui['button_text'] ?? 'Jetzt Mieten';
+$custom_label = $ui['button_text'] ?? '';
+$button_text = $custom_label; // default, final label determined later
 $button_icon = $ui['button_icon'] ?? '';
 $payment_icons = is_array($ui['payment_icons'] ?? null) ? $ui['payment_icons'] : [];
 $accordions = isset($category) && property_exists($category, 'accordion_data') ? json_decode($category->accordion_data, true) : [];
@@ -150,6 +151,7 @@ $shipping_price_id = $shipping->stripe_price_id ?? '';
 $shipping_cost = $shipping->price ?? 0;
 $shipping_provider = $shipping->service_provider ?? '';
 $modus = get_option('produkt_betriebsmodus', 'miete');
+$button_text = $button_text !== '' ? $button_text : ($modus === 'kauf' ? 'Jetzt kaufen' : 'Jetzt mieten');
 $price_label = $ui['price_label'] ?? ($modus === 'kauf' ? 'Einmaliger Kaufpreis' : 'Monatlicher Mietpreis');
 $shipping_label = 'Einmalige Versandkosten:';
 $price_period = $ui['price_period'] ?? 'month';

--- a/views/account/dashboard.php
+++ b/views/account/dashboard.php
@@ -6,6 +6,7 @@
         <?php if (!empty($message)) { echo $message; } ?>
         <form method="post" class="login-email-form">
             <?php wp_nonce_field('request_login_code_action', 'request_login_code_nonce'); ?>
+            <input type="hidden" name="redirect_to" value="<?php echo esc_url($redirect_to); ?>">
             <input type="email" name="email" placeholder="Ihre E-Mail" value="<?php echo esc_attr($email_value); ?>" required>
             <button type="submit" name="request_login_code">Code zum einloggen anfordern</button>
         </form>
@@ -13,6 +14,7 @@
         <form method="post" class="login-code-form">
             <?php wp_nonce_field('verify_login_code_action', 'verify_login_code_nonce'); ?>
             <input type="hidden" name="email" value="<?php echo esc_attr($email_value); ?>">
+            <input type="hidden" name="redirect_to" value="<?php echo esc_url($redirect_to); ?>">
             <input type="text" name="code" placeholder="6-stelliger Code" required>
             <button type="submit" name="verify_login_code">Einloggen</button>
         </form>
@@ -39,13 +41,43 @@
             <div>
         <?php if ($is_sale) : ?>
             <?php if (!empty($sale_orders)) : ?>
-                <?php foreach ($sale_orders as $order) : ?>
-                    <?php
-                        $variant_id = $order->variant_id ?? 0;
-                        $image_url  = pv_get_image_url_by_variant_or_category($variant_id, $order->category_id ?? 0);
-                    ?>
-                    <?php include PRODUKT_PLUGIN_PATH . 'includes/render-order.php'; ?>
-                <?php endforeach; ?>
+                <?php $first = $sale_orders[0]; ?>
+                <div class="abo-row">
+                    <div class="order-box">
+                        <h3>Kundendaten</h3>
+                        <?php if (!empty($first->customer_name)) : ?>
+                            <p><strong>Name:</strong> <?php echo esc_html($first->customer_name); ?></p>
+                        <?php endif; ?>
+                        <?php if (!empty($first->customer_email)) : ?>
+                            <p><strong>E-Mail:</strong> <?php echo esc_html($first->customer_email); ?></p>
+                        <?php endif; ?>
+                        <?php if (!empty($first->customer_phone)) : ?>
+                            <p><strong>Telefon:</strong> <?php echo esc_html($first->customer_phone); ?></p>
+                        <?php endif; ?>
+                        <?php
+                            $addr = $customer_addr;
+                            if (!$addr) {
+                                $addr = trim($first->customer_street . ', ' . $first->customer_postal . ' ' . $first->customer_city);
+                                if ($first->customer_country) {
+                                    $addr .= ', ' . $first->customer_country;
+                                }
+                            }
+                        ?>
+                        <h4>Versandadresse</h4>
+                        <p><?php echo esc_html($addr ?: 'Nicht angegeben'); ?></p>
+                        <h4>Rechnungsadresse</h4>
+                        <p><?php echo esc_html($addr ?: 'Nicht angegeben'); ?></p>
+                    </div>
+                    <div class="orders-column">
+                        <?php foreach ($sale_orders as $order) : ?>
+                            <?php
+                                $variant_id = $order->variant_id ?? 0;
+                                $image_url  = pv_get_image_url_by_variant_or_category($variant_id, $order->category_id ?? 0);
+                            ?>
+                            <?php include PRODUKT_PLUGIN_PATH . 'includes/render-order-details.php'; ?>
+                        <?php endforeach; ?>
+                    </div>
+                </div>
             <?php else : ?>
                 <p>Keine Bestellungen.</p>
             <?php endif; ?>


### PR DESCRIPTION
## Summary
- add utility to get customer page URL and support redirect after login
- pass `is_logged_in` and `account_url` to front-end script
- include login redirect fields in account forms
- show modal on product page asking to login or checkout as guest

## Testing
- `php -l includes/Plugin.php`
- `php -l includes/Admin.php`
- `php -l templates/product-page.php`
- `php -l views/account/dashboard.php`

------
https://chatgpt.com/codex/tasks/task_b_6881f188890c8330a5a01c1170d8ed7b