### PR TITLE
Fix customer account details and inventory logic

### DIFF
--- a/admin/calendar-page.php
+++ b/admin/calendar-page.php
@@ -57,9 +57,16 @@ foreach ($orders as $o) {
     );
 }
 foreach ($orders as $o) {
-    if (preg_match('/(\d{4}-\d{2}-\d{2})\s*-\s*(\d{4}-\d{2}-\d{2})/', $o->dauer_text, $m)) {
+    $start = null;
+    $end   = null;
+    if (!empty($o->start_date) && !empty($o->end_date)) {
+        $start = strtotime($o->start_date);
+        $end   = strtotime($o->end_date);
+    } elseif (preg_match('/(\d{4}-\d{2}-\d{2})\s*-\s*(\d{4}-\d{2}-\d{2})/', $o->dauer_text, $m)) {
         $start = strtotime($m[1]);
         $end   = strtotime($m[2]);
+    }
+    if ($start && $end) {
         while ($start <= $end) {
             $d = date('Y-m-d', $start);
             $status = ($o->status === 'abgeschlossen') ? 'completed' : 'open';
@@ -286,6 +293,7 @@ function buildOrderDetails(order, logs) {
                 <li><strong>Ausführung:</strong> ${order.variant_name}</li>
                 <li><strong>Extra:</strong> ${order.extra_names}</li>
                 <li><strong>${order.mode === 'kauf' ? 'Miettage' : 'Mietdauer'}:</strong> ${order.duration_name}</li>
+                ${order.start_date && order.end_date ? `<li><strong>Zeitraum:</strong> ${new Date(order.start_date).toLocaleDateString('de-DE')} - ${new Date(order.end_date).toLocaleDateString('de-DE')}</li>` : ''}
                 ${order.condition_name ? `<li><strong>Zustand:</strong> ${order.condition_name}</li>` : ''}
                 ${order.product_color_name ? `<li><strong>Produktfarbe:</strong> ${order.product_color_name}</li>` : ''}
                 ${order.frame_color_name ? `<li><strong>Gestellfarbe:</strong> ${order.frame_color_name}</li>` : ''}

--- a/admin/customers-page.php
+++ b/admin/customers-page.php
@@ -147,6 +147,7 @@ foreach ($results as $r) {
                         <th>Preis Gesamt</th>
                         <th>Status</th>
                         <th>Datum</th>
+                        <th>Zeitraum</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -157,6 +158,11 @@ foreach ($results as $r) {
                         <td><?php echo number_format((float)$o->final_price, 2, ',', '.'); ?>€</td>
                         <td><?php echo esc_html($o->status); ?></td>
                         <td><?php echo date('d.m.Y', strtotime($o->created_at)); ?></td>
+                        <td>
+                            <?php if ($o->start_date && $o->end_date): ?>
+                                <?php echo date('d.m.Y', strtotime($o->start_date)); ?> - <?php echo date('d.m.Y', strtotime($o->end_date)); ?>
+                            <?php endif; ?>
+                        </td>
                     </tr>
                     <?php endforeach; ?>
                 </tbody>
@@ -172,6 +178,9 @@ foreach ($results as $r) {
                 <?php endif; ?>
                 <?php if ($o->dauer_text): ?>
                 <p><strong>Dauer:</strong> <?php echo esc_html($o->dauer_text); ?></p>
+                <?php endif; ?>
+                <?php if ($o->start_date && $o->end_date): ?>
+                <p><strong>Zeitraum:</strong> <?php echo date('d.m.Y', strtotime($o->start_date)); ?> - <?php echo date('d.m.Y', strtotime($o->end_date)); ?></p>
                 <?php endif; ?>
                 <p><strong>Preis:</strong> <?php echo number_format((float)$o->final_price, 2, ',', '.'); ?>€</p>
                 <?php

--- a/admin/orders-page.php
+++ b/admin/orders-page.php
@@ -205,6 +205,9 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
                                 <?php else: ?>
                                     <span class="text-gray">⏰ Mietdauer: <?php echo esc_html($order->duration_name); ?></span><br>
                                 <?php endif; ?>
+                                <?php if ($order->start_date && $order->end_date): ?>
+                                    <span class="text-gray">📅 <?php echo date('d.m.Y', strtotime($order->start_date)); ?> - <?php echo date('d.m.Y', strtotime($order->end_date)); ?></span><br>
+                                <?php endif; ?>
                                 
                                 <?php if ($order->condition_name): ?>
                                     <span class="text-gray">🔄 <?php echo esc_html($order->condition_name); ?></span><br>
@@ -372,6 +375,7 @@ function showOrderDetails(orderId) {
             <li><strong>Ausführung:</strong> ${order.variant_name}</li>
             <li><strong>Extra:</strong> ${order.extra_names}</li>
             <li><strong>${order.mode === 'kauf' ? 'Miettage' : 'Mietdauer'}:</strong> ${order.duration_name}</li>
+            ${order.start_date && order.end_date ? `<li><strong>Zeitraum:</strong> ${new Date(order.start_date).toLocaleDateString('de-DE')} - ${new Date(order.end_date).toLocaleDateString('de-DE')}</li>` : ''}
     `;
     
     if (order.condition_name) {

--- a/assets/script.js
+++ b/assets/script.js
@@ -793,7 +793,8 @@ jQuery(document).ready(function($) {
                          data-id="${option.id}"
                          data-price-id="${option.stripe_price_id || ''}"
                          data-extra-image="${option.image_url || ''}"
-                         data-available="${option.available == 0 ? 'false' : 'true'}">
+                         data-available="${option.available == 0 ? 'false' : 'true'}"
+                         data-stock="${option.stock_available}">
                         <div class="produkt-option-content">
                             <span class="produkt-extra-name">${option.name}</span>
                             ${priceHtml ? `<div class="produkt-extra-price">${priceHtml}</div>` : ''}

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -382,7 +382,8 @@ class Ajax {
                         'price'          => $e->price,
                         'stripe_price_id'=> $pid,
                         'image_url'      => $e->image_url ?? '',
-                        'available'      => intval($e->stock_available) > 0 ? 1 : 0,
+                        'available'      => intval($e->available) ? 1 : 0,
+                        'stock_available'=> intval($e->stock_available),
                     ];
                     $amount = StripeService::get_price_amount($pid);
                     if (!is_wp_error($amount)) {

--- a/includes/render-order-details.php
+++ b/includes/render-order-details.php
@@ -27,4 +27,7 @@ if (!defined('ABSPATH')) { exit; }
     <?php if (!empty($order->dauer_text)) : ?>
         <p><strong>Miettage:</strong> <?php echo esc_html($order->dauer_text); ?></p>
     <?php endif; ?>
+    <?php if (!empty($order->start_date) && !empty($order->end_date)) : ?>
+        <p><strong>Zeitraum:</strong> <?php echo esc_html(date_i18n('d.m.Y', strtotime($order->start_date))); ?> - <?php echo esc_html(date_i18n('d.m.Y', strtotime($order->end_date))); ?></p>
+    <?php endif; ?>
 </div>

--- a/includes/render-order.php
+++ b/includes/render-order.php
@@ -28,6 +28,9 @@ if (!defined('ABSPATH')) { exit; }
         <?php if (!empty($order->dauer_text)) : ?>
             <p><strong>Miettage:</strong> <?php echo esc_html($order->dauer_text); ?></p>
         <?php endif; ?>
+        <?php if (!empty($order->start_date) && !empty($order->end_date)) : ?>
+            <p><strong>Zeitraum:</strong> <?php echo esc_html(date_i18n('d.m.Y', strtotime($order->start_date))); ?> - <?php echo esc_html(date_i18n('d.m.Y', strtotime($order->end_date))); ?></p>
+        <?php endif; ?>
     </div>
     <div class="order-box">
         <h3>Kundendaten</h3>


### PR DESCRIPTION
## Summary
- show stock availability separately so extras with zero stock can still be booked when free
- display rental period for orders across admin pages and customer view
- include period info in calendar rendering and order modals
- add timeframe columns on customer admin page

## Testing
- `find admin includes -name '*.php' | xargs -I{} php -l {}`
- `node -c assets/script.js`


------
https://chatgpt.com/codex/tasks/task_b_6887790ccb488330b3b24487be5be55e