### PR TITLE
Remove obsolete info sections from orders

### DIFF
--- a/admin/categories-page.php
+++ b/admin/categories-page.php
@@ -3,64 +3,182 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+use ProduktVerleih\Database;
+
 global $wpdb;
+
+// Latest 4 products
+$recent_products = $wpdb->get_results(
+    "SELECT id, name, default_image FROM {$wpdb->prefix}produkt_categories ORDER BY id DESC LIMIT 4"
+);
+
+// Variables provided by Admin::categories_page()
+$categories        = $categories ?? [];
+$product_categories = $product_categories ?? [];
+$selected_prodcat  = $selected_prodcat ?? 0;
+$search_term       = $search_term ?? '';
+$active_tab        = $active_tab ?? 'list';
+$edit_item         = $edit_item ?? null;
 ?>
 
-<div class="wrap" id="produkt-admin-categories">
-    <div class="produkt-admin-card">
-        <!-- Kompakter Header -->
-        <div class="produkt-admin-header-compact">
-            <div class="produkt-admin-logo-compact">🏷️</div>
-            <div class="produkt-admin-title-compact">
-                <h1>Produkte verwalten</h1>
-                <p>Produkte & SEO-Einstellungen</p>
+<div class="produkt-admin dashboard-wrapper">
+    <h1 class="dashboard-greeting">Hallo, <?php echo esc_html(wp_get_current_user()->display_name); ?> 👋</h1>
+    <p class="dashboard-subline">Produkte verwalten</p>
+
+<?php if ($active_tab === 'list'): ?>
+    <div class="dashboard-grid">
+        <div class="dashboard-left">
+            <div class="dashboard-card">
+                <h2>Neueste Produkte</h2>
+                <p class="card-subline">Die zuletzt hinzugefügten Produkte</p>
+                <div class="recent-product-tiles">
+                    <?php foreach ($recent_products as $prod): ?>
+                        <?php $has_image = !empty($prod->default_image); ?>
+                        <div class="recent-product-tile<?php echo $has_image ? '' : ' no-image'; ?>"<?php echo $has_image ? ' style="background-image:url(' . esc_url($prod->default_image) . ')"' : ''; ?> onclick="window.location.href='?page=produkt-categories&tab=edit&edit=<?php echo $prod->id; ?>'">
+                            <?php if (!$has_image): ?>
+                                <div class="placeholder-icon">🏷️</div>
+                            <?php endif; ?>
+                            <div class="tile-overlay">
+                                <span><?php echo esc_html($prod->name); ?></span>
+                                <button type="button" class="icon-btn edit-btn" aria-label="Bearbeiten" onclick="event.stopPropagation();window.location.href='?page=produkt-categories&tab=edit&edit=<?php echo $prod->id; ?>'">
+                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80.8 80.1">
+                                        <path d="M54.7,4.8l-31.5,31.7c-.6.6-1,1.5-1.2,2.3l-3.3,18.3c-.2,1.2.2,2.7,1.2,3.8.8.8,1.9,1.2,2.9,1.2h.8l18.3-3.3c.8-.2,1.7-.6,2.3-1.2l31.7-31.7c5.8-5.8,5.8-15.2,0-21-6-5.8-15.4-5.8-21.2,0h0ZM69.9,19.8l-30.8,30.8-11,1.9,2.1-11.2,30.6-30.6c2.5-2.5,6.7-2.5,9.2,0,2.5,2.7,2.5,6.7,0,9.2Z"/>
+                                        <path d="M5.1,79.6h70.8c2.3,0,4.2-1.9,4.2-4.2v-35.4c0-2.3-1.9-4.2-4.2-4.2s-4.2,1.9-4.2,4.2v31.2H9.2V8.8h31.2c2.3,0,4.2-1.9,4.2-4.2s-1.9-4.2-4.2-4.2H5.1c-2.3,0-4.2,1.9-4.2,4.2v70.8c0,2.3,1.9,4.2,4.2,4.2h0Z"/>
+                                    </svg>
+                                </button>
+                            </div>
+                        </div>
+                    <?php endforeach; ?>
+                </div>
             </div>
         </div>
-    
-    <!-- Breadcrumb Navigation -->
-    <div class="produkt-breadcrumb">
-        <a href="<?php echo admin_url('admin.php?page=produkt-verleih'); ?>">Dashboard</a> 
-        <span>→</span> 
-        <strong>Produkte</strong>
-    </div>
-    
-    <!-- Tab Navigation -->
-    <div class="produkt-tab-nav">
-        <a href="<?php echo admin_url('admin.php?page=produkt-categories&tab=list'); ?>" 
-           class="produkt-tab <?php echo $active_tab === 'list' ? 'active' : ''; ?>">
-            📋 Übersicht
-        </a>
-        <a href="<?php echo admin_url('admin.php?page=produkt-categories&tab=add'); ?>" 
-           class="produkt-tab <?php echo $active_tab === 'add' ? 'active' : ''; ?>">
-            ➕ Neues Produkt
-        </a>
-        <?php if ($edit_item): ?>
-        <a href="<?php echo admin_url('admin.php?page=produkt-categories&tab=edit&edit=' . $edit_item->id); ?>" 
-           class="produkt-tab <?php echo $active_tab === 'edit' ? 'active' : ''; ?>">
-            ✏️ Bearbeiten
-        </a>
-        <?php endif; ?>
-    </div>
-    
-        <!-- Tab Content -->
-        <div class="produkt-tab-content">
-            <?php
-            switch ($active_tab) {
-                case 'add':
-                    include PRODUKT_PLUGIN_PATH . 'admin/tabs/categories-add-tab.php';
-                    break;
-                case 'edit':
-                    if ($edit_item) {
-                        include PRODUKT_PLUGIN_PATH . 'admin/tabs/categories-edit-tab.php';
-                    } else {
-                        include PRODUKT_PLUGIN_PATH . 'admin/tabs/categories-list-tab.php';
-                    }
-                    break;
-                case 'list':
-                default:
-                    include PRODUKT_PLUGIN_PATH . 'admin/tabs/categories-list-tab.php';
-            }
-            ?>
+        <div class="dashboard-right">
+            <div class="dashboard-row">
+                <div class="dashboard-card card-new-product">
+                    <h2>Neues Produkt</h2>
+                    <p class="card-subline">Produkt erstellen</p>
+                    <a href="<?php echo admin_url('admin.php?page=produkt-categories&tab=add'); ?>" class="icon-btn add-product-btn" aria-label="Hinzufügen">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80.3">
+                            <path d="M12.1,12c-15.4,15.4-15.4,40.4,0,55.8,7.7,7.7,17.7,11.7,27.9,11.7s20.2-3.8,27.9-11.5c15.4-15.4,15.4-40.4,0-55.8-15.4-15.6-40.4-15.6-55.8-.2h0ZM62.1,62c-12.1,12.1-31.9,12.1-44.2,0-12.1-12.1-12.1-31.9,0-44.2,12.1-12.1,31.9-12.1,44.2,0,12.1,12.3,12.1,31.9,0,44.2Z"/>
+                            <path d="M54.6,35.7h-10.4v-10.4c0-2.3-1.9-4.2-4.2-4.2s-4.2,1.9-4.2,4.2v10.4h-10.4c-2.3,0-4.2,1.9-4.2,4.2s1.9,4.2,4.2,4.2h10.4v10.4c0,2.3,1.9,4.2,4.2,4.2s4.2-1.9,4.2-4.2v-10.4h10.4c2.3,0,4.2-1.9,4.2-4.2s-1.9-4.2-4.2-4.2Z"/>
+                        </svg>
+                    </a>
+                </div>
+                <div class="dashboard-card card-quicknav">
+                    <h2>Schnellnavigation</h2>
+                    <p class="card-subline">Direkt zu wichtigen Listen</p>
+                    <div class="quicknav-grid">
+                        <div class="quicknav-card">
+                            <a href="admin.php?page=produkt-variants">
+                                <div class="quicknav-inner">
+                                    <div class="quicknav-icon-circle">🧩</div>
+                                    <div class="quicknav-label">Ausführungen</div>
+                                </div>
+                            </a>
+                        </div>
+                        <div class="quicknav-card">
+                            <a href="admin.php?page=produkt-extras">
+                                <div class="quicknav-inner">
+                                    <div class="quicknav-icon-circle">✨</div>
+                                    <div class="quicknav-label">Extras</div>
+                                </div>
+                            </a>
+                        </div>
+                        <div class="quicknav-card">
+                            <a href="admin.php?page=produkt-conditions">
+                                <div class="quicknav-inner">
+                                    <div class="quicknav-icon-circle">🔧</div>
+                                    <div class="quicknav-label">Zustand</div>
+                                </div>
+                            </a>
+                        </div>
+                        <div class="quicknav-card">
+                            <a href="admin.php?page=produkt-colors">
+                                <div class="quicknav-inner">
+                                    <div class="quicknav-icon-circle">🎨</div>
+                                    <div class="quicknav-label">Farben</div>
+                                </div>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="h2-rental-card">
+                <div class="card-header-flex">
+                    <div>
+                        <h2>Alle Produkte</h2>
+                        <p class="card-subline">Produkte nach Kategorien anzeigen lassen</p>
+                    </div>
+                    <form method="get" class="produkt-filter-form product-search-bar">
+                        <input type="hidden" name="page" value="produkt-categories">
+                        <div class="search-input-wrapper">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="search-icon">
+                                <path d="M10 2a8 8 0 105.3 14.1l4.3 4.3a1 1 0 101.4-1.4l-4.3-4.3A8 8 0 0010 2zm0 2a6 6 0 110 12 6 6 0 010-12z"/>
+                            </svg>
+                            <input type="text" name="s" placeholder="Suchen nach Produkten" value="<?php echo esc_attr($search_term); ?>">
+                        </div>
+                        <select name="prodcat">
+                            <option value="0">Alle Kategorien</option>
+                            <?php foreach ($product_categories as $pc): ?>
+                                <option value="<?php echo $pc->id; ?>" <?php selected($selected_prodcat, $pc->id); ?>><?php echo str_repeat('--', $pc->depth) . ' ' . esc_html($pc->name); ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                        <button type="submit" class="icon-btn filter-submit-btn" aria-label="Filtern">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 22.1">
+                                <path d="M16,0C7.2,0,0,4.9,0,11s7.2,11,16,11,16-4.9,16-11S24.8,0,16,0ZM16,20c-7.7,0-14-4-14-9S8.3,2,16,2s14,4,14,9-6.3,9-14,9ZM16,5c-3.3,0-6,2.7-6,6s2.7,6,6,6,6-2.7,6-6-2.7-6-6-6ZM16,15c-2.2,0-4-1.8-4-4s1.8-4,4-4,4,1.8,4,4-1.8,4-4,4Z"/>
+                            </svg>
+                        </button>
+                    </form>
+                </div>
+                <table class="activity-table">
+                    <thead>
+                        <tr>
+                            <th>Bild</th>
+                            <th>Name</th>
+                            <th>Shortcode</th>
+                            <th>Kategorien</th>
+                            <th>SEO</th>
+                            <th>Aktionen</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($categories as $cat): ?>
+                            <tr>
+                                <td>
+                                    <?php if (!empty($cat->default_image)): ?>
+                                        <img src="<?php echo esc_url($cat->default_image); ?>" style="width:60px;height:60px;object-fit:cover;border-radius:4px;" alt="<?php echo esc_attr($cat->name); ?>">
+                                    <?php else: ?>
+                                        <div style="width:60px;height:60px;background:#f0f0f0;border-radius:4px;display:flex;align-items:center;justify-content:center;">🏷️</div>
+                                    <?php endif; ?>
+                                </td>
+                                <td><?php echo esc_html($cat->name); ?></td>
+                                <td><code>[produkt_product category="<?php echo esc_html($cat->shortcode); ?>"]</code></td>
+                                <td><?php echo esc_html($cat->categories ?: ''); ?></td>
+                                <td><?php echo $cat->meta_title ? '✅' : '❌'; ?></td>
+                                <td>
+                                    <button type="button" class="icon-btn" aria-label="Bearbeiten" onclick="window.location.href='?page=produkt-categories&tab=edit&edit=<?php echo $cat->id; ?>'">
+                                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80.8 80.1">
+                                            <path d="M54.7,4.8l-31.5,31.7c-.6.6-1,1.5-1.2,2.3l-3.3,18.3c-.2,1.2.2,2.7,1.2,3.8.8.8,1.9,1.2,2.9,1.2h.8l18.3-3.3c.8-.2,1.7-.6,2.3-1.2l31.7-31.7c5.8-5.8,5.8-15.2,0-21-6-5.8-15.4-5.8-21.2,0h0ZM69.9,19.8l-30.8,30.8-11,1.9,2.1-11.2,30.6-30.6c2.5-2.5,6.7-2.5,9.2,0,2.5,2.7,2.5,6.7,0,9.2Z"/>
+                                            <path d="M5.1,79.6h70.8c2.3,0,4.2-1.9,4.2-4.2v-35.4c0-2.3-1.9-4.2-4.2-4.2s-4.2,1.9-4.2,4.2v31.2H9.2V8.8h31.2c2.3,0,4.2-1.9,4.2-4.2s-1.9-4.2-4.2-4.2H5.1c-2.3,0-4.2,1.9-4.2,4.2v70.8c0,2.3,1.9,4.2,4.2,4.2h0Z"/>
+                                        </svg>
+                                    </button>
+                                    <button type="button" class="icon-btn" onclick="if(confirm('Wirklich löschen?')){window.location.href='?page=produkt-categories&delete=<?php echo $cat->id; ?>&fw_nonce=<?php echo wp_create_nonce('produkt_admin_action'); ?>';}" aria-label="Löschen">
+                                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 79.9 80.1">
+                                            <path d="M39.8.4C18,.4.3,18.1.3,40s17.7,39.6,39.6,39.6,39.6-17.7,39.6-39.6S61.7.4,39.8.4ZM39.8,71.3c-17.1,0-31.2-14-31.2-31.2s14.2-31.2,31.2-31.2,31.2,14,31.2,31.2-14.2,31.2-31.2,31.2Z"/>
+                                            <path d="M53,26.9c-1.7-1.7-4.2-1.7-5.8,0l-7.3,7.3-7.3-7.3c-1.7-1.7-4.2-1.7-5.8,0-1.7,1.7-1.7,4.2,0,5.8l7.3,7.3-7.3,7.3c-1.7,1.7-1.7,4.2,0,5.8.8.8,1.9,1.2,2.9,1.2s2.1-.4,2.9-1.2l7.3-7.3,7.3,7.3c.8.8,1.9,1.2,2.9,1.2s2.1-.4,2.9-1.2c1.7-1.7,1.7-4.2,0-5.8l-7.3-7.3,7.3-7.3c1.7-1.7,1.7-4.4,0-5.8h0Z"/>
+                                        </svg>
+                                    </button>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
+<?php elseif ($active_tab === 'add'): ?>
+    <?php include PRODUKT_PLUGIN_PATH . 'admin/tabs/categories-add-tab.php'; ?>
+<?php elseif ($active_tab === 'edit' && $edit_item): ?>
+    <?php include PRODUKT_PLUGIN_PATH . 'admin/tabs/categories-edit-tab.php'; ?>
+<?php endif; ?>
 </div>

--- a/admin/content-blocks-page.php
+++ b/admin/content-blocks-page.php
@@ -1,19 +1,29 @@
 <?php
-if (!defined('ABSPATH')) { exit; }
+if (!defined('ABSPATH')) {
+    exit;
+}
 
 global $wpdb;
 $table_name = $wpdb->prefix . 'produkt_content_blocks';
 
 $categories = \ProduktVerleih\Database::get_product_categories_tree();
-array_unshift($categories, (object)['id' => 0, 'name' => 'Alle Kategorien']);
-$selected_category = isset($_GET['category']) ? intval($_GET['category']) : ($categories[0]->id ?? 0);
-$action = isset($_GET['action']) ? sanitize_text_field($_GET['action']) : 'list';
-$edit_id = isset($_GET['edit']) ? intval($_GET['edit']) : 0;
+array_unshift($categories, (object) ['id' => 0, 'name' => 'Alle Kategorien']);
+$selected_category = isset($_GET['category']) ? intval($_GET['category']) : 0;
+$search_term       = isset($_GET['s']) ? sanitize_text_field($_GET['s']) : '';
+$action            = isset($_GET['action']) ? sanitize_text_field($_GET['action']) : 'list';
+$edit_id           = isset($_GET['edit']) ? intval($_GET['edit']) : 0;
+
+// Statistik Werte
+$total_blocks   = $wpdb->get_var("SELECT COUNT(*) FROM $table_name");
+$category_count = $wpdb->get_var("SELECT COUNT(*) FROM {$wpdb->prefix}produkt_categories");
+$wide_count     = $wpdb->get_var("SELECT COUNT(*) FROM $table_name WHERE style='wide'");
+$compact_count  = $wpdb->get_var("SELECT COUNT(*) FROM $table_name WHERE style='compact'");
 
 if (isset($_POST['save_block'])) {
     \ProduktVerleih\Admin::verify_admin_action();
+    $category_id = intval($_POST['category_id']);
     $data = [
-        'category_id' => $selected_category,
+        'category_id'      => $category_id,
         'style'        => sanitize_text_field($_POST['style']),
         'position'     => intval($_POST['position']),
         'position_mobile' => intval($_POST['position_mobile']),
@@ -30,7 +40,7 @@ if (isset($_POST['save_block'])) {
     } else {
         $wpdb->insert($table_name, $data);
     }
-    \ProduktVerleih\Database::clear_content_blocks_cache($selected_category);
+    \ProduktVerleih\Database::clear_content_blocks_cache($category_id);
     $action = 'list';
 }
 
@@ -45,133 +55,207 @@ if ($action === 'edit' && $edit_id) {
     if (!$block) { $action = 'list'; }
 }
 
-$blocks = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE category_id = %d ORDER BY position", $selected_category));
+$sql_blocks = "SELECT * FROM $table_name";
+$params = [];
+$clauses = [];
+if ($selected_category > 0) {
+    $clauses[] = "category_id = %d";
+    $params[] = $selected_category;
+}
+if ($search_term !== '') {
+    $clauses[] = "title LIKE %s";
+    $params[] = '%' . $wpdb->esc_like($search_term) . '%';
+}
+if ($clauses) {
+    $sql_blocks .= ' WHERE ' . implode(' AND ', $clauses);
+}
+$sql_blocks .= ' ORDER BY position';
+$blocks = !empty($params) ? $wpdb->get_results($wpdb->prepare($sql_blocks, ...$params)) : $wpdb->get_results($sql_blocks);
 ?>
-<div class="wrap" id="produkt-admin-content-blocks">
-    <div class="produkt-admin-card">
-        <div class="produkt-admin-header-compact">
-            <div class="produkt-admin-logo-compact">
-                <span class="dashicons dashicons-welcome-write-blog"></span>
+<div class="produkt-admin dashboard-wrapper">
+    <h1 class="dashboard-greeting">Hallo, <?php echo esc_html(wp_get_current_user()->display_name); ?> 👋</h1>
+    <p class="dashboard-subline">Content-Blöcke verwalten</p>
+
+<?php if ($action === 'list'): ?>
+    <div class="product-info-grid cols-4">
+        <div class="product-info-box bg-pastell-gelb">
+            <span class="label">Blöcke</span>
+            <strong class="value"><?php echo intval($total_blocks); ?></strong>
+        </div>
+        <div class="product-info-box bg-pastell-gruen">
+            <span class="label">Kategorien</span>
+            <strong class="value"><?php echo intval($category_count); ?></strong>
+        </div>
+        <div class="product-info-box bg-pastell-mint">
+            <span class="label">Weit</span>
+            <strong class="value"><?php echo intval($wide_count); ?></strong>
+        </div>
+        <div class="product-info-box bg-pastell-orange">
+            <span class="label">Kompakt</span>
+            <strong class="value"><?php echo intval($compact_count); ?></strong>
+        </div>
+    </div>
+
+    <div class="h2-rental-card">
+        <div class="card-header-flex">
+            <div>
+                <h2>Content Blöcke</h2>
+                <p class="card-subline">Blöcke verwalten</p>
             </div>
-            <div class="produkt-admin-title-compact">
-                <h1>Content-Blöcke</h1>
-                <p>Gestalte Texte und Bilder für Kategorien</p>
+            <div class="card-header-actions">
+                <form method="get" class="produkt-filter-form product-search-bar">
+                    <input type="hidden" name="page" value="produkt-content-blocks">
+                    <div class="search-input-wrapper">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="search-icon">
+                            <path d="M10 2a8 8 0 105.3 14.1l4.3 4.3a1 1 0 101.4-1.4l-4.3-4.3A8 8 0 0010 2zm0 2a6 6 0 110 12 6 6 0 010-12z"/>
+                        </svg>
+                        <input type="text" name="s" placeholder="Suchen" value="<?php echo esc_attr($search_term); ?>">
+                    </div>
+                    <select name="category">
+                        <option value="0">Alle Kategorien</option>
+                        <?php foreach ($categories as $cat): ?>
+                            <option value="<?php echo $cat->id; ?>" <?php selected($selected_category, $cat->id); ?>><?php echo str_repeat('--', $cat->depth ?? 0) . ' ' . esc_html($cat->name); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                    <button type="submit" class="icon-btn filter-submit-btn" aria-label="Filtern">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 22.1">
+                            <path d="M16,0C7.2,0,0,4.9,0,11s7.2,11,16,11,16-4.9,16-11S24.8,0,16,0ZM16,20c-7.7,0-14-4-14-9S8.3,2,16,2s14,4,14,9-6.3,9-14,9ZM16,5c-3.3,0-6,2.7-6,6s2.7,6,6,6,6-2.7,6-6-2.7-6-6-6ZM16,15c-2.2,0-4-1.8-4-4s1.8-4,4-4,4,1.8,4,4-1.8,4-4,4Z"/>
+                        </svg>
+                    </button>
+                </form>
+                <a id="add-category-btn" href="<?php echo admin_url('admin.php?page=produkt-content-blocks&action=add'); ?>" class="icon-btn add-category-btn" aria-label="Hinzufügen">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80.3">
+                        <path d="M12.1,12c-15.4,15.4-15.4,40.4,0,55.8,7.7,7.7,17.7,11.7,27.9,11.7s20.2-3.8,27.9-11.5c15.4-15.4,15.4-40.4,0-55.8-15.4-15.6-40.4-15.6-55.8-.2h0ZM62.1,62c-12.1,12.1-31.9,12.1-44.2,0-12.1-12.1-12.1-31.9,0-44.2,12.1-12.1,31.9-12.1,44.2,0,12.1,12.3,12.1,31.9,0,44.2Z"/>
+                        <path d="M54.6,35.7h-10.4v-10.4c0-2.3-1.9-4.2-4.2-4.2s-4.2,1.9-4.2,4.2v10.4h-10.4c-2.3,0-4.2,1.9-4.2,4.2s1.9,4.2,4.2,4.2h10.4v10.4c0,2.3,1.9,4.2,4.2,4.2s4.2-1.9,4.2-4.2v-10.4h10.4c2.3,0,4.2-1.9,4.2-4.2s-1.9-4.2-4.2-4.2Z"/>
+                    </svg>
+                </a>
             </div>
         </div>
-
-    <form method="get" action="">
-        <input type="hidden" name="page" value="produkt-content-blocks">
-        <label for="cb-category-select"><strong>Kategorie:</strong></label>
-        <select id="cb-category-select" name="category" onchange="this.form.submit()">
-            <?php foreach ($categories as $cat): ?>
-                <option value="<?php echo $cat->id; ?>" <?php selected($selected_category, $cat->id); ?>><?php echo str_repeat('--', $cat->depth ?? 0) . ' ' . esc_html($cat->name); ?></option>
-            <?php endforeach; ?>
-        </select>
-        <noscript><input type="submit" value="Wechseln" class="button"></noscript>
+        <table class="activity-table">
+            <thead>
+                <tr>
+                    <th>Titel</th>
+                    <th>Layout</th>
+                    <th>Badge-Text</th>
+                    <th>Position Desktop</th>
+                    <th>Position Mobil</th>
+                    <th>Aktionen</th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($blocks as $b): ?>
+                    <tr>
+                        <td><?php echo esc_html($b->title); ?></td>
+                        <td><?php echo esc_html($b->style); ?></td>
+                        <td><?php echo esc_html($b->badge_text); ?></td>
+                        <td><?php echo intval($b->position); ?></td>
+                        <td><?php echo intval($b->position_mobile); ?></td>
+                        <td>
+                            <button type="button" class="icon-btn" aria-label="Bearbeiten" onclick="window.location.href='?page=produkt-content-blocks&action=edit&edit=<?php echo $b->id; ?>'">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80.8 80.1">
+                                    <path d="M54.7,4.8l-31.5,31.7c-.6.6-1,1.5-1.2,2.3l-3.3,18.3c-.2,1.2.2,2.7,1.2,3.8.8.8,1.9,1.2,2.9,1.2h.8l18.3-3.3c.8-.2,1.7-.6,2.3-1.2l31.7-31.7c5.8-5.8,5.8-15.2,0-21-6-5.8-15.4-5.8-21.2,0h0ZM69.9,19.8l-30.8,30.8-11,1.9,2.1-11.2,30.6-30.6c2.5-2.5,6.7-2.5,9.2,0,2.5,2.7,2.5,6.7,0,9.2Z"/>
+                                    <path d="M5.1,79.6h70.8c2.3,0,4.2-1.9,4.2-4.2v-35.4c0-2.3-1.9-4.2-4.2-4.2s-4.2,1.9-4.2,4.2v31.2H9.2V8.8h31.2c2.3,0,4.2-1.9,4.2-4.2s-1.9-4.2-4.2-4.2H5.1c-2.3,0-4.2,1.9-4.2,4.2v70.8c0,2.3,1.9,4.2,4.2,4.2h0Z"/>
+                                </svg>
+                            </button>
+                            <button type="button" class="icon-btn" onclick="if(confirm('Wirklich löschen?')){window.location.href='?page=produkt-content-blocks&delete=<?php echo $b->id; ?>&fw_nonce=<?php echo wp_create_nonce('produkt_admin_action'); ?>';}" aria-label="Löschen">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 79.9 80.1">
+                                    <path d="M39.8.4C18,.4.3,18.1.3,40s17.7,39.6,39.6,39.6,39.6-17.7,39.6-39.6S61.7.4,39.8.4ZM39.8,71.3c-17.1,0-31.2-14-31.2-31.2s14.2-31.2,31.2-31.2,31.2,14,31.2,31.2-14.2,31.2-31.2,31.2Z"/>
+                                    <path d="M53,26.9c-1.7-1.7-4.2-1.7-5.8,0l-7.3,7.3-7.3-7.3c-1.7-1.7-4.2-1.7-5.8,0-1.7,1.7-1.7,4.2,0,5.8l7.3,7.3-7.3,7.3c-1.7,1.7-1.7,4.2,0,5.8.8.8,1.9,1.2,2.9,1.2s2.1-.4,2.9-1.2l7.3-7.3,7.3,7.3c.8.8,1.9,1.2,2.9,1.2s2.1-.4,2.9-1.2c1.7-1.7,1.7-4.2,0-5.8l-7.3-7.3,7.3-7.3c1.7-1.7,1.7-4.4,0-5.8h0Z"/>
+                                </svg>
+                            </button>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+<?php else: ?>
+    <h2><?php echo $action === 'edit' ? 'Block bearbeiten' : 'Neuen Block hinzufügen'; ?></h2>
+    <form method="post" action="" class="produkt-compact-form">
+        <?php wp_nonce_field('produkt_admin_action', 'produkt_admin_nonce'); ?>
+        <input type="hidden" name="id" value="<?php echo esc_attr($block->id ?? ''); ?>">
+        <table class="form-table">
+            <tr>
+                <th><label>Kategorie *</label></th>
+                <td>
+                    <select name="category_id" required>
+                        <?php foreach ($categories as $cat): ?>
+                            <option value="<?php echo $cat->id; ?>" <?php selected(($block->category_id ?? $selected_category), $cat->id); ?>><?php echo str_repeat('--', $cat->depth ?? 0) . ' ' . esc_html($cat->name); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </td>
+            </tr>
+            <tr>
+                <th><label>Layout</label></th>
+                <td>
+                    <select name="style">
+                        <option value="compact" <?php selected($block->style ?? 'wide', 'compact'); ?>>Kompakt</option>
+                        <option value="wide" <?php selected($block->style ?? 'wide', 'wide'); ?>>Weit</option>
+                    </select>
+                </td>
+            </tr>
+            <tr>
+                <th><label>Position Desktop *</label></th>
+                <td><input type="number" name="position" required value="<?php echo esc_attr($block->position ?? 9); ?>"></td>
+            </tr>
+            <tr>
+                <th><label>Position Mobil *</label></th>
+                <td><input type="number" name="position_mobile" required value="<?php echo esc_attr($block->position_mobile ?? 6); ?>"></td>
+            </tr>
+            <tr>
+                <th><label>Überschrift *</label></th>
+                <td><input type="text" name="title" required value="<?php echo esc_attr($block->title ?? ''); ?>"></td>
+            </tr>
+            <tr>
+                <th><label>Text *</label></th>
+                <td><textarea name="content" rows="4" required><?php echo esc_textarea($block->content ?? ''); ?></textarea></td>
+            </tr>
+            <tr>
+                <th><label>Bild</label></th>
+                <td>
+                    <input type="url" name="image_url" id="image_url" value="<?php echo esc_attr($block->image_url ?? ''); ?>">
+                    <button type="button" class="button produkt-media-button" data-target="image_url">📁</button>
+                </td>
+            </tr>
+            <tr>
+                <th><label>Button-Text</label></th>
+                <td><input type="text" name="button_text" value="<?php echo esc_attr($block->button_text ?? ''); ?>"></td>
+            </tr>
+            <tr>
+                <th><label>Button-Link</label></th>
+                <td><input type="url" name="button_url" value="<?php echo esc_attr($block->button_url ?? ''); ?>"></td>
+            </tr>
+            <tr>
+                <th><label>Hintergrundfarbe</label></th>
+                <td><input type="color" name="background_color" value="<?php echo esc_attr($block->background_color ?? '#ffffff'); ?>"></td>
+            </tr>
+            <tr>
+                <th><label>Badge-Text</label></th>
+                <td><input type="text" name="badge_text" value="<?php echo esc_attr($block->badge_text ?? ''); ?>"></td>
+            </tr>
+        </table>
+        <p>
+            <button type="submit" name="save_block" class="button button-primary">Speichern</button>
+            <a href="<?php echo admin_url('admin.php?page=produkt-content-blocks'); ?>" class="button">Abbrechen</a>
+        </p>
     </form>
-
-    <?php if ($action === 'add' || $action === 'edit'): ?>
-        <h2><?php echo $action === 'edit' ? 'Block bearbeiten' : 'Neuen Block hinzufügen'; ?></h2>
-        <form method="post" action="" class="produkt-compact-form">
-            <?php wp_nonce_field('produkt_admin_action', 'produkt_admin_nonce'); ?>
-            <input type="hidden" name="id" value="<?php echo esc_attr($block->id ?? ''); ?>">
-            <input type="hidden" name="category_id" value="<?php echo $selected_category; ?>">
-            <table class="form-table">
-                <tr>
-                    <th><label>Layout</label></th>
-                    <td>
-                        <select name="style">
-                            <option value="compact" <?php selected($block->style ?? 'wide', 'compact'); ?>>Kompakt</option>
-                            <option value="wide" <?php selected($block->style ?? 'wide', 'wide'); ?>>Weit</option>
-                        </select>
-                    </td>
-                </tr>
-                <tr>
-                    <th><label>Position Desktop *</label></th>
-                    <td><input type="number" name="position" required value="<?php echo esc_attr($block->position ?? 9); ?>"></td>
-                </tr>
-                <tr>
-                    <th><label>Position Mobil *</label></th>
-                    <td><input type="number" name="position_mobile" required value="<?php echo esc_attr($block->position_mobile ?? 6); ?>"></td>
-                </tr>
-                <tr>
-                    <th><label>Überschrift *</label></th>
-                    <td><input type="text" name="title" required value="<?php echo esc_attr($block->title ?? ''); ?>"></td>
-                </tr>
-                <tr>
-                    <th><label>Text *</label></th>
-                    <td><textarea name="content" rows="4" required><?php echo esc_textarea($block->content ?? ''); ?></textarea></td>
-                </tr>
-                <tr>
-                    <th><label>Bild</label></th>
-                    <td>
-                        <input type="url" name="image_url" id="image_url" value="<?php echo esc_attr($block->image_url ?? ''); ?>">
-                        <button type="button" class="button produkt-media-button" data-target="image_url">📁</button>
-                    </td>
-                </tr>
-                <tr>
-                    <th><label>Button-Text</label></th>
-                    <td><input type="text" name="button_text" value="<?php echo esc_attr($block->button_text ?? ''); ?>"></td>
-                </tr>
-                <tr>
-                    <th><label>Button-Link</label></th>
-                    <td><input type="url" name="button_url" value="<?php echo esc_attr($block->button_url ?? ''); ?>"></td>
-                </tr>
-                <tr>
-                    <th><label>Hintergrundfarbe</label></th>
-                    <td><input type="color" name="background_color" value="<?php echo esc_attr($block->background_color ?? '#ffffff'); ?>"></td>
-                </tr>
-                <tr>
-                    <th><label>Badge-Text</label></th>
-                    <td><input type="text" name="badge_text" value="<?php echo esc_attr($block->badge_text ?? ''); ?>"></td>
-                </tr>
-            </table>
-            <p>
-                <button type="submit" name="save_block" class="button button-primary">Speichern</button>
-                <a href="<?php echo admin_url('admin.php?page=produkt-content-blocks&category=' . $selected_category); ?>" class="button">Abbrechen</a>
-            </p>
-        </form>
-        <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            document.querySelectorAll('.produkt-media-button').forEach(function(btn) {
-                btn.addEventListener('click', function(e) {
-                    e.preventDefault();
-                    const targetId = this.getAttribute('data-target');
-                    const field = document.getElementById(targetId);
-                    if (!field) return;
-                    const frame = wp.media({ title: 'Bild auswählen', button: { text: 'Bild verwenden' }, multiple: false });
-                    frame.on('select', function() {
-                        const att = frame.state().get('selection').first().toJSON();
-                        field.value = att.url;
-                    });
-                    frame.open();
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        document.querySelectorAll('.produkt-media-button').forEach(function(btn) {
+            btn.addEventListener('click', function(e) {
+                e.preventDefault();
+                const targetId = this.getAttribute('data-target');
+                const field = document.getElementById(targetId);
+                if (!field) return;
+                const frame = wp.media({ title: 'Bild auswählen', button: { text: 'Bild verwenden' }, multiple: false });
+                frame.on('select', function() {
+                    const att = frame.state().get('selection').first().toJSON();
+                    field.value = att.url;
                 });
+                frame.open();
             });
         });
-        </script>
-    <?php else: ?>
-        <h2>Blöcke</h2>
-        <p><a href="<?php echo admin_url('admin.php?page=produkt-content-blocks&category=' . $selected_category . '&action=add'); ?>" class="button button-primary">Neuen Block hinzufügen</a></p>
-        <?php if (empty($blocks)): ?>
-            <p>Noch keine Blöcke definiert.</p>
-        <?php else: ?>
-            <table class="widefat striped">
-                <thead><tr><th>Desktop</th><th>Mobil</th><th>Titel</th><th>Aktionen</th></tr></thead>
-                <tbody>
-                    <?php foreach ($blocks as $b): ?>
-                        <tr>
-                            <td><?php echo intval($b->position); ?></td>
-                            <td><?php echo intval($b->position_mobile); ?></td>
-                            <td><?php echo esc_html($b->title); ?></td>
-                            <td>
-                                <a href="<?php echo admin_url('admin.php?page=produkt-content-blocks&category=' . $selected_category . '&action=edit&edit=' . $b->id); ?>" class="button">Bearbeiten</a>
-                                <a href="<?php echo admin_url('admin.php?page=produkt-content-blocks&category=' . $selected_category . '&delete=' . $b->id . '&fw_nonce=' . wp_create_nonce('produkt_admin_action')); ?>" class="button button-danger" onclick="return confirm('Wirklich löschen?')">Löschen</a>
-                            </td>
-                        </tr>
-                    <?php endforeach; ?>
-                </tbody>
-            </table>
-        <?php endif; ?>
-    <?php endif; ?>
-    </div>
+    });
+    </script>
+<?php endif; ?>
 </div>

--- a/admin/extras-page.php
+++ b/admin/extras-page.php
@@ -281,84 +281,148 @@ if ($edit_item) {
 }
 ?>
 
-<div class="wrap">
-    <div class="produkt-admin-card">
-        <!-- Kompakter Header -->
-        <div class="produkt-admin-header-compact">
-        <div class="produkt-admin-logo-compact">🎁</div>
-        <div class="produkt-admin-title-compact">
-            <h1>Extras verwalten</h1>
-            <p>Zusatzoptionen mit Bildern</p>
+<div class="produkt-admin dashboard-wrapper">
+    <h1 class="dashboard-greeting">Hallo, <?php echo esc_html(wp_get_current_user()->display_name); ?> 👋</h1>
+    <p class="dashboard-subline">Extras verwalten</p>
+
+<?php if ($active_tab === 'list'): ?>
+    <div class="dashboard-grid">
+        <div class="dashboard-left">
+            <div class="dashboard-card card-product-selector">
+                <h2>Produkt auswählen</h2>
+                <p class="card-subline">Für welches Produkt möchten Sie ein Extra bearbeiten?</p>
+                <form method="get" action="" class="produkt-category-selector" style="background:none;border:none;padding:0;">
+                    <input type="hidden" name="page" value="produkt-extras">
+                    <input type="hidden" name="tab" value="<?php echo esc_attr($active_tab); ?>">
+                    <select name="category" id="category-select" onchange="this.form.submit()">
+                        <?php foreach ($categories as $category): ?>
+                            <option value="<?php echo $category->id; ?>" <?php selected($selected_category, $category->id); ?>><?php echo esc_html($category->name); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                    <noscript><input type="submit" value="Wechseln" class="button"></noscript>
+                </form>
+                <?php if ($current_category): ?>
+                <div class="selected-product-preview">
+                    <?php if (!empty($current_category->default_image)): ?>
+                        <img src="<?php echo esc_url($current_category->default_image); ?>" alt="<?php echo esc_attr($current_category->name); ?>">
+                    <?php else: ?>
+                        <div class="placeholder-icon">🏷️</div>
+                    <?php endif; ?>
+                    <div class="tile-overlay"><span><?php echo esc_html($current_category->name); ?></span></div>
+                </div>
+                <?php endif; ?>
+            </div>
+        </div>
+        <div class="dashboard-right">
+            <div class="dashboard-row">
+                <div class="dashboard-card card-new-product">
+                    <h2>Neues Extra</h2>
+                    <p class="card-subline">Extra erstellen</p>
+                    <a href="<?php echo admin_url('admin.php?page=produkt-extras&category=' . $selected_category . '&tab=add'); ?>" class="icon-btn add-product-btn" aria-label="Hinzufügen">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80.3">
+                            <path d="M12.1,12c-15.4,15.4-15.4,40.4,0,55.8,7.7,7.7,17.7,11.7,27.9,11.7s20.2-3.8,27.9-11.5c15.4-15.4,15.4-40.4,0-55.8-15.4-15.6-40.4-15.6-55.8-.2h0ZM62.1,62c-12.1,12.1-31.9,12.1-44.2,0-12.1-12.1-12.1-31.9,0-44.2,12.1-12.1,31.9-12.1,44.2,0,12.1,12.3,12.1,31.9,0,44.2Z"/>
+                            <path d="M54.6,35.7h-10.4v-10.4c0-2.3-1.9-4.2-4.2-4.2s-4.2,1.9-4.2,4.2v10.4h-10.4c-2.3,0-4.2,1.9-4.2,4.2s1.9,4.2,4.2,4.2h10.4v10.4c0,2.3,1.9,4.2,4.2,4.2s4.2-1.9,4.2-4.2v-10.4h10.4c2.3,0,4.2-1.9,4.2-4.2s-1.9-4.2-4.2-4.2Z"/>
+                        </svg>
+                    </a>
+                </div>
+                <div class="dashboard-card card-quicknav">
+                    <h2>Schnellnavigation</h2>
+                    <p class="card-subline">Direkt zu wichtigen Listen</p>
+                    <div class="quicknav-grid">
+                        <div class="quicknav-card">
+                            <a href="admin.php?page=produkt-verleih">
+                                <div class="quicknav-inner">
+                                    <div class="quicknav-icon-circle">🏠</div>
+                                    <div class="quicknav-label">Dashboard</div>
+                                </div>
+                            </a>
+                        </div>
+                        <div class="quicknav-card">
+                            <a href="admin.php?page=produkt-categories">
+                                <div class="quicknav-inner">
+                                    <div class="quicknav-icon-circle">🧩</div>
+                                    <div class="quicknav-label">Kategorien</div>
+                                </div>
+                            </a>
+                        </div>
+                        <div class="quicknav-card">
+                            <a href="admin.php?page=produkt-products">
+                                <div class="quicknav-inner">
+                                    <div class="quicknav-icon-circle">🏷️</div>
+                                    <div class="quicknav-label">Produkte</div>
+                                </div>
+                            </a>
+                        </div>
+                        <div class="quicknav-card">
+                            <a href="admin.php?page=produkt-variants&category=<?php echo $selected_category; ?>">
+                                <div class="quicknav-inner">
+                                    <div class="quicknav-icon-circle">🧩</div>
+                                    <div class="quicknav-label">Ausführungen</div>
+                                </div>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="dashboard-card">
+                <div class="card-header-flex">
+                    <div>
+                        <h2>Extras</h2>
+                        <p class="card-subline">Verfügbare Extras des Produkts</p>
+                    </div>
+                </div>
+                <table class="activity-table">
+                    <thead>
+                        <tr>
+                            <th>Bild</th>
+                            <th>Name</th>
+                            <th>Preis</th>
+                            <th>Aktionen</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php $modus = get_option('produkt_betriebsmodus', 'miete'); ?>
+                        <?php foreach ($extras as $extra): ?>
+                            <tr>
+                                <td>
+                                    <?php if (!empty($extra->image_url)): ?>
+                                        <img src="<?php echo esc_url($extra->image_url); ?>" style="width:60px;height:60px;object-fit:cover;border-radius:4px;" alt="<?php echo esc_attr($extra->name); ?>">
+                                    <?php else: ?>
+                                        <div style="width:60px;height:60px;background:#f0f0f0;border-radius:4px;display:flex;align-items:center;justify-content:center;">🎁</div>
+                                    <?php endif; ?>
+                                </td>
+                                <td><?php echo esc_html($extra->name); ?></td>
+                                <td>
+                                    <?php if ($modus === 'kauf'): ?>
+                                        <?php echo number_format($extra->price_sale ?? 0, 2, ',', '.'); ?>€
+                                    <?php else: ?>
+                                        <?php echo number_format($extra->price_rent ?? $extra->price, 2, ',', '.'); ?>€
+                                    <?php endif; ?>
+                                </td>
+                                <td>
+                                    <button type="button" class="icon-btn" aria-label="Bearbeiten" onclick="window.location.href='?page=produkt-extras&category=<?php echo $selected_category; ?>&tab=edit&edit=<?php echo $extra->id; ?>'">
+                                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80.8 80.1">
+                                            <path d="M54.7,4.8l-31.5,31.7c-.6.6-1,1.5-1.2,2.3l-3.3,18.3c-.2,1.2.2,2.7,1.2,3.8.8.8,1.9,1.2,2.9,1.2h.8l18.3-3.3c.8-.2,1.7-.6,2.3-1.2l31.7-31.7c5.8-5.8,5.8-15.2,0-21-6-5.8-15.4-5.8-21.2,0h0ZM69.9,19.8l-30.8,30.8-11,1.9,2.1-11.2,30.6-30.6c2.5-2.5,6.7-2.5,9.2,0,2.5,2.7,2.5,6.7,0,9.2Z"/>
+                                            <path d="M5.1,79.6h70.8c2.3,0,4.2-1.9,4.2-4.2v-35.4c0-2.3-1.9-4.2-4.2-4.2s-4.2,1.9-4.2,4.2v31.2H9.2V8.8h31.2c2.3,0,4.2-1.9,4.2-4.2s-1.9-4.2-4.2-4.2H5.1c-2.3,0-4.2,1.9-4.2,4.2v70.8c0,2.3,1.9,4.2,4.2,4.2h0Z"/>
+                                        </svg>
+                                    </button>
+                                    <button type="button" class="icon-btn" onclick="if(confirm('Wirklich löschen?')){window.location.href='?page=produkt-extras&category=<?php echo $selected_category; ?>&delete=<?php echo $extra->id; ?>&fw_nonce=<?php echo wp_create_nonce('produkt_admin_action'); ?>';}" aria-label="Löschen">
+                                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 79.9 80.1">
+                                            <path d="M39.8.4C18,.4.3,18.1.3,40s17.7,39.6,39.6,39.6,39.6-17.7,39.6-39.6S61.7.4,39.8.4ZM39.8,71.3c-17.1,0-31.2-14-31.2-31.2s14.2-31.2,31.2-31.2,31.2,14,31.2,31.2-14.2,31.2-31.2,31.2Z"/>
+                                            <path d="M53,26.9c-1.7-1.7-4.2-1.7-5.8,0l-7.3,7.3-7.3-7.3c-1.7-1.7-4.2-1.7-5.8,0-1.7,1.7-1.7,4.2,0,5.8l7.3,7.3-7.3,7.3c-1.7,1.7-1.7,4.2,0,5.8.8.8,1.9,1.2,2.9,1.2s2.1-.4,2.9-1.2l7.3-7.3,7.3,7.3c.8.8,1.9,1.2,2.9,1.2s2.1-.4,2.9-1.2c1.7-1.7,1.7-4.2,0-5.8l-7.3-7.3,7.3-7.3c1.7-1.7,1.7-4.4,0-5.8h0Z"/>
+                                        </svg>
+                                    </button>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
-    
-    <!-- Breadcrumb Navigation -->
-    <div class="produkt-breadcrumb">
-        <a href="<?php echo admin_url('admin.php?page=produkt-verleih'); ?>">Dashboard</a> 
-        <span>→</span> 
-        <strong>Extras</strong>
-    </div>
-    
-    <!-- Category Selection -->
-    <div class="produkt-category-selector">
-        <form method="get" action="">
-            <input type="hidden" name="page" value="produkt-extras">
-            <input type="hidden" name="tab" value="<?php echo esc_attr($active_tab); ?>">
-            <label for="category-select"><strong>🏷️ Produkt:</strong></label>
-            <select name="category" id="category-select" onchange="this.form.submit()">
-                <?php foreach ($categories as $category): ?>
-                <option value="<?php echo $category->id; ?>" <?php selected($selected_category, $category->id); ?>>
-                    <?php echo esc_html($category->name); ?>
-                </option>
-                <?php endforeach; ?>
-            </select>
-            <noscript><input type="submit" value="Wechseln" class="button"></noscript>
-        </form>
-        
-        <?php if ($current_category): ?>
-        <div class="produkt-category-info">
-            <code>[produkt_product category="<?php echo esc_html($current_category->shortcode); ?>"]</code>
-        </div>
-        <?php endif; ?>
-    </div>
-    
-    <!-- Tab Navigation -->
-    <div class="produkt-tab-nav">
-        <a href="<?php echo admin_url('admin.php?page=produkt-extras&category=' . $selected_category . '&tab=list'); ?>" 
-           class="produkt-tab <?php echo $active_tab === 'list' ? 'active' : ''; ?>">
-            📋 Übersicht
-        </a>
-        <a href="<?php echo admin_url('admin.php?page=produkt-extras&category=' . $selected_category . '&tab=add'); ?>" 
-           class="produkt-tab <?php echo $active_tab === 'add' ? 'active' : ''; ?>">
-            ➕ Neues Extra
-        </a>
-        <?php if ($edit_item): ?>
-        <a href="<?php echo admin_url('admin.php?page=produkt-extras&category=' . $selected_category . '&tab=edit&edit=' . $edit_item->id); ?>" 
-           class="produkt-tab <?php echo $active_tab === 'edit' ? 'active' : ''; ?>">
-            ✏️ Bearbeiten
-        </a>
-        <?php endif; ?>
-    </div>
-    
-    <!-- Tab Content -->
-    <div class="produkt-tab-content">
-        <?php
-        switch ($active_tab) {
-            case 'add':
-                include PRODUKT_PLUGIN_PATH . 'admin/tabs/extras-add-tab.php';
-                break;
-            case 'edit':
-                if ($edit_item) {
-                    include PRODUKT_PLUGIN_PATH . 'admin/tabs/extras-edit-tab.php';
-                } else {
-                    include PRODUKT_PLUGIN_PATH . 'admin/tabs/extras-list-tab.php';
-                }
-                break;
-            case 'list':
-            default:
-                include PRODUKT_PLUGIN_PATH . 'admin/tabs/extras-list-tab.php';
-        }
-        ?>
-    </div>
-    </div>
+<?php elseif ($active_tab === 'add'): ?>
+    <?php include PRODUKT_PLUGIN_PATH . 'admin/tabs/extras-add-tab.php'; ?>
+<?php elseif ($active_tab === 'edit' && $edit_item): ?>
+    <?php include PRODUKT_PLUGIN_PATH . 'admin/tabs/extras-edit-tab.php'; ?>
+<?php endif; ?>
 </div>

--- a/admin/orders-page.php
+++ b/admin/orders-page.php
@@ -87,7 +87,7 @@ $search_term = isset($_GET['s']) ? sanitize_text_field($_GET['s']) : '';
                 </div>
     
     <!-- Orders Table -->
-    <div class="orders-table-container">
+    <div>
         <?php if (empty($orders)): ?>
         <div class="orders-empty">
             <p class="orders-empty-message">Keine Bestellungen im gewählten Zeitraum gefunden.</p>
@@ -219,7 +219,7 @@ $search_term = isset($_GET['s']) ? sanitize_text_field($_GET['s']) : '';
     </div>
     
 
-    </div> <!-- end orders-table-container card -->
+    </div> <!-- end orders card -->
 </div>
 
 <!-- Order Details Modal -->

--- a/admin/orders-page.php
+++ b/admin/orders-page.php
@@ -24,106 +24,70 @@ foreach ($branding_results as $result) {
     $branding[$result->setting_key] = $result->setting_value;
 }
 $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
+
+// Search term (not yet used in query but kept for UI consistency)
+$search_term = isset($_GET['s']) ? sanitize_text_field($_GET['s']) : '';
 ?>
 
-<div class="wrap" id="produkt-admin-orders">
-    <div class="produkt-admin-card">
-        <div class="produkt-admin-header-compact">
-            <div class="produkt-admin-logo-compact">
-                <span class="dashicons dashicons-clipboard"></span>
-            </div>
-            <div class="produkt-admin-title-compact">
-                <h1>Bestellungen</h1>
-                <p>Übersicht aller Kundenbestellungen mit detaillierten Produktinformationen</p>
-            </div>
-        </div>
-    
-    
-    <!-- Filter Section -->
-    <div class="orders-filter-box">
-        <h3>🔍 Filter & Zeitraum</h3>
-        <form method="get" action="" class="orders-filter-form">
-            <input type="hidden" name="page" value="produkt-orders">
-            
-            <div>
-                <label for="category-select"><strong>Produkt:</strong></label>
-                <select name="category" id="category-select">
-                    <option value="0" <?php selected($selected_category, 0); ?>>Alle Produkte</option>
-                    <?php foreach ($categories as $category): ?>
-                    <option value="<?php echo $category->id; ?>" <?php selected($selected_category, $category->id); ?>>
-                        <?php echo esc_html($category->name); ?>
-                    </option>
-                    <?php endforeach; ?>
-                </select>
-            </div>
-            
-            <div>
-                <label for="date-from"><strong>Von:</strong></label>
-                <input type="date" name="date_from" id="date-from" value="<?php echo esc_attr($date_from); ?>">
-            </div>
-            
-            <div>
-                <label for="date-to"><strong>Bis:</strong></label>
-                <input type="date" name="date_to" id="date-to" value="<?php echo esc_attr($date_to); ?>">
-            </div>
-            
-            <input type="submit" value="Filter anwenden" class="button button-primary">
-        </form>
-        
-        <?php if ($current_category): ?>
-        <div class="current-category-box">
-            <strong>📝 Aktuelle Produkt:</strong> <?php echo esc_html($current_category->name); ?>
-            <code>[produkt_product category="<?php echo esc_html($current_category->shortcode); ?>"]</code>
-        </div>
-        <?php endif; ?>
-    </div>
-    
-    <!-- Summary Statistics -->
-    <div class="produkt-summary-grid">
-        <div class="produkt-summary-card">
-            <h3>📋 Gesamt-Bestellungen</h3>
-            <div class="produkt-summary-value summary-green">
-                <?php echo number_format($total_orders); ?>
-            </div>
-            <p class="produkt-summary-note">Im gewählten Zeitraum</p>
-        </div>
+<div class="produkt-admin dashboard-wrapper">
+    <h1 class="dashboard-greeting">Hallo, <?php echo esc_html(wp_get_current_user()->display_name); ?> 👋</h1>
+    <p class="dashboard-subline">Bestellungen verwalten</p>
 
-        <div class="produkt-summary-card">
-            <h3>💰 Gesamt-Umsatz</h3>
-            <div class="produkt-summary-value summary-gray">
-                <?php echo number_format($total_revenue, 2, ',', '.'); ?>€
+    <div class="h2-rental-card">
+        <h2>Statistik</h2>
+        <p class="card-subline">Kennzahlen zum gewählten Zeitraum</p>
+        <div class="product-info-grid cols-4">
+            <div class="product-info-box bg-pastell-orange">
+                <span class="label">Gesamt-Umsatz</span>
+                <strong class="value orders-stat-value">€ <?php echo number_format($total_revenue, 2, ',', '.'); ?></strong>
             </div>
-            <p class="produkt-summary-note">Monatlicher Mietumsatz</p>
-        </div>
-
-        <div class="produkt-summary-card">
-            <h3>📊 Durchschnittswert</h3>
-            <div class="produkt-summary-value summary-red">
-                <?php echo number_format($avg_order_value, 2, ',', '.'); ?>€
+            <div class="product-info-box bg-pastell-mint">
+                <span class="label">Durchschnitt</span>
+                <strong class="value orders-stat-value">€ <?php echo number_format($avg_order_value, 2, ',', '.'); ?></strong>
             </div>
-            <p class="produkt-summary-note">Pro Bestellung</p>
-        </div>
-
-        <div class="produkt-summary-card">
-            <h3>📅 Zeitraum</h3>
-            <div class="produkt-summary-range">
-                <?php echo date('d.m.Y', strtotime($date_from)); ?><br>
-                <small>bis</small><br>
-                <?php echo date('d.m.Y', strtotime($date_to)); ?>
+            <div class="product-info-box bg-pastell-gruen">
+                <span class="label">Zeitraum</span>
+                <strong class="value orders-stat-value"><?php echo date('d.m.', strtotime($date_from)); ?>–<?php echo date('d.m.', strtotime($date_to)); ?></strong>
+            </div>
+            <div class="product-info-box bg-pastell-gelb">
+                <span class="label">Bestellungen</span>
+                <strong class="value orders-stat-value"><?php echo intval($total_orders); ?></strong>
             </div>
         </div>
     </div>
+
+    <div class="h2-rental-card">
+                <div class="card-header-flex">
+                    <div>
+                        <h2>Bestellübersicht</h2>
+                        <p class="card-subline">Kundenaufträge ansehen</p>
+                    </div>
+                    <form method="get" class="produkt-filter-form product-search-bar">
+                        <input type="hidden" name="page" value="produkt-orders">
+                        <div class="search-input-wrapper">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="search-icon">
+                                <path d="M10 2a8 8 0 105.3 14.1l4.3 4.3a1 1 0 101.4-1.4l-4.3-4.3A8 8 0 0010 2zm0 2a6 6 0 110 12 6 6 0 010-12z"/>
+                            </svg>
+                            <input type="text" name="s" placeholder="Suchen" value="<?php echo esc_attr($search_term); ?>">
+                        </div>
+                        <select name="category">
+                            <option value="0" <?php selected($selected_category, 0); ?>>Alle Produkte</option>
+                            <?php foreach ($categories as $category): ?>
+                                <option value="<?php echo $category->id; ?>" <?php selected($selected_category, $category->id); ?>><?php echo esc_html($category->name); ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                        <input type="date" name="date_from" value="<?php echo esc_attr($date_from); ?>">
+                        <input type="date" name="date_to" value="<?php echo esc_attr($date_to); ?>">
+                        <button type="submit" class="icon-btn filter-submit-btn" aria-label="Filtern">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 22.1">
+                                <path d="M16,0C7.2,0,0,4.9,0,11s7.2,11,16,11,16-4.9,16-11S24.8,0,16,0ZM16,20c-7.7,0-14-4-14-9S8.3,2,16,2s14,4,14,9-6.3,9-14,9ZM16,5c-3.3,0-6,2.7-6,6s2.7,6,6,6,6-2.7,6-6-2.7-6-6-6ZM16,15c-2.2,0-4-1.8-4-4s1.8-4,4-4,4,1.8,4,4-1.8,4-4,4Z"/>
+                            </svg>
+                        </button>
+                    </form>
+                </div>
     
     <!-- Orders Table -->
     <div class="orders-table-container">
-        <h3>📋 Bestellübersicht</h3>
-        <?php if (!empty($orders)): ?>
-        <div class="orders-bulk-actions">
-            <button type="button" class="button" onclick="toggleSelectAll()">Alle auswählen</button>
-            <button type="button" class="button" onclick="deleteSelected()" class="text-red">Ausgewählte löschen</button>
-        </div>
-        <?php endif; ?>
-        
         <?php if (empty($orders)): ?>
         <div class="orders-empty">
             <p class="orders-empty-message">Keine Bestellungen im gewählten Zeitraum gefunden.</p>
@@ -131,8 +95,7 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
         </div>
         <?php else: ?>
         
-        <div class="table-responsive">
-            <table class="wp-list-table widefat fixed striped">
+        <table class="activity-table">
                 <thead>
                     <tr>
                         <th class="col-checkbox"><input type="checkbox" id="select-all-orders"></th>
@@ -143,7 +106,6 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
                         <th>Versandadresse</th>
                         <th>Rechnungsadresse</th>
                         <th class="col-type">Produkttyp</th>
-                        <th>Produktdetails</th>
                         <th class="col-price">Preis</th>
                         <th class="col-discount">Rabatt</th>
                         <th class="col-status">Status</th>
@@ -197,34 +159,6 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
                         ?>
                         <td><?php echo esc_html($type); ?></td>
                         <td>
-                            <div class="order-details-info">
-                                <strong><?php echo esc_html($order->category_name); ?></strong><br>
-                                <span class="text-gray">📦 <?php echo esc_html($order->variant_name); ?></span><br>
-                                <span class="text-gray">🎁 <?php echo esc_html($order->extra_names); ?></span><br>
-                                <?php if ($type === 'Verkauf'): ?>
-                                    <span class="text-gray">⏰ Miettage: <?php echo esc_html($order->rental_days ?? $order->duration_name); ?></span><br>
-                                <?php else: ?>
-                                    <span class="text-gray">⏰ Mietdauer: <?php echo esc_html($order->duration_name); ?></span><br>
-                                <?php endif; ?>
-                                <?php list($sd,$ed) = pv_get_order_period($order); ?>
-                                <?php if ($sd && $ed): ?>
-                                    <span class="text-gray">📅 <?php echo date('d.m.Y', strtotime($sd)); ?> - <?php echo date('d.m.Y', strtotime($ed)); ?></span><br>
-                                <?php endif; ?>
-                                
-                                <?php if ($order->condition_name): ?>
-                                    <span class="text-gray">🔄 <?php echo esc_html($order->condition_name); ?></span><br>
-                                <?php endif; ?>
-                                
-                                <?php if ($order->product_color_name): ?>
-                                    <span class="text-gray">🎨 Produkt: <?php echo esc_html($order->product_color_name); ?></span><br>
-                                <?php endif; ?>
-                                
-                                <?php if ($order->frame_color_name): ?>
-                                    <span class="text-gray">🖼️ Gestell: <?php echo esc_html($order->frame_color_name); ?></span><br>
-                                <?php endif; ?>
-                            </div>
-                        </td>
-                        <td>
                             <strong class="order-price">
                                 <?php echo number_format($order->final_price, 2, ',', '.'); ?>€
                             </strong><br>
@@ -252,87 +186,40 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
                             <?php endif; ?>
                         </td>
                         <td>
-                            <button type="button" class="button button-small" onclick="showOrderDetails(<?php echo $order->id; ?>)" title="Details anzeigen">
-                                👁️ Details
+                            <button type="button" class="icon-btn" aria-label="Bearbeiten" onclick="showOrderDetails(<?php echo $order->id; ?>)">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80.8 80.1">
+                                    <path d="M54.7,4.8l-31.5,31.7c-.6.6-1,1.5-1.2,2.3l-3.3,18.3c-.2,1.2.2,2.7,1.2,3.8.8.8,1.9,1.2,2.9,1.2h.8l18.3-3.3c.8-.2,1.7-.6,2.3-1.2l31.7-31.7c5.8-5.8,5.8-15.2,0-21-6-5.8-15.4-5.8-21.2,0h0ZM69.9,19.8l-30.8,30.8-11,1.9,2.1-11.2,30.6-30.6c2.5-2.5,6.7-2.5,9.2,0,2.5,2.7,2.5,6.7,0,9.2Z"/>
+                                    <path d="M5.1,79.6h70.8c2.3,0,4.2-1.9,4.2-4.2v-35.4c0-2.3-1.9-4.2-4.2-4.2s-4.2,1.9-4.2,4.2v31.2H9.2V8.8h31.2c2.3,0,4.2-1.9,4.2-4.2s-1.9-4.2-4.2-4.2H5.1c-2.3,0-4.2,1.9-4.2,4.2v70.8c0,2.3,1.9,4.2,4.2,4.2h0Z"/>
+                                </svg>
                             </button>
                             <?php
                                 $due = ($order->mode === 'kauf' && $order->end_date && $order->inventory_reverted == 0 && $order->end_date <= current_time('Y-m-d'));
                                 if ($due):
                             ?>
-                                <br><br>
-                                <button type="button" class="button button-small produkt-return-confirm" data-id="<?php echo $order->id; ?>">Alles i.O.</button>
+                                <button type="button" class="icon-btn produkt-return-confirm" data-id="<?php echo $order->id; ?>" aria-label="Bestätigung">
+                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80.3 80.3">
+                                        <path d="M32,53.4c.8.8,1.9,1.2,2.9,1.2s2.1-.4,2.9-1.2l20.8-20.8c1.7-1.7,1.7-4.2,0-5.8-1.7-1.7-4.2-1.7-5.8,0l-17.9,17.9-7.7-7.7c-1.7-1.7-4.2-1.7-5.8,0-1.7,1.7-1.7,4.2,0,5.8l10.6,10.6Z"/>
+                                        <path d="M40.2,79.6c21.9,0,39.6-17.7,39.6-39.6S62,.5,40.2.5.6,18.2.6,40.1s17.7,39.6,39.6,39.6ZM40.2,8.8c17.1,0,31.2,14,31.2,31.2s-14,31.2-31.2,31.2-31.2-14.2-31.2-31.2,14.2-31.2,31.2-31.2Z"/>
+                                    </svg>
+                                </button>
                             <?php endif; ?>
-                            <br><br>
-                            <a href="<?php echo admin_url('admin.php?page=produkt-orders&category=' . $selected_category . '&delete_order=' . $order->id . '&date_from=' . $date_from . '&date_to=' . $date_to); ?>"
-                               class="button button-small text-red"
-                               onclick="return confirm('Sind Sie sicher, dass Sie diese Bestellung löschen möchten?\n\nBestellung #<?php echo !empty($order->order_number) ? $order->order_number : $order->id; ?> wird unwiderruflich gelöscht!')">
-                                🗑️ Löschen
-                            </a>
+                            <button type="button" class="icon-btn" onclick="if(confirm('Wirklich löschen?')){window.location.href='?page=produkt-orders&category=<?php echo $selected_category; ?>&delete_order=<?php echo $order->id; ?>&date_from=<?php echo $date_from; ?>&date_to=<?php echo $date_to; ?>';}" aria-label="Löschen">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 79.9 80.1">
+                                    <path d="M39.8.4C18,.4.3,18.1.3,40s17.7,39.6,39.6,39.6,39.6-17.7,39.6-39.6S61.7.4,39.8.4ZM39.8,71.3c-17.1,0-31.2-14-31.2-31.2s14.2-31.2,31.2-31.2,31.2,14,31.2,31.2-14.2,31.2-31.2,31.2Z"/>
+                                    <path d="M53,26.9c-1.7-1.7-4.2-1.7-5.8,0l-7.3,7.3-7.3-7.3c-1.7-1.7-4.2-1.7-5.8,0-1.7,1.7-1.7,4.2,0,5.8l7.3,7.3-7.3,7.3c-1.7,1.7-1.7,4.2,0,5.8.8.8,1.9,1.2,2.9,1.2s2.1-.4,2.9-1.2l7.3-7.3,7.3,7.3c.8.8,1.9,1.2,2.9,1.2s2.1-.4,2.9-1.2c1.7-1.7,1.7-4.2,0-5.8l-7.3-7.3,7.3-7.3c1.7-1.7,1.7-4.4,0-5.8h0Z"/>
+                                </svg>
+                            </button>
                         </td>
                     </tr>
                     <?php endforeach; ?>
                 </tbody>
             </table>
-        </div>
         
         <?php endif; ?>
     </div>
     
-    <!-- Export Section -->
-    <div class="orders-export-box">
-        <h3>📤 Export & Aktionen</h3>
-        <div class="orders-export-actions">
-            <button type="button" class="button" onclick="exportOrders('csv')">
-                📊 Als CSV exportieren
-            </button>
-            <button type="button" class="button" onclick="exportOrders('excel')">
-                📈 Als Excel exportieren
-            </button>
-            <button type="button" class="button" onclick="printOrders()">
-                🖨️ Drucken
-            </button>
-        </div>
-        <p class="orders-export-note">
-            Exportiert werden alle Bestellungen im aktuell gewählten Filter-Zeitraum und der ausgewählten Produkt.
-        </p>
-    </div>
-    
-    <!-- Info Box -->
-    <div class="info-box">
-        <h3>📋 Bestellungen-System</h3>
-        <div class="info-box-grid">
-            <div>
-                <h4>🎯 Was wird erfasst:</h4>
-                <ul>
-                    <li><strong>Produktauswahl:</strong> Alle gewählten Optionen</li>
-                    <li><strong>Kundendaten:</strong> E-Mail, Name, Telefon und Adresse (falls angegeben)</li>
-                    <li><strong>Preisberechnung:</strong> Finaler Mietpreis pro Monat</li>
-                    <li><strong>Zeitstempel:</strong> Exakte Bestellzeit</li>
-                    <li><strong>Tracking-Daten:</strong> IP-Adresse und Browser</li>
-                </ul>
-            </div>
-            <div>
-                <h4>📊 Verwendung der Daten:</h4>
-                <ul>
-                    <li><strong>Bestellverfolgung:</strong> Nachvollziehung aller Anfragen</li>
-                    <li><strong>Kundenservice:</strong> Support bei Fragen</li>
-                    <li><strong>Analytics:</strong> Beliebte Produktkombinationen</li>
-                    <li><strong>Umsatzanalyse:</strong> Monatliche Einnahmen</li>
-                    <li><strong>Produktoptimierung:</strong> Welche Optionen werden gewählt</li>
-                    <li><strong>E-Mail-Marketing:</strong> Kundenkommunikation</li>
-                </ul>
-            </div>
-        </div>
-        
-        <div class="tip-box">
-            <strong>💡 Tipp:</strong> Nutzen Sie die Filterfunktionen um spezifische Zeiträume oder Produkte zu analysieren. Die Export-Funktion hilft bei der weiteren Datenverarbeitung in Excel oder anderen Tools.
-        </div>
-        
-        <div class="privacy-box">
-            <strong>🔒 Datenschutz:</strong> Alle Kundendaten werden sicher gespeichert und nur für die Bestellabwicklung verwendet. IP-Adressen dienen der Fraud-Prevention und werden nach 30 Tagen anonymisiert.
-        </div>
-    </div>
-    </div>
+
+    </div> <!-- end orders-table-container card -->
 </div>
 
 <!-- Order Details Modal -->
@@ -440,43 +327,6 @@ function printOrders() {
     window.print();
 }
 
-function toggleSelectAll() {
-    const selectAllCheckbox = document.getElementById('select-all-orders');
-    const orderCheckboxes = document.querySelectorAll('.order-checkbox');
-
-    const allChecked = Array.from(orderCheckboxes).every(cb => cb.checked);
-
-    orderCheckboxes.forEach(cb => cb.checked = !allChecked);
-    selectAllCheckbox.checked = !allChecked;
-}
-
-function deleteSelected() {
-    const selectedOrders = Array.from(document.querySelectorAll('.order-checkbox:checked')).map(cb => cb.value);
-
-    if (selectedOrders.length === 0) {
-        alert('Bitte wählen Sie mindestens eine Bestellung aus.');
-        return;
-    }
-
-    if (!confirm(`Sind Sie sicher, dass Sie ${selectedOrders.length} Bestellung(en) löschen möchten?\n\nDieser Vorgang kann nicht rückgängig gemacht werden!`)) {
-        return;
-    }
-
-    const form = document.createElement('form');
-    form.method = 'POST';
-    form.action = window.location.href;
-
-    selectedOrders.forEach(id => {
-        const input = document.createElement('input');
-        input.type = 'hidden';
-        input.name = 'delete_orders[]';
-        input.value = id;
-        form.appendChild(input);
-    });
-
-    document.body.appendChild(form);
-    form.submit();
-}
 
 const selectAllOrders = document.getElementById('select-all-orders');
 if (selectAllOrders) {

--- a/admin/product-categories-page.php
+++ b/admin/product-categories-page.php
@@ -54,6 +54,12 @@ $counts = [];
 foreach ($raw_cats as $r) { $counts[$r->id] = $r->product_count; }
 foreach ($categories as $c) { $c->product_count = $counts[$c->id] ?? 0; }
 
+// Statistiken für Info-Boxen
+$category_count = $wpdb->get_var("SELECT COUNT(*) FROM {$wpdb->prefix}produkt_product_categories WHERE parent_id IS NULL OR parent_id = 0");
+$subcategory_count = $wpdb->get_var("SELECT COUNT(*) FROM {$wpdb->prefix}produkt_product_categories WHERE parent_id IS NOT NULL AND parent_id != 0");
+$total_category_count = $wpdb->get_var("SELECT COUNT(*) FROM {$wpdb->prefix}produkt_product_categories");
+$products_with_category = $wpdb->get_var("SELECT COUNT(DISTINCT produkt_id) FROM {$wpdb->prefix}produkt_product_to_category");
+
 // Wenn Bearbeiten
 $edit_category = null;
 if (isset($_GET['edit'])) {
@@ -114,13 +120,32 @@ if (isset($_GET['edit'])) {
     <h1 class="dashboard-greeting">Hallo, <?php echo esc_html(wp_get_current_user()->display_name); ?> 👋</h1>
     <p class="dashboard-subline">Kategorien verwalten</p>
 
-    <div class="h2-rental-card card-category-list">
-        <div style="display:flex;justify-content:space-between;align-items:center;">
+    <div class="product-info-grid cols-4">
+        <div class="product-info-box bg-pastell-gelb">
+            <span class="label">Kategorien</span>
+            <strong class="value"><?php echo intval($category_count); ?></strong>
+        </div>
+        <div class="product-info-box bg-pastell-gruen">
+            <span class="label">Subkategorien</span>
+            <strong class="value"><?php echo intval($subcategory_count); ?></strong>
+        </div>
+        <div class="product-info-box bg-pastell-mint">
+            <span class="label">Gesamt</span>
+            <strong class="value"><?php echo intval($total_category_count); ?></strong>
+        </div>
+        <div class="product-info-box bg-pastell-orange">
+            <span class="label">Produkte zugeordnet</span>
+            <strong class="value"><?php echo intval($products_with_category); ?></strong>
+        </div>
+    </div>
+
+    <div class="dashboard-card card-category-list">
+        <div class="card-header-flex">
             <div>
                 <h2>Bestehende Kategorien</h2>
                 <p class="card-subline">Verwalten Sie Ihre Kategorien</p>
             </div>
-            <button id="add-category-btn" type="button" class="icon-btn" style="margin-right:20px;" aria-label="Hinzufügen">
+            <button id="add-category-btn" type="button" class="icon-btn add-category-btn" aria-label="Hinzufügen">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80.3">
                     <path d="M12.1,12c-15.4,15.4-15.4,40.4,0,55.8,7.7,7.7,17.7,11.7,27.9,11.7s20.2-3.8,27.9-11.5c15.4-15.4,15.4-40.4,0-55.8-15.4-15.6-40.4-15.6-55.8-.2h0ZM62.1,62c-12.1,12.1-31.9,12.1-44.2,0-12.1-12.1-12.1-31.9,0-44.2,12.1-12.1,31.9-12.1,44.2,0,12.1,12.3,12.1,31.9,0,44.2Z"/>
                     <path d="M54.6,35.7h-10.4v-10.4c0-2.3-1.9-4.2-4.2-4.2s-4.2,1.9-4.2,4.2v10.4h-10.4c-2.3,0-4.2,1.9-4.2,4.2s1.9,4.2,4.2,4.2h10.4v10.4c0,2.3,1.9,4.2,4.2,4.2s4.2-1.9,4.2-4.2v-10.4h10.4c2.3,0,4.2-1.9,4.2-4.2s-1.9-4.2-4.2-4.2Z"/>

--- a/admin/variants-page.php
+++ b/admin/variants-page.php
@@ -305,84 +305,165 @@ foreach ($branding_results as $result) {
 }
 ?>
 
-<div class="wrap">
-    <div class="produkt-admin-card">
-        <!-- Kompakter Header -->
-        <div class="produkt-admin-header-compact">
-        <div class="produkt-admin-logo-compact">🖼️</div>
-        <div class="produkt-admin-title-compact">
-            <h1>Ausführungen verwalten</h1>
-            <p>Produktvarianten mit Bildergalerie</p>
+<div class="produkt-admin dashboard-wrapper">
+    <h1 class="dashboard-greeting">Hallo, <?php echo esc_html(wp_get_current_user()->display_name); ?> 👋</h1>
+    <p class="dashboard-subline">Ausführungen verwalten</p>
+
+<?php if ($active_tab === 'list'): ?>
+    <div class="dashboard-grid">
+        <div class="dashboard-left">
+            <div class="dashboard-card card-product-selector">
+                <h2>Produkt auswählen</h2>
+                <p class="card-subline">Für welches Produkt möchten Sie eine Ausführung bearbeiten?</p>
+                <form method="get" action="" class="produkt-category-selector" style="background:none;border:none;padding:0;">
+                    <input type="hidden" name="page" value="produkt-variants">
+                    <input type="hidden" name="tab" value="<?php echo esc_attr($active_tab); ?>">
+                    <select name="category" id="category-select" onchange="this.form.submit()">
+                        <?php foreach ($categories as $category): ?>
+                            <option value="<?php echo $category->id; ?>" <?php selected($selected_category, $category->id); ?>><?php echo esc_html($category->name); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                    <noscript><input type="submit" value="Wechseln" class="button"></noscript>
+                </form>
+                <?php if ($current_category): ?>
+                <div class="selected-product-preview">
+                    <?php if (!empty($current_category->default_image)): ?>
+                        <img src="<?php echo esc_url($current_category->default_image); ?>" alt="<?php echo esc_attr($current_category->name); ?>">
+                    <?php else: ?>
+                        <div class="placeholder-icon">🏷️</div>
+                    <?php endif; ?>
+                    <div class="tile-overlay"><span><?php echo esc_html($current_category->name); ?></span></div>
+                </div>
+                <?php endif; ?>
+            </div>
+        </div>
+        <div class="dashboard-right">
+            <div class="dashboard-row">
+                <div class="dashboard-card card-new-product">
+                    <h2>Neue Ausführung</h2>
+                    <p class="card-subline">Ausführung erstellen</p>
+                    <a href="<?php echo admin_url('admin.php?page=produkt-variants&category=' . $selected_category . '&tab=add'); ?>" class="icon-btn add-product-btn" aria-label="Hinzufügen">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80.3">
+                            <path d="M12.1,12c-15.4,15.4-15.4,40.4,0,55.8,7.7,7.7,17.7,11.7,27.9,11.7s20.2-3.8,27.9-11.5c15.4-15.4,15.4-40.4,0-55.8-15.4-15.6-40.4-15.6-55.8-.2h0ZM62.1,62c-12.1,12.1-31.9,12.1-44.2,0-12.1-12.1-12.1-31.9,0-44.2,12.1-12.1,31.9-12.1,44.2,0,12.1,12.3,12.1,31.9,0,44.2Z"/>
+                            <path d="M54.6,35.7h-10.4v-10.4c0-2.3-1.9-4.2-4.2-4.2s-4.2,1.9-4.2,4.2v10.4h-10.4c-2.3,0-4.2,1.9-4.2,4.2s1.9,4.2,4.2,4.2h10.4v10.4c0,2.3,1.9,4.2,4.2,4.2s4.2-1.9,4.2-4.2v-10.4h10.4c2.3,0,4.2-1.9,4.2-4.2s-1.9-4.2-4.2-4.2Z"/>
+                        </svg>
+                    </a>
+                </div>
+                <div class="dashboard-card card-quicknav">
+                    <h2>Schnellnavigation</h2>
+                    <p class="card-subline">Direkt zu wichtigen Listen</p>
+                    <div class="quicknav-grid">
+                        <div class="quicknav-card">
+                            <a href="admin.php?page=produkt-verleih">
+                                <div class="quicknav-inner">
+                                    <div class="quicknav-icon-circle">🏠</div>
+                                    <div class="quicknav-label">Dashboard</div>
+                                </div>
+                            </a>
+                        </div>
+                        <div class="quicknav-card">
+                            <a href="admin.php?page=produkt-categories">
+                                <div class="quicknav-inner">
+                                    <div class="quicknav-icon-circle">🧩</div>
+                                    <div class="quicknav-label">Kategorien</div>
+                                </div>
+                            </a>
+                        </div>
+                        <div class="quicknav-card">
+                            <a href="admin.php?page=produkt-products">
+                                <div class="quicknav-inner">
+                                    <div class="quicknav-icon-circle">🏷️</div>
+                                    <div class="quicknav-label">Produkte</div>
+                                </div>
+                            </a>
+                        </div>
+                        <div class="quicknav-card">
+                            <a href="admin.php?page=produkt-extras">
+                                <div class="quicknav-inner">
+                                    <div class="quicknav-icon-circle">✨</div>
+                                    <div class="quicknav-label">Extras</div>
+                                </div>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="dashboard-card">
+                <div class="card-header-flex">
+                    <div>
+                        <h2>Ausführungen</h2>
+                        <p class="card-subline">Vorhandene Varianten des Produkts</p>
+                    </div>
+                </div>
+                <table class="activity-table">
+                    <thead>
+                        <tr>
+                            <th>Bild</th>
+                            <th>Name</th>
+                            <th>Verfügbar</th>
+                            <th>Preis</th>
+                            <th>Bilder</th>
+                            <th>Aktionen</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php $modus = get_option('produkt_betriebsmodus', 'miete'); ?>
+                        <?php foreach ($variants as $variant): ?>
+                            <?php
+                                $image_count = 0;
+                                $main_image = '';
+                                for ($i = 1; $i <= 5; $i++) {
+                                    $field = 'image_url_' . $i;
+                                    if (!empty($variant->$field)) {
+                                        $image_count++;
+                                        if (!$main_image) {
+                                            $main_image = $variant->$field;
+                                        }
+                                    }
+                                }
+                            ?>
+                            <tr>
+                                <td>
+                                    <?php if ($main_image): ?>
+                                        <img src="<?php echo esc_url($main_image); ?>" style="width:60px;height:60px;object-fit:cover;border-radius:4px;" alt="<?php echo esc_attr($variant->name); ?>">
+                                    <?php else: ?>
+                                        <div style="width:60px;height:60px;background:#f0f0f0;border-radius:4px;display:flex;align-items:center;justify-content:center;">📦</div>
+                                    <?php endif; ?>
+                                </td>
+                                <td><?php echo esc_html($variant->name); ?></td>
+                                <td><?php echo ($variant->available ?? 1) ? '✅' : '❌'; ?></td>
+                                <td>
+                                    <?php if ($modus === 'kauf'): ?>
+                                        <?php echo number_format($variant->verkaufspreis_einmalig, 2, ',', '.'); ?>€
+                                    <?php else: ?>
+                                        <?php echo number_format($variant->mietpreis_monatlich, 2, ',', '.'); ?>€
+                                    <?php endif; ?>
+                                </td>
+                                <td><?php echo $image_count; ?></td>
+                                <td>
+                                    <button type="button" class="icon-btn" aria-label="Bearbeiten" onclick="window.location.href='?page=produkt-variants&category=<?php echo $selected_category; ?>&tab=edit&edit=<?php echo $variant->id; ?>'">
+                                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80.8 80.1">
+                                            <path d="M54.7,4.8l-31.5,31.7c-.6.6-1,1.5-1.2,2.3l-3.3,18.3c-.2,1.2.2,2.7,1.2,3.8.8.8,1.9,1.2,2.9,1.2h.8l18.3-3.3c.8-.2,1.7-.6,2.3-1.2l31.7-31.7c5.8-5.8,5.8-15.2,0-21-6-5.8-15.4-5.8-21.2,0h0ZM69.9,19.8l-30.8,30.8-11,1.9,2.1-11.2,30.6-30.6c2.5-2.5,6.7-2.5,9.2,0,2.5,2.7,2.5,6.7,0,9.2Z"/>
+                                            <path d="M5.1,79.6h70.8c2.3,0,4.2-1.9,4.2-4.2v-35.4c0-2.3-1.9-4.2-4.2-4.2s-4.2,1.9-4.2,4.2v31.2H9.2V8.8h31.2c2.3,0,4.2-1.9,4.2-4.2s-1.9-4.2-4.2-4.2H5.1c-2.3,0-4.2,1.9-4.2,4.2v70.8c0,2.3,1.9,4.2,4.2,4.2h0Z"/>
+                                        </svg>
+                                    </button>
+                                    <button type="button" class="icon-btn" onclick="if(confirm('Wirklich löschen?')){window.location.href='?page=produkt-variants&category=<?php echo $selected_category; ?>&delete=<?php echo $variant->id; ?>&fw_nonce=<?php echo wp_create_nonce('produkt_admin_action'); ?>';}" aria-label="Löschen">
+                                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 79.9 80.1">
+                                            <path d="M39.8.4C18,.4.3,18.1.3,40s17.7,39.6,39.6,39.6,39.6-17.7,39.6-39.6S61.7.4,39.8.4ZM39.8,71.3c-17.1,0-31.2-14-31.2-31.2s14.2-31.2,31.2-31.2,31.2,14,31.2,31.2-14.2,31.2-31.2,31.2Z"/>
+                                            <path d="M53,26.9c-1.7-1.7-4.2-1.7-5.8,0l-7.3,7.3-7.3-7.3c-1.7-1.7-4.2-1.7-5.8,0-1.7,1.7-1.7,4.2,0,5.8l7.3,7.3-7.3,7.3c-1.7,1.7-1.7,4.2,0,5.8.8.8,1.9,1.2,2.9,1.2s2.1-.4,2.9-1.2l7.3-7.3,7.3,7.3c.8.8,1.9,1.2,2.9,1.2s2.1-.4,2.9-1.2c1.7-1.7,1.7-4.2,0-5.8l-7.3-7.3,7.3-7.3c1.7-1.7,1.7-4.4,0-5.8h0Z"/>
+                                        </svg>
+                                    </button>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
-    
-    <!-- Breadcrumb Navigation -->
-    <div class="produkt-breadcrumb">
-        <a href="<?php echo admin_url('admin.php?page=produkt-verleih'); ?>">Dashboard</a> 
-        <span>→</span> 
-        <strong>Ausführungen</strong>
-    </div>
-    
-    <!-- Category Selection -->
-    <div class="produkt-category-selector">
-        <form method="get" action="">
-            <input type="hidden" name="page" value="produkt-variants">
-            <input type="hidden" name="tab" value="<?php echo esc_attr($active_tab); ?>">
-            <label for="category-select"><strong>🏷️ Produkt:</strong></label>
-            <select name="category" id="category-select" onchange="this.form.submit()">
-                <?php foreach ($categories as $category): ?>
-                <option value="<?php echo $category->id; ?>" <?php selected($selected_category, $category->id); ?>>
-                    <?php echo esc_html($category->name); ?>
-                </option>
-                <?php endforeach; ?>
-            </select>
-            <noscript><input type="submit" value="Wechseln" class="button"></noscript>
-        </form>
-        
-        <?php if ($current_category): ?>
-        <div class="produkt-category-info">
-            <code>[produkt_product category="<?php echo esc_html($current_category->shortcode); ?>"]</code>
-        </div>
-        <?php endif; ?>
-    </div>
-    
-    <!-- Tab Navigation -->
-    <div class="produkt-tab-nav">
-        <a href="<?php echo admin_url('admin.php?page=produkt-variants&category=' . $selected_category . '&tab=list'); ?>" 
-           class="produkt-tab <?php echo $active_tab === 'list' ? 'active' : ''; ?>">
-            📋 Übersicht
-        </a>
-        <a href="<?php echo admin_url('admin.php?page=produkt-variants&category=' . $selected_category . '&tab=add'); ?>" 
-           class="produkt-tab <?php echo $active_tab === 'add' ? 'active' : ''; ?>">
-            ➕ Neue Ausführung
-        </a>
-        <?php if ($edit_item): ?>
-        <a href="<?php echo admin_url('admin.php?page=produkt-variants&category=' . $selected_category . '&tab=edit&edit=' . $edit_item->id); ?>" 
-           class="produkt-tab <?php echo $active_tab === 'edit' ? 'active' : ''; ?>">
-            ✏️ Bearbeiten
-        </a>
-        <?php endif; ?>
-    </div>
-    
-    <!-- Tab Content -->
-    <div class="produkt-tab-content">
-        <?php
-        switch ($active_tab) {
-            case 'add':
-                include PRODUKT_PLUGIN_PATH . 'admin/tabs/variants-add-tab.php';
-                break;
-            case 'edit':
-                if ($edit_item) {
-                    include PRODUKT_PLUGIN_PATH . 'admin/tabs/variants-edit-tab.php';
-                } else {
-                    include PRODUKT_PLUGIN_PATH . 'admin/tabs/variants-list-tab.php';
-                }
-                break;
-            case 'list':
-            default:
-                include PRODUKT_PLUGIN_PATH . 'admin/tabs/variants-list-tab.php';
-        }
-        ?>
-    </div>
-    </div>
+<?php elseif ($active_tab === 'add'): ?>
+    <?php include PRODUKT_PLUGIN_PATH . 'admin/tabs/variants-add-tab.php'; ?>
+<?php elseif ($active_tab === 'edit' && $edit_item): ?>
+    <?php include PRODUKT_PLUGIN_PATH . 'admin/tabs/variants-edit-tab.php'; ?>
+<?php endif; ?>
 </div>

--- a/assets/admin-style.css
+++ b/assets/admin-style.css
@@ -2663,13 +2663,6 @@ body.category-modal-open {
     background: #fff;
     border-radius: 4px;
 }
-.orders-table-container {
-    background: #fff;
-    border: 1px solid #ddd;
-    border-radius: 8px;
-    padding: 20px;
-    margin-bottom: 30px;
-}
 .orders-bulk-actions { margin:10px 0; }
 .orders-empty { text-align:center; padding:40px; }
 .orders-empty-message { font-size:18px; color:#666; }
@@ -2679,7 +2672,7 @@ body.category-modal-open {
 .text-blue { color:#0073aa; font-weight:bold; }
 .order-details-info { line-height:1.4; }
 .order-price { color:#666666; font-size:16px; }
-.orders-stat-value { font-size:2rem; }
+.orders-stat-value { font-size:2rem !important; }
 .modal-heading { margin-top:0; }
 .order-modal-footer { text-align:right; margin-top:20px; }
 .details-grid { display:grid; grid-template-columns:1fr 1fr; gap:20px; }

--- a/assets/admin-style.css
+++ b/assets/admin-style.css
@@ -2466,6 +2466,7 @@ body.category-modal-open {
     border: 1px solid #e9ecef;
     border-radius: 8px;
     padding: 15px;
+    position: relative;
 }
 
 .produkt-category-card h4 {
@@ -2678,36 +2679,7 @@ body.category-modal-open {
 .text-blue { color:#0073aa; font-weight:bold; }
 .order-details-info { line-height:1.4; }
 .order-price { color:#666666; font-size:16px; }
-.orders-export-box {
-    background: #f8f9fa;
-    border: 1px solid #e9ecef;
-    border-radius: 8px;
-    padding: 20px;
-    margin-bottom: 30px;
-}
-.orders-export-actions { display:flex; gap:15px; flex-wrap:wrap; }
-.orders-export-note { margin-top:10px; color:#666; font-size:13px; }
-.info-box {
-    background: #d1ecf1;
-    border: 1px solid #bee5eb;
-    padding: 20px;
-    border-radius: 8px;
-}
-.info-box-grid { display:grid; grid-template-columns:1fr 1fr; gap:20px; }
-.tip-box {
-    margin-top: 15px;
-    padding: 15px;
-    background: #d4edda;
-    border: 1px solid #c3e6cb;
-    border-radius: 4px;
-}
-.privacy-box {
-    margin-top: 10px;
-    padding: 15px;
-    background: #fff3cd;
-    border: 1px solid #ffeaa7;
-    border-radius: 4px;
-}
+.orders-stat-value { font-size:2rem; }
 .modal-heading { margin-top:0; }
 .order-modal-footer { text-align:right; margin-top:20px; }
 .details-grid { display:grid; grid-template-columns:1fr 1fr; gap:20px; }
@@ -2777,7 +2749,7 @@ body.category-modal-open {
     display: flex;
     gap: 2rem;
     align-items: flex-start;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
 }
 
 .dashboard-card h2 {
@@ -2802,6 +2774,9 @@ body.category-modal-open {
     display: flex;
     gap: 2rem;
 }
+.dashboard-row > .dashboard-card {
+    flex: 1;
+}
 
 .card-products, .card-quicknav {
     flex: 1;
@@ -2818,6 +2793,7 @@ body.category-modal-open {
     border-radius: 20px;
     padding: 1.5rem;
     margin-right: 20px;
+    margin-bottom: 2rem;
 }
 .h2-rental-card h2 {
     margin: 0 0 0.5rem 0;
@@ -2854,6 +2830,13 @@ body.category-modal-open {
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 1rem;
+}
+.product-info-grid.cols-4 {
+    grid-template-columns: repeat(4, 1fr);
+    margin-bottom: 2rem;
+}
+.product-info-grid.cols-4 .product-info-box:last-child {
+    margin-right: 20px;
 }
 
 .product-info-box {
@@ -2932,6 +2915,125 @@ body.category-modal-open {
     margin-top: 20px;
 }
 
+.card-new-product {
+    background: linear-gradient(210deg, #315143, #062216);
+    color: #ffffff !important;
+    border-radius: 20px;
+    padding: 1.5rem;
+    position: relative;
+}
+.card-new-product h2,
+.card-new-product p {
+    color: #ffffff;
+}
+.add-product-btn {
+    position: absolute;
+    bottom: 15px;
+    right: 15px;
+}
+.add-product-btn svg {
+    width: 48px !important;
+    height: 48px !important;
+    fill: #ffffff !important;
+    stroke: none !important;
+}
+.add-category-btn {
+    margin-right: 20px;
+}
+
+.card-product-selector {
+    background: #fff;
+    border-radius: 20px;
+    padding: 1.5rem;
+}
+.selected-product-preview {
+    margin-top: 1rem;
+    position: relative;
+    overflow: hidden;
+    border-radius: 8px;
+}
+.selected-product-preview img,
+.selected-product-preview .placeholder-icon {
+    width: 100%;
+    height: 300px;
+    display: block;
+    object-fit: cover;
+}
+.selected-product-preview .placeholder-icon {
+    background: #f0f0f0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 2rem;
+    color: #777;
+}
+.selected-product-preview .tile-overlay {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.6);
+    color: #fff;
+    padding: 0.3rem 0.5rem;
+    font-size: 14px;
+}
+.selected-product-preview .tile-overlay span {
+    color: #ffffff !important;
+}
+
+.prod-card-title {
+    margin-top: 20px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 18px;
+}
+.card-header-flex {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+.card-header-actions {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+/* Search/filter bar within product list */
+.product-search-bar {
+    background: #fdfaf1;
+    border-radius: 999px;
+    padding: 0.3rem 2.5rem;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    height: 50px;
+}
+.search-input-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+.product-search-bar .search-icon {
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
+    display: block;
+    fill: #15287a;
+}
+.product-search-bar input[type="text"] {
+    border: none;
+    background: transparent;
+    flex: 1;
+    padding: 0 0.5rem;
+}
+.product-search-bar select {
+    border: none;
+    background: transparent;
+    min-width: 150px;
+    padding: 0;
+}
+
 .card-company a {
     color: #ffffff;
     text-decoration: underline;
@@ -2951,6 +3053,80 @@ body.category-modal-open {
 }
 .card-company strong {
     color: #ffffff;
+}
+
+/* Mini tiles for recent products */
+.recent-product-tiles {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    gap: 15px;
+}
+
+.recent-product-tile {
+    position: relative;
+    height: 160px;
+    border-radius: 12px;
+    overflow: hidden;
+    background-size: cover;
+    background-position: center;
+    transition: transform 0.3s ease;
+    cursor: pointer;
+}
+
+.recent-product-tile:hover {
+    transform: scale(1.05);
+}
+
+.recent-product-tile .tile-overlay {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 25%;
+    background: rgba(0, 0, 0, 0.6);
+    color: #ffffff;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 0.5rem;
+    font-size: 14px;
+    transition: background 0.3s ease;
+}
+
+.recent-product-tile .tile-overlay span {
+    color: #ffffff !important;
+}
+
+.recent-product-tile:hover .tile-overlay {
+    background: rgba(0, 0, 0, 0.4);
+}
+
+.recent-product-tile .edit-btn {
+    display: none;
+}
+
+.recent-product-tile:hover .edit-btn {
+    display: block;
+}
+
+.recent-product-tile.no-image {
+    background: #f0f0f0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #777;
+    font-size: 2rem;
+}
+
+.recent-product-tile .placeholder-icon {
+    pointer-events: none;
+}
+
+.recent-product-tile .edit-btn svg {
+    fill: #ffffff;
+    stroke: none;
+    width: 15px;
+    height: 15px;
 }
 	
 .quicknav-grid {
@@ -3169,6 +3345,18 @@ body.category-modal-open {
     grid-template-columns: 1fr;
   }
 }
+@media (max-width: 1500px) {
+  .dashboard-grid {
+    flex-wrap: wrap;
+  }
+  .dashboard-left,
+  .dashboard-right {
+    flex-basis: 100%;
+  }
+  .dashboard-right {
+    padding-right: 0;
+  }
+}
 /* === Erweiterung: Sidebar Order Details Struktur === */
 
 /* Header mit Auftragsnummer */
@@ -3359,4 +3547,10 @@ body.category-modal-open {
 }
 .icon-btn + .icon-btn {
     margin-left: 8px;
+}
+.filter-submit-btn svg {
+    width: 24px;
+    height: 24px;
+    stroke: none;
+    stroke-width: 0;
 }


### PR DESCRIPTION
## Summary
- trim exports and help info from orders page
- show smaller stats for orders dashboard

## Testing
- `php -l admin/orders-page.php`
- `php -l admin/categories-page.php`
- `php -l admin/main-page.php`
- `php -l admin/product-categories-page.php`
- `php -l admin/variants-page.php`
- `php -l admin/extras-page.php`
- `php -l admin/content-blocks-page.php`

------
https://chatgpt.com/codex/tasks/task_b_688bd54aa0bc8330ac8b14da1de529e6