### PR TITLE
Retrieve full session in webhook

### DIFF
--- a/h2-rent-pro-stripe/includes/webhook/handler.php
+++ b/h2-rent-pro-stripe/includes/webhook/handler.php
@@ -31,7 +31,23 @@ try {
 
 // Event behandeln
 if ($event->type === 'checkout.session.completed') {
-    $session = $event->data->object;
+    try {
+        $session = \Stripe\Checkout\Session::retrieve(
+            $event->data->object->id,
+            [
+                'expand' => [
+                    'customer',
+                    'customer_details',
+                    'shipping_details',
+                    'payment_intent.customer',
+                    'subscription',
+                ],
+            ]
+        );
+    } catch (\Exception $e) {
+        $session = $event->data->object;
+        file_put_contents($log_file, "Retrieve Error: " . $e->getMessage() . "\n", FILE_APPEND);
+    }
     try {
         \ProduktVerleih\StripeService::process_checkout_session($session);
         file_put_contents($log_file, "Session verarbeitet: " . json_encode($session, JSON_PRETTY_PRINT) . "\n", FILE_APPEND);


### PR DESCRIPTION
## Summary
- expand Stripe checkout session in webhook handler
- keep partial session as fallback if retrieval fails

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_68872389fa90833096d4cea7bf4c52d5