### PR TITLE
Implement customer dashboard with statistics and card grid

### DIFF
--- a/admin/categories-page.php
+++ b/admin/categories-page.php
@@ -3,64 +3,182 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+use ProduktVerleih\Database;
+
 global $wpdb;
+
+// Latest 4 products
+$recent_products = $wpdb->get_results(
+    "SELECT id, name, default_image FROM {$wpdb->prefix}produkt_categories ORDER BY id DESC LIMIT 4"
+);
+
+// Variables provided by Admin::categories_page()
+$categories        = $categories ?? [];
+$product_categories = $product_categories ?? [];
+$selected_prodcat  = $selected_prodcat ?? 0;
+$search_term       = $search_term ?? '';
+$active_tab        = $active_tab ?? 'list';
+$edit_item         = $edit_item ?? null;
 ?>
 
-<div class="wrap" id="produkt-admin-categories">
-    <div class="produkt-admin-card">
-        <!-- Kompakter Header -->
-        <div class="produkt-admin-header-compact">
-            <div class="produkt-admin-logo-compact">🏷️</div>
-            <div class="produkt-admin-title-compact">
-                <h1>Produkte verwalten</h1>
-                <p>Produkte & SEO-Einstellungen</p>
+<div class="produkt-admin dashboard-wrapper">
+    <h1 class="dashboard-greeting"><?php echo pv_get_time_greeting(); ?>, <?php echo esc_html(wp_get_current_user()->display_name); ?> 👋</h1>
+    <p class="dashboard-subline">Produkte verwalten</p>
+
+<?php if ($active_tab === 'list'): ?>
+    <div class="dashboard-grid">
+        <div class="dashboard-left">
+            <div class="dashboard-card">
+                <h2>Neueste Produkte</h2>
+                <p class="card-subline">Die zuletzt hinzugefügten Produkte</p>
+                <div class="recent-product-tiles">
+                    <?php foreach ($recent_products as $prod): ?>
+                        <?php $has_image = !empty($prod->default_image); ?>
+                        <div class="recent-product-tile<?php echo $has_image ? '' : ' no-image'; ?>"<?php echo $has_image ? ' style="background-image:url(' . esc_url($prod->default_image) . ')"' : ''; ?> onclick="window.location.href='?page=produkt-categories&tab=edit&edit=<?php echo $prod->id; ?>'">
+                            <?php if (!$has_image): ?>
+                                <div class="placeholder-icon">🏷️</div>
+                            <?php endif; ?>
+                            <div class="tile-overlay">
+                                <span><?php echo esc_html($prod->name); ?></span>
+                                <button type="button" class="icon-btn edit-btn" aria-label="Bearbeiten" onclick="event.stopPropagation();window.location.href='?page=produkt-categories&tab=edit&edit=<?php echo $prod->id; ?>'">
+                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80.8 80.1">
+                                        <path d="M54.7,4.8l-31.5,31.7c-.6.6-1,1.5-1.2,2.3l-3.3,18.3c-.2,1.2.2,2.7,1.2,3.8.8.8,1.9,1.2,2.9,1.2h.8l18.3-3.3c.8-.2,1.7-.6,2.3-1.2l31.7-31.7c5.8-5.8,5.8-15.2,0-21-6-5.8-15.4-5.8-21.2,0h0ZM69.9,19.8l-30.8,30.8-11,1.9,2.1-11.2,30.6-30.6c2.5-2.5,6.7-2.5,9.2,0,2.5,2.7,2.5,6.7,0,9.2Z"/>
+                                        <path d="M5.1,79.6h70.8c2.3,0,4.2-1.9,4.2-4.2v-35.4c0-2.3-1.9-4.2-4.2-4.2s-4.2,1.9-4.2,4.2v31.2H9.2V8.8h31.2c2.3,0,4.2-1.9,4.2-4.2s-1.9-4.2-4.2-4.2H5.1c-2.3,0-4.2,1.9-4.2,4.2v70.8c0,2.3,1.9,4.2,4.2,4.2h0Z"/>
+                                    </svg>
+                                </button>
+                            </div>
+                        </div>
+                    <?php endforeach; ?>
+                </div>
             </div>
         </div>
-    
-    <!-- Breadcrumb Navigation -->
-    <div class="produkt-breadcrumb">
-        <a href="<?php echo admin_url('admin.php?page=produkt-verleih'); ?>">Dashboard</a> 
-        <span>→</span> 
-        <strong>Produkte</strong>
-    </div>
-    
-    <!-- Tab Navigation -->
-    <div class="produkt-tab-nav">
-        <a href="<?php echo admin_url('admin.php?page=produkt-categories&tab=list'); ?>" 
-           class="produkt-tab <?php echo $active_tab === 'list' ? 'active' : ''; ?>">
-            📋 Übersicht
-        </a>
-        <a href="<?php echo admin_url('admin.php?page=produkt-categories&tab=add'); ?>" 
-           class="produkt-tab <?php echo $active_tab === 'add' ? 'active' : ''; ?>">
-            ➕ Neues Produkt
-        </a>
-        <?php if ($edit_item): ?>
-        <a href="<?php echo admin_url('admin.php?page=produkt-categories&tab=edit&edit=' . $edit_item->id); ?>" 
-           class="produkt-tab <?php echo $active_tab === 'edit' ? 'active' : ''; ?>">
-            ✏️ Bearbeiten
-        </a>
-        <?php endif; ?>
-    </div>
-    
-        <!-- Tab Content -->
-        <div class="produkt-tab-content">
-            <?php
-            switch ($active_tab) {
-                case 'add':
-                    include PRODUKT_PLUGIN_PATH . 'admin/tabs/categories-add-tab.php';
-                    break;
-                case 'edit':
-                    if ($edit_item) {
-                        include PRODUKT_PLUGIN_PATH . 'admin/tabs/categories-edit-tab.php';
-                    } else {
-                        include PRODUKT_PLUGIN_PATH . 'admin/tabs/categories-list-tab.php';
-                    }
-                    break;
-                case 'list':
-                default:
-                    include PRODUKT_PLUGIN_PATH . 'admin/tabs/categories-list-tab.php';
-            }
-            ?>
+        <div class="dashboard-right">
+            <div class="dashboard-row">
+                <div class="dashboard-card card-new-product">
+                    <h2>Neues Produkt</h2>
+                    <p class="card-subline">Produkt erstellen</p>
+                    <a href="<?php echo admin_url('admin.php?page=produkt-categories&tab=add'); ?>" class="icon-btn add-product-btn" aria-label="Hinzufügen">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80.3">
+                            <path d="M12.1,12c-15.4,15.4-15.4,40.4,0,55.8,7.7,7.7,17.7,11.7,27.9,11.7s20.2-3.8,27.9-11.5c15.4-15.4,15.4-40.4,0-55.8-15.4-15.6-40.4-15.6-55.8-.2h0ZM62.1,62c-12.1,12.1-31.9,12.1-44.2,0-12.1-12.1-12.1-31.9,0-44.2,12.1-12.1,31.9-12.1,44.2,0,12.1,12.3,12.1,31.9,0,44.2Z"/>
+                            <path d="M54.6,35.7h-10.4v-10.4c0-2.3-1.9-4.2-4.2-4.2s-4.2,1.9-4.2,4.2v10.4h-10.4c-2.3,0-4.2,1.9-4.2,4.2s1.9,4.2,4.2,4.2h10.4v10.4c0,2.3,1.9,4.2,4.2,4.2s4.2-1.9,4.2-4.2v-10.4h10.4c2.3,0,4.2-1.9,4.2-4.2s-1.9-4.2-4.2-4.2Z"/>
+                        </svg>
+                    </a>
+                </div>
+                <div class="dashboard-card card-quicknav">
+                    <h2>Schnellnavigation</h2>
+                    <p class="card-subline">Direkt zu wichtigen Listen</p>
+                    <div class="quicknav-grid">
+                        <div class="quicknav-card">
+                            <a href="admin.php?page=produkt-variants">
+                                <div class="quicknav-inner">
+                                    <div class="quicknav-icon-circle">🧩</div>
+                                    <div class="quicknav-label">Ausführungen</div>
+                                </div>
+                            </a>
+                        </div>
+                        <div class="quicknav-card">
+                            <a href="admin.php?page=produkt-extras">
+                                <div class="quicknav-inner">
+                                    <div class="quicknav-icon-circle">✨</div>
+                                    <div class="quicknav-label">Extras</div>
+                                </div>
+                            </a>
+                        </div>
+                        <div class="quicknav-card">
+                            <a href="admin.php?page=produkt-conditions">
+                                <div class="quicknav-inner">
+                                    <div class="quicknav-icon-circle">🔧</div>
+                                    <div class="quicknav-label">Zustand</div>
+                                </div>
+                            </a>
+                        </div>
+                        <div class="quicknav-card">
+                            <a href="admin.php?page=produkt-colors">
+                                <div class="quicknav-inner">
+                                    <div class="quicknav-icon-circle">🎨</div>
+                                    <div class="quicknav-label">Farben</div>
+                                </div>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="h2-rental-card">
+                <div class="card-header-flex">
+                    <div>
+                        <h2>Alle Produkte</h2>
+                        <p class="card-subline">Produkte nach Kategorien anzeigen lassen</p>
+                    </div>
+                    <form method="get" class="produkt-filter-form product-search-bar">
+                        <input type="hidden" name="page" value="produkt-categories">
+                        <div class="search-input-wrapper">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="search-icon">
+                                <path d="M10 2a8 8 0 105.3 14.1l4.3 4.3a1 1 0 101.4-1.4l-4.3-4.3A8 8 0 0010 2zm0 2a6 6 0 110 12 6 6 0 010-12z"/>
+                            </svg>
+                            <input type="text" name="s" placeholder="Suchen nach Produkten" value="<?php echo esc_attr($search_term); ?>">
+                        </div>
+                        <select name="prodcat">
+                            <option value="0">Alle Kategorien</option>
+                            <?php foreach ($product_categories as $pc): ?>
+                                <option value="<?php echo $pc->id; ?>" <?php selected($selected_prodcat, $pc->id); ?>><?php echo str_repeat('--', $pc->depth) . ' ' . esc_html($pc->name); ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                        <button type="submit" class="icon-btn filter-submit-btn" aria-label="Filtern">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 22.1">
+                                <path d="M16,0C7.2,0,0,4.9,0,11s7.2,11,16,11,16-4.9,16-11S24.8,0,16,0ZM16,20c-7.7,0-14-4-14-9S8.3,2,16,2s14,4,14,9-6.3,9-14,9ZM16,5c-3.3,0-6,2.7-6,6s2.7,6,6,6,6-2.7,6-6-2.7-6-6-6ZM16,15c-2.2,0-4-1.8-4-4s1.8-4,4-4,4,1.8,4,4-1.8,4-4,4Z"/>
+                            </svg>
+                        </button>
+                    </form>
+                </div>
+                <table class="activity-table">
+                    <thead>
+                        <tr>
+                            <th>Bild</th>
+                            <th>Name</th>
+                            <th>Shortcode</th>
+                            <th>Kategorien</th>
+                            <th>SEO</th>
+                            <th>Aktionen</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($categories as $cat): ?>
+                            <tr>
+                                <td>
+                                    <?php if (!empty($cat->default_image)): ?>
+                                        <img src="<?php echo esc_url($cat->default_image); ?>" style="width:60px;height:60px;object-fit:cover;border-radius:4px;" alt="<?php echo esc_attr($cat->name); ?>">
+                                    <?php else: ?>
+                                        <div style="width:60px;height:60px;background:#f0f0f0;border-radius:4px;display:flex;align-items:center;justify-content:center;">🏷️</div>
+                                    <?php endif; ?>
+                                </td>
+                                <td><?php echo esc_html($cat->name); ?></td>
+                                <td><code>[produkt_product category="<?php echo esc_html($cat->shortcode); ?>"]</code></td>
+                                <td><?php echo esc_html($cat->categories ?: ''); ?></td>
+                                <td><?php echo $cat->meta_title ? '✅' : '❌'; ?></td>
+                                <td>
+                                    <button type="button" class="icon-btn" aria-label="Bearbeiten" onclick="window.location.href='?page=produkt-categories&tab=edit&edit=<?php echo $cat->id; ?>'">
+                                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80.8 80.1">
+                                            <path d="M54.7,4.8l-31.5,31.7c-.6.6-1,1.5-1.2,2.3l-3.3,18.3c-.2,1.2.2,2.7,1.2,3.8.8.8,1.9,1.2,2.9,1.2h.8l18.3-3.3c.8-.2,1.7-.6,2.3-1.2l31.7-31.7c5.8-5.8,5.8-15.2,0-21-6-5.8-15.4-5.8-21.2,0h0ZM69.9,19.8l-30.8,30.8-11,1.9,2.1-11.2,30.6-30.6c2.5-2.5,6.7-2.5,9.2,0,2.5,2.7,2.5,6.7,0,9.2Z"/>
+                                            <path d="M5.1,79.6h70.8c2.3,0,4.2-1.9,4.2-4.2v-35.4c0-2.3-1.9-4.2-4.2-4.2s-4.2,1.9-4.2,4.2v31.2H9.2V8.8h31.2c2.3,0,4.2-1.9,4.2-4.2s-1.9-4.2-4.2-4.2H5.1c-2.3,0-4.2,1.9-4.2,4.2v70.8c0,2.3,1.9,4.2,4.2,4.2h0Z"/>
+                                        </svg>
+                                    </button>
+                                    <button type="button" class="icon-btn" onclick="if(confirm('Wirklich löschen?')){window.location.href='?page=produkt-categories&delete=<?php echo $cat->id; ?>&fw_nonce=<?php echo wp_create_nonce('produkt_admin_action'); ?>';}" aria-label="Löschen">
+                                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 79.9 80.1">
+                                            <path d="M39.8.4C18,.4.3,18.1.3,40s17.7,39.6,39.6,39.6,39.6-17.7,39.6-39.6S61.7.4,39.8.4ZM39.8,71.3c-17.1,0-31.2-14-31.2-31.2s14.2-31.2,31.2-31.2,31.2,14,31.2,31.2-14.2,31.2-31.2,31.2Z"/>
+                                            <path d="M53,26.9c-1.7-1.7-4.2-1.7-5.8,0l-7.3,7.3-7.3-7.3c-1.7-1.7-4.2-1.7-5.8,0-1.7,1.7-1.7,4.2,0,5.8l7.3,7.3-7.3,7.3c-1.7,1.7-1.7,4.2,0,5.8.8.8,1.9,1.2,2.9,1.2s2.1-.4,2.9-1.2l7.3-7.3,7.3,7.3c.8.8,1.9,1.2,2.9,1.2s2.1-.4,2.9-1.2c1.7-1.7,1.7-4.2,0-5.8l-7.3-7.3,7.3-7.3c1.7-1.7,1.7-4.4,0-5.8h0Z"/>
+                                        </svg>
+                                    </button>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
+<?php elseif ($active_tab === 'add'): ?>
+    <?php include PRODUKT_PLUGIN_PATH . 'admin/tabs/categories-add-tab.php'; ?>
+<?php elseif ($active_tab === 'edit' && $edit_item): ?>
+    <?php include PRODUKT_PLUGIN_PATH . 'admin/tabs/categories-edit-tab.php'; ?>
+<?php endif; ?>
 </div>

--- a/admin/content-blocks-page.php
+++ b/admin/content-blocks-page.php
@@ -1,19 +1,29 @@
 <?php
-if (!defined('ABSPATH')) { exit; }
+if (!defined('ABSPATH')) {
+    exit;
+}
 
 global $wpdb;
 $table_name = $wpdb->prefix . 'produkt_content_blocks';
 
 $categories = \ProduktVerleih\Database::get_product_categories_tree();
-array_unshift($categories, (object)['id' => 0, 'name' => 'Alle Kategorien']);
-$selected_category = isset($_GET['category']) ? intval($_GET['category']) : ($categories[0]->id ?? 0);
-$action = isset($_GET['action']) ? sanitize_text_field($_GET['action']) : 'list';
-$edit_id = isset($_GET['edit']) ? intval($_GET['edit']) : 0;
+array_unshift($categories, (object) ['id' => 0, 'name' => 'Alle Kategorien']);
+$selected_category = isset($_GET['category']) ? intval($_GET['category']) : 0;
+$search_term       = isset($_GET['s']) ? sanitize_text_field($_GET['s']) : '';
+$action            = isset($_GET['action']) ? sanitize_text_field($_GET['action']) : 'list';
+$edit_id           = isset($_GET['edit']) ? intval($_GET['edit']) : 0;
+
+// Statistik Werte
+$total_blocks   = $wpdb->get_var("SELECT COUNT(*) FROM $table_name");
+$category_count = $wpdb->get_var("SELECT COUNT(*) FROM {$wpdb->prefix}produkt_categories");
+$wide_count     = $wpdb->get_var("SELECT COUNT(*) FROM $table_name WHERE style='wide'");
+$compact_count  = $wpdb->get_var("SELECT COUNT(*) FROM $table_name WHERE style='compact'");
 
 if (isset($_POST['save_block'])) {
     \ProduktVerleih\Admin::verify_admin_action();
+    $category_id = intval($_POST['category_id']);
     $data = [
-        'category_id' => $selected_category,
+        'category_id'      => $category_id,
         'style'        => sanitize_text_field($_POST['style']),
         'position'     => intval($_POST['position']),
         'position_mobile' => intval($_POST['position_mobile']),
@@ -30,7 +40,7 @@ if (isset($_POST['save_block'])) {
     } else {
         $wpdb->insert($table_name, $data);
     }
-    \ProduktVerleih\Database::clear_content_blocks_cache($selected_category);
+    \ProduktVerleih\Database::clear_content_blocks_cache($category_id);
     $action = 'list';
 }
 
@@ -45,133 +55,207 @@ if ($action === 'edit' && $edit_id) {
     if (!$block) { $action = 'list'; }
 }
 
-$blocks = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE category_id = %d ORDER BY position", $selected_category));
+$sql_blocks = "SELECT * FROM $table_name";
+$params = [];
+$clauses = [];
+if ($selected_category > 0) {
+    $clauses[] = "category_id = %d";
+    $params[] = $selected_category;
+}
+if ($search_term !== '') {
+    $clauses[] = "title LIKE %s";
+    $params[] = '%' . $wpdb->esc_like($search_term) . '%';
+}
+if ($clauses) {
+    $sql_blocks .= ' WHERE ' . implode(' AND ', $clauses);
+}
+$sql_blocks .= ' ORDER BY position';
+$blocks = !empty($params) ? $wpdb->get_results($wpdb->prepare($sql_blocks, ...$params)) : $wpdb->get_results($sql_blocks);
 ?>
-<div class="wrap" id="produkt-admin-content-blocks">
-    <div class="produkt-admin-card">
-        <div class="produkt-admin-header-compact">
-            <div class="produkt-admin-logo-compact">
-                <span class="dashicons dashicons-welcome-write-blog"></span>
+<div class="produkt-admin dashboard-wrapper">
+    <h1 class="dashboard-greeting"><?php echo pv_get_time_greeting(); ?>, <?php echo esc_html(wp_get_current_user()->display_name); ?> 👋</h1>
+    <p class="dashboard-subline">Content-Blöcke verwalten</p>
+
+<?php if ($action === 'list'): ?>
+    <div class="product-info-grid cols-4">
+        <div class="product-info-box bg-pastell-gelb">
+            <span class="label">Blöcke</span>
+            <strong class="value"><?php echo intval($total_blocks); ?></strong>
+        </div>
+        <div class="product-info-box bg-pastell-gruen">
+            <span class="label">Kategorien</span>
+            <strong class="value"><?php echo intval($category_count); ?></strong>
+        </div>
+        <div class="product-info-box bg-pastell-mint">
+            <span class="label">Weit</span>
+            <strong class="value"><?php echo intval($wide_count); ?></strong>
+        </div>
+        <div class="product-info-box bg-pastell-orange">
+            <span class="label">Kompakt</span>
+            <strong class="value"><?php echo intval($compact_count); ?></strong>
+        </div>
+    </div>
+
+    <div class="h2-rental-card">
+        <div class="card-header-flex">
+            <div>
+                <h2>Content Blöcke</h2>
+                <p class="card-subline">Blöcke verwalten</p>
             </div>
-            <div class="produkt-admin-title-compact">
-                <h1>Content-Blöcke</h1>
-                <p>Gestalte Texte und Bilder für Kategorien</p>
+            <div class="card-header-actions">
+                <form method="get" class="produkt-filter-form product-search-bar">
+                    <input type="hidden" name="page" value="produkt-content-blocks">
+                    <div class="search-input-wrapper">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="search-icon">
+                            <path d="M10 2a8 8 0 105.3 14.1l4.3 4.3a1 1 0 101.4-1.4l-4.3-4.3A8 8 0 0010 2zm0 2a6 6 0 110 12 6 6 0 010-12z"/>
+                        </svg>
+                        <input type="text" name="s" placeholder="Suchen" value="<?php echo esc_attr($search_term); ?>">
+                    </div>
+                    <select name="category">
+                        <option value="0">Alle Kategorien</option>
+                        <?php foreach ($categories as $cat): ?>
+                            <option value="<?php echo $cat->id; ?>" <?php selected($selected_category, $cat->id); ?>><?php echo str_repeat('--', $cat->depth ?? 0) . ' ' . esc_html($cat->name); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                    <button type="submit" class="icon-btn filter-submit-btn" aria-label="Filtern">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 22.1">
+                            <path d="M16,0C7.2,0,0,4.9,0,11s7.2,11,16,11,16-4.9,16-11S24.8,0,16,0ZM16,20c-7.7,0-14-4-14-9S8.3,2,16,2s14,4,14,9-6.3,9-14,9ZM16,5c-3.3,0-6,2.7-6,6s2.7,6,6,6,6-2.7,6-6-2.7-6-6-6ZM16,15c-2.2,0-4-1.8-4-4s1.8-4,4-4,4,1.8,4,4-1.8,4-4,4Z"/>
+                        </svg>
+                    </button>
+                </form>
+                <a id="add-category-btn" href="<?php echo admin_url('admin.php?page=produkt-content-blocks&action=add'); ?>" class="icon-btn add-category-btn" aria-label="Hinzufügen">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80.3">
+                        <path d="M12.1,12c-15.4,15.4-15.4,40.4,0,55.8,7.7,7.7,17.7,11.7,27.9,11.7s20.2-3.8,27.9-11.5c15.4-15.4,15.4-40.4,0-55.8-15.4-15.6-40.4-15.6-55.8-.2h0ZM62.1,62c-12.1,12.1-31.9,12.1-44.2,0-12.1-12.1-12.1-31.9,0-44.2,12.1-12.1,31.9-12.1,44.2,0,12.1,12.3,12.1,31.9,0,44.2Z"/>
+                        <path d="M54.6,35.7h-10.4v-10.4c0-2.3-1.9-4.2-4.2-4.2s-4.2,1.9-4.2,4.2v10.4h-10.4c-2.3,0-4.2,1.9-4.2,4.2s1.9,4.2,4.2,4.2h10.4v10.4c0,2.3,1.9,4.2,4.2,4.2s4.2-1.9,4.2-4.2v-10.4h10.4c2.3,0,4.2-1.9,4.2-4.2s-1.9-4.2-4.2-4.2Z"/>
+                    </svg>
+                </a>
             </div>
         </div>
-
-    <form method="get" action="">
-        <input type="hidden" name="page" value="produkt-content-blocks">
-        <label for="cb-category-select"><strong>Kategorie:</strong></label>
-        <select id="cb-category-select" name="category" onchange="this.form.submit()">
-            <?php foreach ($categories as $cat): ?>
-                <option value="<?php echo $cat->id; ?>" <?php selected($selected_category, $cat->id); ?>><?php echo str_repeat('--', $cat->depth ?? 0) . ' ' . esc_html($cat->name); ?></option>
-            <?php endforeach; ?>
-        </select>
-        <noscript><input type="submit" value="Wechseln" class="button"></noscript>
+        <table class="activity-table">
+            <thead>
+                <tr>
+                    <th>Titel</th>
+                    <th>Layout</th>
+                    <th>Badge-Text</th>
+                    <th>Position Desktop</th>
+                    <th>Position Mobil</th>
+                    <th>Aktionen</th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($blocks as $b): ?>
+                    <tr>
+                        <td><?php echo esc_html($b->title); ?></td>
+                        <td><?php echo esc_html($b->style); ?></td>
+                        <td><?php echo esc_html($b->badge_text); ?></td>
+                        <td><?php echo intval($b->position); ?></td>
+                        <td><?php echo intval($b->position_mobile); ?></td>
+                        <td>
+                            <button type="button" class="icon-btn" aria-label="Bearbeiten" onclick="window.location.href='?page=produkt-content-blocks&action=edit&edit=<?php echo $b->id; ?>'">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80.8 80.1">
+                                    <path d="M54.7,4.8l-31.5,31.7c-.6.6-1,1.5-1.2,2.3l-3.3,18.3c-.2,1.2.2,2.7,1.2,3.8.8.8,1.9,1.2,2.9,1.2h.8l18.3-3.3c.8-.2,1.7-.6,2.3-1.2l31.7-31.7c5.8-5.8,5.8-15.2,0-21-6-5.8-15.4-5.8-21.2,0h0ZM69.9,19.8l-30.8,30.8-11,1.9,2.1-11.2,30.6-30.6c2.5-2.5,6.7-2.5,9.2,0,2.5,2.7,2.5,6.7,0,9.2Z"/>
+                                    <path d="M5.1,79.6h70.8c2.3,0,4.2-1.9,4.2-4.2v-35.4c0-2.3-1.9-4.2-4.2-4.2s-4.2,1.9-4.2,4.2v31.2H9.2V8.8h31.2c2.3,0,4.2-1.9,4.2-4.2s-1.9-4.2-4.2-4.2H5.1c-2.3,0-4.2,1.9-4.2,4.2v70.8c0,2.3,1.9,4.2,4.2,4.2h0Z"/>
+                                </svg>
+                            </button>
+                            <button type="button" class="icon-btn" onclick="if(confirm('Wirklich löschen?')){window.location.href='?page=produkt-content-blocks&delete=<?php echo $b->id; ?>&fw_nonce=<?php echo wp_create_nonce('produkt_admin_action'); ?>';}" aria-label="Löschen">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 79.9 80.1">
+                                    <path d="M39.8.4C18,.4.3,18.1.3,40s17.7,39.6,39.6,39.6,39.6-17.7,39.6-39.6S61.7.4,39.8.4ZM39.8,71.3c-17.1,0-31.2-14-31.2-31.2s14.2-31.2,31.2-31.2,31.2,14,31.2,31.2-14.2,31.2-31.2,31.2Z"/>
+                                    <path d="M53,26.9c-1.7-1.7-4.2-1.7-5.8,0l-7.3,7.3-7.3-7.3c-1.7-1.7-4.2-1.7-5.8,0-1.7,1.7-1.7,4.2,0,5.8l7.3,7.3-7.3,7.3c-1.7,1.7-1.7,4.2,0,5.8.8.8,1.9,1.2,2.9,1.2s2.1-.4,2.9-1.2l7.3-7.3,7.3,7.3c.8.8,1.9,1.2,2.9,1.2s2.1-.4,2.9-1.2c1.7-1.7,1.7-4.2,0-5.8l-7.3-7.3,7.3-7.3c1.7-1.7,1.7-4.4,0-5.8h0Z"/>
+                                </svg>
+                            </button>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+<?php else: ?>
+    <h2><?php echo $action === 'edit' ? 'Block bearbeiten' : 'Neuen Block hinzufügen'; ?></h2>
+    <form method="post" action="" class="produkt-compact-form">
+        <?php wp_nonce_field('produkt_admin_action', 'produkt_admin_nonce'); ?>
+        <input type="hidden" name="id" value="<?php echo esc_attr($block->id ?? ''); ?>">
+        <table class="form-table">
+            <tr>
+                <th><label>Kategorie *</label></th>
+                <td>
+                    <select name="category_id" required>
+                        <?php foreach ($categories as $cat): ?>
+                            <option value="<?php echo $cat->id; ?>" <?php selected(($block->category_id ?? $selected_category), $cat->id); ?>><?php echo str_repeat('--', $cat->depth ?? 0) . ' ' . esc_html($cat->name); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </td>
+            </tr>
+            <tr>
+                <th><label>Layout</label></th>
+                <td>
+                    <select name="style">
+                        <option value="compact" <?php selected($block->style ?? 'wide', 'compact'); ?>>Kompakt</option>
+                        <option value="wide" <?php selected($block->style ?? 'wide', 'wide'); ?>>Weit</option>
+                    </select>
+                </td>
+            </tr>
+            <tr>
+                <th><label>Position Desktop *</label></th>
+                <td><input type="number" name="position" required value="<?php echo esc_attr($block->position ?? 9); ?>"></td>
+            </tr>
+            <tr>
+                <th><label>Position Mobil *</label></th>
+                <td><input type="number" name="position_mobile" required value="<?php echo esc_attr($block->position_mobile ?? 6); ?>"></td>
+            </tr>
+            <tr>
+                <th><label>Überschrift *</label></th>
+                <td><input type="text" name="title" required value="<?php echo esc_attr($block->title ?? ''); ?>"></td>
+            </tr>
+            <tr>
+                <th><label>Text *</label></th>
+                <td><textarea name="content" rows="4" required><?php echo esc_textarea($block->content ?? ''); ?></textarea></td>
+            </tr>
+            <tr>
+                <th><label>Bild</label></th>
+                <td>
+                    <input type="url" name="image_url" id="image_url" value="<?php echo esc_attr($block->image_url ?? ''); ?>">
+                    <button type="button" class="button produkt-media-button" data-target="image_url">📁</button>
+                </td>
+            </tr>
+            <tr>
+                <th><label>Button-Text</label></th>
+                <td><input type="text" name="button_text" value="<?php echo esc_attr($block->button_text ?? ''); ?>"></td>
+            </tr>
+            <tr>
+                <th><label>Button-Link</label></th>
+                <td><input type="url" name="button_url" value="<?php echo esc_attr($block->button_url ?? ''); ?>"></td>
+            </tr>
+            <tr>
+                <th><label>Hintergrundfarbe</label></th>
+                <td><input type="color" name="background_color" value="<?php echo esc_attr($block->background_color ?? '#ffffff'); ?>"></td>
+            </tr>
+            <tr>
+                <th><label>Badge-Text</label></th>
+                <td><input type="text" name="badge_text" value="<?php echo esc_attr($block->badge_text ?? ''); ?>"></td>
+            </tr>
+        </table>
+        <p>
+            <button type="submit" name="save_block" class="button button-primary">Speichern</button>
+            <a href="<?php echo admin_url('admin.php?page=produkt-content-blocks'); ?>" class="button">Abbrechen</a>
+        </p>
     </form>
-
-    <?php if ($action === 'add' || $action === 'edit'): ?>
-        <h2><?php echo $action === 'edit' ? 'Block bearbeiten' : 'Neuen Block hinzufügen'; ?></h2>
-        <form method="post" action="" class="produkt-compact-form">
-            <?php wp_nonce_field('produkt_admin_action', 'produkt_admin_nonce'); ?>
-            <input type="hidden" name="id" value="<?php echo esc_attr($block->id ?? ''); ?>">
-            <input type="hidden" name="category_id" value="<?php echo $selected_category; ?>">
-            <table class="form-table">
-                <tr>
-                    <th><label>Layout</label></th>
-                    <td>
-                        <select name="style">
-                            <option value="compact" <?php selected($block->style ?? 'wide', 'compact'); ?>>Kompakt</option>
-                            <option value="wide" <?php selected($block->style ?? 'wide', 'wide'); ?>>Weit</option>
-                        </select>
-                    </td>
-                </tr>
-                <tr>
-                    <th><label>Position Desktop *</label></th>
-                    <td><input type="number" name="position" required value="<?php echo esc_attr($block->position ?? 9); ?>"></td>
-                </tr>
-                <tr>
-                    <th><label>Position Mobil *</label></th>
-                    <td><input type="number" name="position_mobile" required value="<?php echo esc_attr($block->position_mobile ?? 6); ?>"></td>
-                </tr>
-                <tr>
-                    <th><label>Überschrift *</label></th>
-                    <td><input type="text" name="title" required value="<?php echo esc_attr($block->title ?? ''); ?>"></td>
-                </tr>
-                <tr>
-                    <th><label>Text *</label></th>
-                    <td><textarea name="content" rows="4" required><?php echo esc_textarea($block->content ?? ''); ?></textarea></td>
-                </tr>
-                <tr>
-                    <th><label>Bild</label></th>
-                    <td>
-                        <input type="url" name="image_url" id="image_url" value="<?php echo esc_attr($block->image_url ?? ''); ?>">
-                        <button type="button" class="button produkt-media-button" data-target="image_url">📁</button>
-                    </td>
-                </tr>
-                <tr>
-                    <th><label>Button-Text</label></th>
-                    <td><input type="text" name="button_text" value="<?php echo esc_attr($block->button_text ?? ''); ?>"></td>
-                </tr>
-                <tr>
-                    <th><label>Button-Link</label></th>
-                    <td><input type="url" name="button_url" value="<?php echo esc_attr($block->button_url ?? ''); ?>"></td>
-                </tr>
-                <tr>
-                    <th><label>Hintergrundfarbe</label></th>
-                    <td><input type="color" name="background_color" value="<?php echo esc_attr($block->background_color ?? '#ffffff'); ?>"></td>
-                </tr>
-                <tr>
-                    <th><label>Badge-Text</label></th>
-                    <td><input type="text" name="badge_text" value="<?php echo esc_attr($block->badge_text ?? ''); ?>"></td>
-                </tr>
-            </table>
-            <p>
-                <button type="submit" name="save_block" class="button button-primary">Speichern</button>
-                <a href="<?php echo admin_url('admin.php?page=produkt-content-blocks&category=' . $selected_category); ?>" class="button">Abbrechen</a>
-            </p>
-        </form>
-        <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            document.querySelectorAll('.produkt-media-button').forEach(function(btn) {
-                btn.addEventListener('click', function(e) {
-                    e.preventDefault();
-                    const targetId = this.getAttribute('data-target');
-                    const field = document.getElementById(targetId);
-                    if (!field) return;
-                    const frame = wp.media({ title: 'Bild auswählen', button: { text: 'Bild verwenden' }, multiple: false });
-                    frame.on('select', function() {
-                        const att = frame.state().get('selection').first().toJSON();
-                        field.value = att.url;
-                    });
-                    frame.open();
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        document.querySelectorAll('.produkt-media-button').forEach(function(btn) {
+            btn.addEventListener('click', function(e) {
+                e.preventDefault();
+                const targetId = this.getAttribute('data-target');
+                const field = document.getElementById(targetId);
+                if (!field) return;
+                const frame = wp.media({ title: 'Bild auswählen', button: { text: 'Bild verwenden' }, multiple: false });
+                frame.on('select', function() {
+                    const att = frame.state().get('selection').first().toJSON();
+                    field.value = att.url;
                 });
+                frame.open();
             });
         });
-        </script>
-    <?php else: ?>
-        <h2>Blöcke</h2>
-        <p><a href="<?php echo admin_url('admin.php?page=produkt-content-blocks&category=' . $selected_category . '&action=add'); ?>" class="button button-primary">Neuen Block hinzufügen</a></p>
-        <?php if (empty($blocks)): ?>
-            <p>Noch keine Blöcke definiert.</p>
-        <?php else: ?>
-            <table class="widefat striped">
-                <thead><tr><th>Desktop</th><th>Mobil</th><th>Titel</th><th>Aktionen</th></tr></thead>
-                <tbody>
-                    <?php foreach ($blocks as $b): ?>
-                        <tr>
-                            <td><?php echo intval($b->position); ?></td>
-                            <td><?php echo intval($b->position_mobile); ?></td>
-                            <td><?php echo esc_html($b->title); ?></td>
-                            <td>
-                                <a href="<?php echo admin_url('admin.php?page=produkt-content-blocks&category=' . $selected_category . '&action=edit&edit=' . $b->id); ?>" class="button">Bearbeiten</a>
-                                <a href="<?php echo admin_url('admin.php?page=produkt-content-blocks&category=' . $selected_category . '&delete=' . $b->id . '&fw_nonce=' . wp_create_nonce('produkt_admin_action')); ?>" class="button button-danger" onclick="return confirm('Wirklich löschen?')">Löschen</a>
-                            </td>
-                        </tr>
-                    <?php endforeach; ?>
-                </tbody>
-            </table>
-        <?php endif; ?>
-    <?php endif; ?>
-    </div>
+    });
+    </script>
+<?php endif; ?>
 </div>

--- a/admin/customers-page.php
+++ b/admin/customers-page.php
@@ -6,16 +6,18 @@ if (!defined('ABSPATH')) {
 global $wpdb;
 require_once PRODUKT_PLUGIN_PATH . 'includes/account-helpers.php';
 require_once PRODUKT_PLUGIN_PATH . 'includes/Database.php';
+
 $search      = isset($_GET['s']) ? sanitize_text_field($_GET['s']) : '';
 $customer_id = isset($_GET['customer']) ? intval($_GET['customer']) : 0;
 
-$branding = [];
-$results = $wpdb->get_results("SELECT setting_key, setting_value FROM {$wpdb->prefix}produkt_branding");
-foreach ($results as $r) {
-    $branding[$r->setting_key] = $r->setting_value;
-}
-
 if (!$customer_id) {
+    // Stats
+    $total_customers = count(get_users(['role' => 'kunde']));
+    $total_orders    = (int) $wpdb->get_var("SELECT COUNT(*) FROM {$wpdb->prefix}produkt_orders");
+    $total_revenue   = (float) $wpdb->get_var("SELECT SUM(final_price) FROM {$wpdb->prefix}produkt_orders");
+    $avg_per_customer = $total_customers ? $total_revenue / $total_customers : 0;
+
+    // Customer list
     $args = [
         'role'    => 'kunde',
         'orderby' => 'display_name',
@@ -36,76 +38,97 @@ if (!$customer_id) {
             $name = $u->display_name;
         }
         $orders = \ProduktVerleih\Database::get_orders_for_user($u->ID);
-        foreach ($orders as $o) {
-            $o->rental_days = pv_get_order_rental_days($o);
-        }
-        $last_date = $orders ? date_i18n('d.m.Y', strtotime($orders[0]->created_at)) : '';
-        $kunden[] = (object)[
-            'id'             => $u->ID,
-            'name'           => $name,
-            'email'          => $u->user_email,
-            'telefon'        => $phone,
-            'orders'         => $orders,
-            'last_order_date'=> $last_date,
+        $kunden[] = (object) [
+            'id'      => $u->ID,
+            'first'   => $first,
+            'last'    => $last,
+            'name'    => $name,
+            'email'   => $u->user_email,
+            'telefon' => $phone,
+            'orders'  => $orders,
         ];
     }
 }
 ?>
-<div class="wrap" id="produkt-admin-customers">
+<div class="produkt-admin dashboard-wrapper" id="produkt-admin-customers">
 <?php if (!$customer_id): ?>
-    <div class="produkt-admin-card">
-        <div class="produkt-admin-header-compact">
-            <div class="produkt-admin-logo-compact">
-                <span class="dashicons dashicons-groups"></span>
-            </div>
-            <div class="produkt-admin-title-compact">
-                <h1>Kundenübersicht</h1>
-                <p>Alle registrierten Kunden im Überblick</p>
-            </div>
+    <h1 class="dashboard-greeting"><?php echo pv_get_time_greeting(); ?>, <?php echo esc_html(wp_get_current_user()->display_name); ?> 👋</h1>
+    <p class="dashboard-subline">Kunden verwalten</p>
+
+    <div class="product-info-grid cols-4">
+        <div class="product-info-box bg-pastell-gelb">
+            <div class="label">Kunden</div>
+            <div class="value"><?php echo esc_html($total_customers); ?></div>
         </div>
+        <div class="product-info-box bg-pastell-gruen">
+            <div class="label">Bestellungen</div>
+            <div class="value"><?php echo esc_html($total_orders); ?></div>
+        </div>
+        <div class="product-info-box bg-pastell-mint">
+            <div class="label">Umsatz</div>
+            <div class="value"><?php echo number_format($total_revenue, 2, ',', '.'); ?>€</div>
+        </div>
+        <div class="product-info-box bg-pastell-orange">
+            <div class="label">Ø pro Kunde</div>
+            <div class="value"><?php echo number_format($avg_per_customer, 2, ',', '.'); ?>€</div>
+        </div>
+    </div>
 
-        <form method="get" action="" style="margin:20px 0;">
-            <input type="hidden" name="page" value="produkt-customers">
-            <input type="search" name="s" value="<?php echo esc_attr($search); ?>" placeholder="Nach Namen suchen">
-            <input type="submit" class="button" value="Suchen">
-        </form>
-
-        <?php if (empty($kunden)) : ?>
-            <div class="produkt-empty-state">
-                <span class="dashicons dashicons-info"></span>
-                <h4>Keine Kunden gefunden</h4>
-                <p>Es wurden bisher keine Kunden im System erfasst.</p>
+    <div class="h2-rental-card">
+        <div class="card-header-flex">
+            <div>
+                <h2>Kundenübersicht</h2>
+                <p class="card-subline">Kunden durchsuchen</p>
             </div>
-        <?php else : ?>
-            <div class="produkt-items-grid">
-                <?php foreach ($kunden as $kunde) : ?>
-                    <div class="produkt-item-card">
-                        <div class="produkt-item-content">
-                            <h5><?php echo esc_html($kunde->name); ?></h5>
-                            <p><span class="dashicons dashicons-email"></span> <?php echo esc_html($kunde->email); ?></p>
-                            <p><span class="dashicons dashicons-phone"></span> <?php echo esc_html($kunde->telefon ?: '–'); ?></p>
+            <form method="get" class="produkt-filter-form product-search-bar">
+                <input type="hidden" name="page" value="produkt-customers">
+                <div class="search-input-wrapper">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="search-icon">
+                        <path d="M10 2a8 8 0 105.3 14.1l4.3 4.3a1 1 0 101.4-1.4l-4.3-4.3A8 8 0 0010 2zm0 2a6 6 0 110 12 6 6 0 010-12z"/>
+                    </svg>
+                    <input type="text" name="s" placeholder="Nach Namen suchen" value="<?php echo esc_attr($search); ?>">
+                </div>
+                <button type="submit" class="icon-btn filter-submit-btn" aria-label="Filtern">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 22.1">
+                        <path d="M16,0C7.2,0,0,4.9,0,11s7.2,11,16,11,16-4.9,16-11S24.8,0,16,0ZM16,20c-7.7,0-14-4-14-9S8.3,2,16,2s14,4,14,9-6.3,9-14,9ZM16,5c-3.3,0-6,2.7-6,6s2.7,6,6,6,6-2.7,6-6-2.7-6-6-6ZM16,15c-2.2,0-4-1.8-4-4s1.8-4,4-4,4,1.8,4,4-1.8,4-4,4Z"/>
+                    </svg>
+                </button>
+            </form>
+        </div>
+    </div>
 
-                            <div class="produkt-item-meta">
-                                <div class="produkt-status available">
-                                    Letzte Bestellung: <br>
-                                    <strong><?php echo esc_html($kunde->last_order_date ?: '–'); ?></strong>
-                                </div>
-                                <div class="produkt-status-badge badge badge-success">
-                                    <?php echo esc_html(count($kunde->orders)); ?> Bestellungen
-                                </div>
-                            </div>
-
-                        </div>
-                        <div class="produkt-item-actions">
-                            <a href="mailto:<?php echo esc_attr($kunde->email); ?>" class="button">E-Mail senden</a>
-                            <a href="<?php echo esc_url(admin_url('admin.php?page=produkt-customers&customer=' . $kunde->id)); ?>" class="button">Details</a>
-                            <a href="<?php echo esc_url(admin_url('admin.php?page=produkt-orders')); ?>" class="button button-primary">Alle Bestellungen</a>
+    <?php if (empty($kunden)) : ?>
+        <p>Keine Kunden gefunden.</p>
+    <?php else : ?>
+        <div class="customers-grid">
+            <?php foreach ($kunden as $kunde) :
+                $initials = strtoupper(mb_substr($kunde->first, 0, 1) . mb_substr($kunde->last, 0, 1));
+                $last_order_date = !empty($kunde->orders) ? date_i18n('d.m.Y', strtotime($kunde->orders[0]->created_at)) : '–';
+            ?>
+                <div class="customer-card">
+                    <div class="customer-header">
+                        <div class="customer-avatar"><?php echo esc_html($initials); ?></div>
+                        <div class="customer-ident">
+                            <h3 class="customer-name"><?php echo esc_html($kunde->name); ?></h3>
+                            <p class="customer-email"><?php echo esc_html($kunde->email); ?></p>
                         </div>
                     </div>
-                <?php endforeach; ?>
-            </div>
-        <?php endif; ?>
-    </div>
+                    <p class="customer-phone">Telefon: <?php echo esc_html($kunde->telefon ?: '–'); ?></p>
+                    <div class="customer-orders-row">
+                        <span class="customer-orders">Bestellungen: <?php echo esc_html(count($kunde->orders)); ?></span>
+                        <span class="customer-last-order">Letzte Bestellung: <?php echo esc_html($last_order_date); ?></span>
+                    </div>
+                    <div class="customer-actions">
+                        <a href="<?php echo admin_url('admin.php?page=produkt-customers&customer=' . $kunde->id); ?>" class="icon-btn icon-btn-no-stroke" aria-label="Details">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 22.1">
+                                <path d="M16,0C7.2,0,0,4.9,0,11s7.2,11,16,11,16-4.9,16-11S24.8,0,16,0ZM16,20c-7.7,0-14-4-14-9S8.3,2,16,2s14,4,14,9-6.3,9-14,9ZM16,5c-3.3,0-6,2.7-6,6s2.7,6,6,6,6-2.7,6-6-2.7-6-6-6ZM16,15c-2.2,0-4-1.8-4-4s1.8-4,4-4,4,1.8,4,4-1.8,4-4,4Z"/>
+                            </svg>
+                        </a>
+                    </div>
+                </div>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
 <?php else: ?>
 <?php
     $user = get_user_by('ID', $customer_id);
@@ -132,6 +155,33 @@ if (!$customer_id) {
             }
         }
     }
+
+    $total_spent = (float) $wpdb->get_var($wpdb->prepare(
+        "SELECT SUM(final_price) FROM {$wpdb->prefix}produkt_orders WHERE customer_email = %s AND status = 'abgeschlossen'",
+        $user->user_email
+    ));
+    $completed_orders = (int) $wpdb->get_var($wpdb->prepare(
+        "SELECT COUNT(*) FROM {$wpdb->prefix}produkt_orders WHERE customer_email = %s AND status = 'abgeschlossen'",
+        $user->user_email
+    ));
+    $canceled_orders = (int) $wpdb->get_var($wpdb->prepare(
+        "SELECT COUNT(*) FROM {$wpdb->prefix}produkt_orders WHERE customer_email = %s AND status = 'gekündigt'",
+        $user->user_email
+    ));
+    $year_start = date('Y-01-01 00:00:00');
+    $year_end   = date('Y-12-31 23:59:59');
+    $year_orders = (int) $wpdb->get_var($wpdb->prepare(
+        "SELECT COUNT(*) FROM {$wpdb->prefix}produkt_orders WHERE customer_email = %s AND status = 'abgeschlossen' AND created_at BETWEEN %s AND %s",
+        $user->user_email, $year_start, $year_end
+    ));
+    if ($year_orders <= 5) {
+        $activity_score = 'Gering';
+    } elseif ($year_orders <= 12) {
+        $activity_score = 'Mittel';
+    } else {
+        $activity_score = 'Hoch';
+    }
+
     $orders = $wpdb->get_results(
         $wpdb->prepare(
             "SELECT o.*, c.name AS category_name,
@@ -151,80 +201,193 @@ if (!$customer_id) {
             $user->user_email
         )
     );
-    foreach ($orders as $o) {
-        $o->rental_days = pv_get_order_rental_days($o);
+
+    $last_order = $orders[0] ?? null;
+    $order_ids = wp_list_pluck($orders, 'id');
+    if ($order_ids) {
+        $placeholders = implode(',', array_fill(0, count($order_ids), '%d'));
+        $sql = "SELECT event, message, created_at FROM {$wpdb->prefix}produkt_order_logs WHERE order_id IN ($placeholders) ORDER BY created_at DESC LIMIT 5";
+        $customer_logs = $wpdb->get_results($wpdb->prepare($sql, $order_ids));
+        $count_sql = "SELECT COUNT(*) FROM {$wpdb->prefix}produkt_order_logs WHERE order_id IN ($placeholders)";
+        $total_logs = (int) $wpdb->get_var($wpdb->prepare($count_sql, $order_ids));
+    } else {
+        $customer_logs = [];
+        $total_logs = 0;
     }
+
+    $customer_notes = $wpdb->get_results($wpdb->prepare(
+        "SELECT id, message, created_at FROM {$wpdb->prefix}produkt_customer_notes WHERE customer_id = %d ORDER BY created_at DESC",
+        $user->ID
+    ));
+
+    $addr_row = $wpdb->get_row(
+        $wpdb->prepare(
+            "SELECT street, postal_code, city, country FROM {$wpdb->prefix}produkt_customers WHERE email = %s",
+            $user->user_email
+        )
+    );
+    $addr = '';
+    if ($addr_row) {
+        $addr = trim($addr_row->street . ', ' . $addr_row->postal_code . ' ' . $addr_row->city);
+        if ($addr_row->country) {
+            $addr .= ', ' . $addr_row->country;
+        }
+    }
+    $initials = strtoupper(mb_substr($first,0,1) . mb_substr($last,0,1));
 ?>
-    <div class="produkt-admin-card">
-      <div class="produkt-admin-header-compact">
-        <div class="produkt-admin-logo-compact">
-          <span class="dashicons dashicons-id"></span>
+    <h1 class="dashboard-greeting"><?php echo pv_get_time_greeting(); ?>, <?php echo esc_html(wp_get_current_user()->display_name); ?> 👋</h1>
+    <p class="dashboard-subline">Kundendetails</p>
+
+    <div class="product-info-grid cols-4">
+        <div class="product-info-box bg-pastell-gelb">
+            <div class="label">Ausgaben</div>
+            <div class="value"><?php echo number_format($total_spent, 2, ',', '.'); ?>€</div>
         </div>
-        <div class="produkt-admin-title-compact">
-          <h1>Kundendetails: <?php echo esc_html($first . ' ' . $last); ?></h1>
-          <p><?php echo esc_html($user->user_email); ?></p>
+        <div class="product-info-box bg-pastell-gruen">
+            <div class="label">Abgeschlossen</div>
+            <div class="value"><?php echo esc_html($completed_orders); ?></div>
         </div>
-      </div>
-
-      <p><a href="<?php echo admin_url('admin.php?page=produkt-customers'); ?>" class="button">&larr; Zur Kundenübersicht</a></p>
-
-      <div class="produkt-customer-grid">
-        <div class="produkt-customer-details">
-          <h2>Kundendaten</h2>
-          <p><strong>Vorname:</strong> <?php echo esc_html($first); ?></p>
-          <p><strong>Nachname:</strong> <?php echo esc_html($last); ?></p>
-          <p><strong>Telefon:</strong> <?php echo esc_html($phone ?: '–'); ?></p>
-          <p><strong>E-Mail:</strong> <?php echo esc_html($user->user_email); ?></p>
-
-          <?php
-            $addr_row = $wpdb->get_row(
-                $wpdb->prepare(
-                    "SELECT street, postal_code, city, country FROM {$wpdb->prefix}produkt_customers WHERE email = %s",
-                    $user->user_email
-                )
-            );
-            $addr = '';
-            if ($addr_row) {
-                $addr = trim($addr_row->street . ', ' . $addr_row->postal_code . ' ' . $addr_row->city);
-                if ($addr_row->country) {
-                    $addr .= ', ' . $addr_row->country;
-                }
-            }
-          ?>
-          <h3>Versandadresse</h3>
-          <p><?php echo esc_html($addr ?: '–'); ?></p>
-
-          <h3>Rechnungsadresse</h3>
-          <p><?php echo esc_html($addr ?: '–'); ?></p>
-
-          <h3>Statistik</h3>
-          <p><strong>Bestellungen:</strong> <?php echo count($orders); ?></p>
+        <div class="product-info-box bg-pastell-mint">
+            <div class="label">Abgebrochen</div>
+            <div class="value"><?php echo esc_html($canceled_orders); ?></div>
         </div>
+        <div class="product-info-box bg-pastell-orange">
+            <div class="label">Activity Score</div>
+            <div class="value"><?php echo esc_html($activity_score); ?></div>
+        </div>
+    </div>
 
-        <div class="produkt-customer-orders orders-accordion">
-          <h2>Bestellübersicht</h2>
-          <?php if (empty($orders)) : ?>
-            <p>Keine Bestellungen gefunden.</p>
-          <?php else : ?>
-            <?php foreach ($orders as $idx => $o): ?>
-              <?php
-                $variant_id = $o->variant_id ?? 0;
-                $image_url  = pv_get_image_url_by_variant_or_category($variant_id, $o->category_id ?? 0);
-                $order      = $o;
-              ?>
-              <div class="produkt-accordion-item <?php echo $idx === 0 ? 'active' : ''; ?>">
-                <button type="button" class="produkt-accordion-header">
-                  Bestellung #<?php echo esc_html($o->order_number ?: $o->id); ?> – <?php echo esc_html(date_i18n('d.m.Y', strtotime($o->created_at))); ?>
-                </button>
-                <div class="produkt-accordion-content">
-                  <?php include PRODUKT_PLUGIN_PATH . 'includes/render-order-details.php'; ?>
+    <div class="customer-detail-grid">
+        <div class="customer-left">
+            <div class="dashboard-card customer-card">
+                <div class="customer-header">
+                    <div class="customer-avatar"><?php echo esc_html($initials); ?></div>
+                    <div class="customer-ident">
+                        <h3 class="customer-name"><?php echo esc_html(trim($first . ' ' . $last)); ?></h3>
+                        <p class="customer-email"><?php echo esc_html($user->user_email); ?></p>
+                    </div>
                 </div>
-              </div>
-            <?php endforeach; ?>
-          <?php endif; ?>
+                <p class="customer-phone">Telefon: <?php echo esc_html($phone ?: '–'); ?></p>
+                <p class="customer-address">Versandadresse: <?php echo esc_html($addr ?: '–'); ?></p>
+                <p class="customer-address">Rechnungsadresse: <?php echo esc_html($addr ?: '–'); ?></p>
+            </div>
+
+            <div class="customer-row">
+                <div class="dashboard-card customer-tech-card">
+                    <h2>Technische Daten</h2>
+                    <p class="card-subline">Technische Informationen zum Nutzer</p>
+                    <p><strong>User Agent:</strong> <?php echo esc_html($last_order->user_agent ?? '–'); ?></p>
+                    <p><strong>IP-Adresse:</strong> <?php echo esc_html($last_order->user_ip ?? '–'); ?></p>
+                </div>
+                <div class="dashboard-card">
+                    <h2>Verlauf</h2>
+                    <p class="card-subline">Benutzerverlauf im Detail</p>
+                    <?php if ($customer_logs) : ?>
+                        <ul class="order-log-list">
+                            <?php foreach ($customer_logs as $log) : ?>
+                                <li><?php echo esc_html(date_i18n('d.m.Y H:i', strtotime($log->created_at)) . ' – ' . $log->event . ($log->message ? ': ' . $log->message : '')); ?></li>
+                            <?php endforeach; ?>
+                        </ul>
+                        <?php if ($total_logs > 5) : ?>
+                            <button type="button" class="icon-btn icon-btn-no-stroke customer-log-load-more" title="Mehr anzeigen" data-offset="5" data-total="<?php echo intval($total_logs); ?>" data-order-ids="<?php echo esc_attr(implode(',', $order_ids)); ?>">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 5c-.6 0-1 .4-1 1v5H6c-.6 0-1 .4-1 1s.4 1 1 1h5v5c0 .6.4 1 1 1s1-.4 1-1v-5h5c.6 0 1-.4 1-1s-.4-1-1-1h-5V6c0-.6-.4-1-1-1z"/></svg>
+                            </button>
+                        <?php endif; ?>
+                    <?php else : ?>
+                        <p>Keine Einträge</p>
+                    <?php endif; ?>
+                </div>
+            </div>
+
+            <div class="dashboard-card">
+                <div class="card-header-flex">
+                    <div>
+                        <h2>Notizen</h2>
+                        <p class="card-subline">Anmerkungen zum Kunden</p>
+                    </div>
+                    <button type="button" class="icon-btn icon-btn-no-stroke customer-note-icon" title="Notiz hinzufügen">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 5c-.6 0-1 .4-1 1v5H6c-.6 0-1 .4-1 1s.4 1 1 1h5v5c0 .6.4 1 1 1s1-.4 1-1v-5h5c.6 0 1-.4 1-1s-.4-1-1-1h-5V6c0-.6-.4-1-1-1z"/></svg>
+                    </button>
+                </div>
+                <div class="customer-notes-section">
+                    <?php foreach ($customer_notes as $note) : ?>
+                        <div class="order-note" data-note-id="<?php echo intval($note->id); ?>">
+                            <div class="note-text"><?php echo esc_html($note->message); ?></div>
+                            <div class="note-date"><?php echo esc_html(date_i18n('d.m.Y H:i', strtotime($note->created_at))); ?></div>
+                            <button type="button" class="icon-btn customer-note-delete-btn" title="Notiz löschen"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 79.9 80.1"><path d="M39.8.4C18,.4.3,18.1.3,40s17.7,39.6,39.6,39.6,39.6-17.7,39.6-39.6S61.7.4,39.8.4ZM39.8,71.3c-17.1,0-31.2-14-31.2-31.2s14.2-31.2,31.2-31.2,31.2,14,31.2,31.2-14.2,31.2-31.2,31.2Z"/><path d="M53,26.9c-1.7-1.7-4.2-1.7-5.8,0l-7.3,7.3-7.3-7.3c-1.7-1.7-4.2-1.7-5.8,0-1.7,1.7-1.7,4.2,0,5.8l7.3,7.3-7.3,7.3c-1.7,1.7-1.7,4.2,0,5.8.8.8,1.9,1.2,2.9,1.2s2.1-.4,2.9-1.2l7.3-7.3,7.3,7.3c.8.8,1.9,1.2,2.9,1.2s2.1-.4,2.9-1.2c1.7-1.7,1.7-4.2,0-5.8l-7.3-7.3,7.3-7.3c1.7-1.7,1.7-4.4,0-5.8h0Z"/></svg></button>
+                        </div>
+                    <?php endforeach; ?>
+                </div>
+                <div id="customer-note-form" class="order-note-form" data-customer-id="<?php echo $user->ID; ?>">
+                    <textarea placeholder="Notiz"></textarea>
+                    <div class="note-actions">
+                        <button type="button" class="button button-primary customer-note-save">Speichern</button>
+                        <button type="button" class="button customer-note-cancel">Abbrechen</button>
+                    </div>
+                </div>
+            </div>
         </div>
-      </div>
+
+        <div class="customer-right">
+            <div class="dashboard-card">
+                <div class="card-header-flex">
+                    <div>
+                        <h2>Bestellübersicht</h2>
+                        <p class="card-subline">Letzte Bestellungen</p>
+                    </div>
+                </div>
+                <?php if ($orders) : ?>
+                <table class="activity-table">
+                    <thead>
+                        <tr>
+                            <th>ID</th>
+                            <th>Produkte</th>
+                            <th>Ausführungen</th>
+                            <th>Extras</th>
+                            <th>Mietzeitraum</th>
+                            <th>Gesamtpreis</th>
+                            <th>Versand</th>
+                            <th>Details</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($orders as $o) : ?>
+                            <tr>
+                                <td>#<?php echo esc_html($o->order_number ?: $o->id); ?></td>
+                                <td><?php echo esc_html($o->category_name); ?></td>
+                                <td><?php echo esc_html($o->variant_name ?: '–'); ?></td>
+                                <td><?php echo esc_html($o->extra_names ?: '–'); ?></td>
+                                <td><?php echo esc_html(date_i18n('d.m.Y', strtotime($o->start_date)) . ' - ' . date_i18n('d.m.Y', strtotime($o->end_date))); ?></td>
+                                <td><?php echo number_format($o->final_price, 2, ',', '.'); ?>€</td>
+                                <td><?php echo esc_html($o->shipping_name ?: '–'); ?><?php if ($o->shipping_cost > 0) : ?> (<?php echo number_format($o->shipping_cost, 2, ',', '.'); ?>€)<?php endif; ?></td>
+                                <td class="details-cell">
+                                    <button type="button" class="icon-btn icon-btn-no-stroke view-details-link" data-order-id="<?php echo esc_attr($o->id); ?>" aria-label="Details">
+                                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 22.1">
+                                            <path d="M16,0C7.2,0,0,4.9,0,11s7.2,11,16,11,16-4.9,16-11S24.8,0,16,0ZM16,20c-7.7,0-14-4-14-9S8.3,2,16,2s14,4,14,9-6.3,9-14,9ZM16,5c-3.3,0-6,2.7-6,6s2.7,6,6,6,6-2.7,6-6-2.7-6-6-6ZM16,15c-2.2,0-4-1.8-4-4s1.8-4,4-4,4,1.8,4,4-1.8,4-4,4Z"/>
+                                        </svg>
+                                    </button>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+                <?php else : ?>
+                    <p>Keine Bestellungen gefunden.</p>
+                <?php endif; ?>
+            </div>
+        </div>
     </div>
 <?php endif; ?>
-</div>
 
+<!-- Sidebar-Overlay für Bestelldetails -->
+<div id="order-details-sidebar" class="order-details-sidebar">
+    <div class="order-details-header">
+        <h3>Bestelldetails</h3>
+        <button class="close-sidebar" aria-label="Schließen">&times;</button>
+    </div>
+    <div class="order-details-content">
+        <p>Lade Details…</p>
+    </div>
+</div>
+<div id="order-details-overlay" class="order-details-overlay"></div>
+</div>

--- a/admin/dashboard/sidebar-order-details.php
+++ b/admin/dashboard/sidebar-order-details.php
@@ -26,16 +26,24 @@ if (!empty($sd) && !empty($ed)) {
     $percent = floor(($elapsed / $total) * 100);
 }
 
+// Status-Text für den Badge ermitteln
+$badge_status = 'In Vermietung';
+if ($percent >= 100) {
+    $badge_status = 'Abgeschlossen';
+} elseif ($percent <= 0) {
+    $badge_status = 'Ausstehend';
+}
+
 // Produkte ermitteln
 $produkte = $order->produkte ?? [$order]; // fallback
 ?>
 
-<div class="sidebar-wrapper">
+<div class="sidebar-wrapper" data-order-id="<?php echo esc_attr($order->id); ?>">
 
     <!-- Header -->
     <div class="sidebar-header">
         <h2>Bestellübersicht</h2>
-        <span class="order-id">#<?php echo esc_html($order->id ?? '–'); ?></span>
+        <span class="order-id">#<?php echo esc_html(!empty($order->order_number) ? $order->order_number : $order->id); ?></span>
     </div>
 
     <!-- Kundeninfo -->
@@ -45,10 +53,17 @@ $produkte = $order->produkte ?? [$order]; // fallback
             <strong><?php echo esc_html($order->customer_name ?? '–'); ?></strong>
             <div class="email"><?php echo esc_html($order->customer_email ?? '–'); ?></div>
         </div>
+        <?php $user = get_user_by('email', $order->customer_email); ?>
         <div class="customer-icons">
-            <span class="icon">@</span>
-            <span class="icon">📞</span>
-            <span class="icon">⚙️</span>
+            <a class="icon-btn icon-btn-no-stroke customer-profile-link" href="<?php echo $user ? admin_url('admin.php?page=produkt-customers&customer=' . $user->ID) : '#'; ?>" title="Kundenprofil">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 85 85.1"><path d="M42.5.4C19.4.4.6,19.1.6,42.2s18.8,41.8,41.8,41.8,41.8-18.8,41.8-41.8S65.5.4,42.5.4ZM18.1,70.2l2.3-4.8,13.9-2.2c1.1-.2,1.9-1,2-2.1l.4-4.3c1.8.9,3.8,1.4,5.8,1.4s4-.5,5.8-1.4l.4,4.3c.1,1.1.9,1.9,2,2.1l13.9,2.2,2.3,4.8c-6.5,5.7-15.1,9.2-24.4,9.2s-17.9-3.5-24.4-9.2h0ZM51.7,20.1c2.7,2.3,4.4,5.7,4.8,9.9,0,.7.5,1.4,1.1,1.8.2.2.9,1.3.9,3.2s-.5,2.7-.8,3.1h0c-1,0-1.9.7-2.2,1.7-2.4,8.1-7.7,13.8-12.9,13.8s-10.5-5.7-12.9-13.8c-.3-1-1.2-1.7-2.2-1.7h0c-.3-.4-.8-1.4-.8-3.1s.7-3.1.9-3.2c.6-.4,1-1,.1-1.8.7-8,6.1-12.9,14-12.9s1.7,0,2.6.2c.3,0,.6,0,.9,0l5.8-1.4c-.3.5-.5,1.1-.8,1.6-.4,1-.1,2.1.7,2.7h0ZM70.4,66.7l-2.1-4.4c-.3-.7-1-1.2-1.7-1.3l-13.3-2.1-.5-5.2c3-2.9,5.3-7,6.7-11.1,2.2-.9,3.7-3.9,3.7-7.5s-.8-4.9-2.1-6.3c-.6-4.4-2.3-8.1-5-10.9,1.1-2.1,2.6-4.2,2.7-4.2.6-.8.6-1.9,0-2.7-.5-.8-1.5-1.2-2.5-1l-10.9,2.7c-.9-.1-1.9-.2-2.8-.2-10.1,0-17.3,6.4-18.6,16.3-1.3,1.4-2.1,3.7-2.1,6.3s1.5,6.6,3.7,7.5c1.4,4.1,3.7,8.1,6.7,11.1l-.5,5.3-13.3,2.1c-.8.1-1.4.6-1.7,1.3l-2.1,4.4c-5.7-6.6-9.2-15.1-9.2-24.5C5.3,21.7,22,5,42.5,5s37.2,16.7,37.2,37.2-3.5,17.9-9.2,24.5h0Z"/></svg>
+            </a>
+            <a class="icon-btn icon-btn-no-stroke" href="mailto:<?php echo esc_attr($order->customer_email); ?>" title="E-Mail senden">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 84.7 66.7"><path d="M70.6.7H14.3C6.9.7.9,6.8.9,14.2v38.1c0,7.4,6,13.4,13.4,13.4h56.3c7.4,0,13.4-6,13.4-13.4V14.2c0-7.4-6-13.4-13.4-13.4ZM78.2,56.5l-17.2-20.4,18.3-16.6v32.7c0,1.5-.4,3-1.1,4.2h0ZM14.3,5.4h56.3c4.5,0,8.2,3.4,8.7,7.8l-36.8,33.4L5.6,13.2c.5-4.4,4.2-7.8,8.7-7.8h0ZM6.7,56.5c-.7-1.3-1.1-2.7-1.1-4.2V19.5l18.3,16.6L6.7,56.5ZM14.3,61c-.9,0-1.7-.1-2.5-.4l12.6-2.9c1.3-.3,2-1.6,1.8-2.8-.3-1.3-1.5-2-2.8-1.8l-9.6,2.2,13.6-16.1,13.5,12.3c.4.4,1,.6,1.6.6s1.1-.2,1.6-.6l13.6-12.3,13.6,16.1-9.6-2.2c-1.3-.3-2.5.5-2.8,1.8-.3,1.3.5,2.5,1.8,2.8l12.6,2.9c-.8.2-1.6.4-2.5.4H14.3h0Z"/></svg>
+            </a>
+            <button type="button" class="icon-btn icon-btn-no-stroke note-icon" title="Notiz hinzufügen">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 81.2 80.7"><path d="M80.5,19.1c0-2.2-.9-4.2-2.4-5.8l-10.3-10.3c-1.5-1.5-3.6-2.4-5.8-2.4s-4.2.8-5.8,2.4l-3.9,3.9c-1.2-.6-2.6-.9-4-.9-2.5,0-4.9,1-6.7,2.8-2.9,2.9-3.5,7.1-1.9,10.6L7.4,51.9s0,0-.1.1c0,0-.1.1-.1.2,0,0,0,.1-.1.2,0,0,0,.1-.1.2,0,0,0,.2,0,.2,0,0,0,.1,0,.2L1,77.4c-.2.8,0,1.6.6,2.2.4.4,1,.7,1.7.7s.4,0,.5,0l24.3-5.8c0,0,.1,0,.2,0,0,0,.2,0,.2,0,0,0,.1,0,.2-.1,0,0,.1,0,.2-.1,0,0,.1-.1.2-.2,0,0,0,0,.1-.1l32.5-32.5c1.2.6,2.6.9,4,.9,2.5,0,4.9-1,6.7-2.8,2.9-2.9,3.5-7.1,1.9-10.6l3.9-3.9c1.5-1.5,2.4-3.6,2.4-5.8h0ZM25.5,66.7l-11.2-11.2c.1,0,.2,0,.4-.1l17.4-6.4-6.7,17.7ZM34.8,43l-18.8,6.9,26.8-26.8,5.9,5.9-13.9,13.9ZM10.4,58.2l12.6,12.6-16.6,4,4-16.6ZM31,65.4l7.2-19.1,13.9-13.9,5.9,5.9-27.1,27.1ZM69.1,36.1s0,0,0,0c-.9.9-2.1,1.4-3.3,1.4s-2.5-.5-3.3-1.4l-17.3-17.3c-1.8-1.8-1.8-4.8,0-6.7.9-.9,2.1-1.4,3.3-1.4s2.5.5,3.3,1.4l17.3,17.3c1.9,1.8,1.9,4.8,0,6.7h0ZM74.9,21.5l-3.5,3.5-15.2-15.2,3.5-3.5c.7-.7,1.5-1,2.5-1s1.8.4,2.5,1l10.3,10.3c.6.6,1,1.5,1,2.5s-.4,1.8-1,2.5h0Z"/></svg>
+            </button>
         </div>
     </div>
 
@@ -59,24 +74,28 @@ $produkte = $order->produkte ?? [$order]; // fallback
             <p><strong>Telefon:</strong> <?php echo esc_html($order->customer_phone); ?></p>
         <?php endif; ?>
 
-        <?php if (!empty($order->customer_street)) : ?>
-            <p><strong>Adresse:</strong>
-                <?php
-                echo esc_html($order->customer_street);
-                if (!empty($order->customer_postal) || !empty($order->customer_city)) {
-                    echo ', ' . esc_html(trim($order->customer_postal . ' ' . $order->customer_city));
-                }
-                if (!empty($order->customer_country)) {
-                    echo ', ' . esc_html($order->customer_country);
-                }
-                ?>
-            </p>
+        <?php
+            $addr_parts = [];
+            if (!empty($order->customer_street)) {
+                $addr_parts[] = $order->customer_street;
+            }
+            if (!empty($order->customer_postal) || !empty($order->customer_city)) {
+                $addr_parts[] = trim(($order->customer_postal ?: '') . ' ' . ($order->customer_city ?: ''));
+            }
+            if (!empty($order->customer_country)) {
+                $addr_parts[] = $order->customer_country;
+            }
+            $full_address = implode(', ', array_filter($addr_parts));
+        ?>
+        <?php if ($full_address) : ?>
+            <p><strong>Rechnung:</strong> <?php echo esc_html($full_address); ?></p>
+            <p><strong>Versand:</strong> <?php echo esc_html($full_address); ?></p>
         <?php endif; ?>
     </div>
 
     <!-- Mietzeitraum -->
     <div class="rental-period-box">
-        <div class="badge-status">In Progress</div>
+        <div class="badge-status"><?php echo esc_html($badge_status); ?></div>
         <h3>Mietzeitraum</h3>
         <div class="rental-progress-number"><?php echo $percent; ?>%</div>
         <div class="rental-progress">
@@ -110,7 +129,7 @@ $produkte = $order->produkte ?? [$order]; // fallback
                     <?php if (!empty($p->extra_names)) : ?>
                         <div>Extras: <?php echo esc_html($p->extra_names); ?></div>
                     <?php endif; ?>
-                    <div>Miettage: <?php echo esc_html($p->dauer_text ?? '–'); ?></div>
+                    <div>Miettage: <?php echo esc_html($days !== null ? $days : ($p->dauer_text ?? '–')); ?></div>
                 </div>
 
                 <div class="product-price">
@@ -132,5 +151,50 @@ $produkte = $order->produkte ?? [$order]; // fallback
                 <?php endif; ?>
             </p>
         <?php endif; ?>
+    </div>
+
+    <div class="orders-accordion">
+        <div class="produkt-accordion-item">
+            <button type="button" class="produkt-accordion-header">Technische Daten</button>
+            <div class="produkt-accordion-content">
+                <p><strong>User Agent:</strong> <?php echo esc_html($order->user_agent ?: '–'); ?></p>
+                <p><strong>IP-Adresse:</strong> <?php echo esc_html($order->user_ip ?: '–'); ?></p>
+            </div>
+        </div>
+        <div class="produkt-accordion-item">
+            <button type="button" class="produkt-accordion-header">Verlauf</button>
+            <div class="produkt-accordion-content">
+                <?php if (!empty($order_logs)) : ?>
+                    <ul class="order-log-list">
+                        <?php foreach ($order_logs as $log) : ?>
+                            <li><?php echo esc_html(date_i18n('d.m.Y H:i', strtotime($log->created_at))); ?> – <?php echo esc_html($log->event . ($log->message ? ': ' . $log->message : '')); ?></li>
+                        <?php endforeach; ?>
+                    </ul>
+                <?php else : ?>
+                    <p>Keine Einträge</p>
+                <?php endif; ?>
+            </div>
+        </div>
+    </div>
+    <div class="order-notes-section">
+        <h3>Notizen</h3>
+        <?php if (!empty($order_notes)) : ?>
+            <?php foreach ($order_notes as $note) : ?>
+                <div class="order-note" data-note-id="<?php echo intval($note->id); ?>">
+                    <div class="note-text"><?php echo esc_html($note->message); ?></div>
+                    <div class="note-date"><?php echo esc_html(date_i18n('d.m.Y H:i', strtotime($note->created_at))); ?></div>
+                    <button type="button" class="icon-btn note-delete-btn" title="Notiz löschen">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 79.9 80.1"><path d="M39.8.4C18,.4.3,18.1.3,40s17.7,39.6,39.6,39.6,39.6-17.7,39.6-39.6S61.7.4,39.8.4ZM39.8,71.3c-17.1,0-31.2-14-31.2-31.2s14.2-31.2,31.2-31.2,31.2,14,31.2,31.2-14.2,31.2-31.2,31.2Z"/><path d="M53,26.9c-1.7-1.7-4.2-1.7-5.8,0l-7.3,7.3-7.3-7.3c-1.7-1.7-4.2-1.7-5.8,0-1.7,1.7-1.7,4.2,0,5.8l7.3,7.3-7.3,7.3c-1.7,1.7-1.7,4.2,0,5.8.8.8,1.9,1.2,2.9,1.2s2.1-.4,2.9-1.2l7.3-7.3,7.3,7.3c.8.8,1.9,1.2,2.9,1.2s2.1-.4,2.9-1.2c1.7-1.7,1.7-4.2,0-5.8l-7.3-7.3,7.3-7.3c1.7-1.7,1.7-4.4,0-5.8h0Z"/></svg>
+                    </button>
+                </div>
+            <?php endforeach; ?>
+        <?php endif; ?>
+    </div>
+    <div id="order-note-form" class="order-note-form">
+        <textarea placeholder="Notiz"></textarea>
+        <div class="note-actions">
+            <button type="button" class="button button-primary note-save">Speichern</button>
+            <button type="button" class="button note-cancel">Abbrechen</button>
+        </div>
     </div>
 </div>

--- a/admin/extras-page.php
+++ b/admin/extras-page.php
@@ -281,84 +281,148 @@ if ($edit_item) {
 }
 ?>
 
-<div class="wrap">
-    <div class="produkt-admin-card">
-        <!-- Kompakter Header -->
-        <div class="produkt-admin-header-compact">
-        <div class="produkt-admin-logo-compact">🎁</div>
-        <div class="produkt-admin-title-compact">
-            <h1>Extras verwalten</h1>
-            <p>Zusatzoptionen mit Bildern</p>
+<div class="produkt-admin dashboard-wrapper">
+    <h1 class="dashboard-greeting"><?php echo pv_get_time_greeting(); ?>, <?php echo esc_html(wp_get_current_user()->display_name); ?> 👋</h1>
+    <p class="dashboard-subline">Extras verwalten</p>
+
+<?php if ($active_tab === 'list'): ?>
+    <div class="dashboard-grid">
+        <div class="dashboard-left">
+            <div class="dashboard-card card-product-selector">
+                <h2>Produkt auswählen</h2>
+                <p class="card-subline">Für welches Produkt möchten Sie ein Extra bearbeiten?</p>
+                <form method="get" action="" class="produkt-category-selector" style="background:none;border:none;padding:0;">
+                    <input type="hidden" name="page" value="produkt-extras">
+                    <input type="hidden" name="tab" value="<?php echo esc_attr($active_tab); ?>">
+                    <select name="category" id="category-select" onchange="this.form.submit()">
+                        <?php foreach ($categories as $category): ?>
+                            <option value="<?php echo $category->id; ?>" <?php selected($selected_category, $category->id); ?>><?php echo esc_html($category->name); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                    <noscript><input type="submit" value="Wechseln" class="button"></noscript>
+                </form>
+                <?php if ($current_category): ?>
+                <div class="selected-product-preview">
+                    <?php if (!empty($current_category->default_image)): ?>
+                        <img src="<?php echo esc_url($current_category->default_image); ?>" alt="<?php echo esc_attr($current_category->name); ?>">
+                    <?php else: ?>
+                        <div class="placeholder-icon">🏷️</div>
+                    <?php endif; ?>
+                    <div class="tile-overlay"><span><?php echo esc_html($current_category->name); ?></span></div>
+                </div>
+                <?php endif; ?>
+            </div>
+        </div>
+        <div class="dashboard-right">
+            <div class="dashboard-row">
+                <div class="dashboard-card card-new-product">
+                    <h2>Neues Extra</h2>
+                    <p class="card-subline">Extra erstellen</p>
+                    <a href="<?php echo admin_url('admin.php?page=produkt-extras&category=' . $selected_category . '&tab=add'); ?>" class="icon-btn add-product-btn" aria-label="Hinzufügen">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80.3">
+                            <path d="M12.1,12c-15.4,15.4-15.4,40.4,0,55.8,7.7,7.7,17.7,11.7,27.9,11.7s20.2-3.8,27.9-11.5c15.4-15.4,15.4-40.4,0-55.8-15.4-15.6-40.4-15.6-55.8-.2h0ZM62.1,62c-12.1,12.1-31.9,12.1-44.2,0-12.1-12.1-12.1-31.9,0-44.2,12.1-12.1,31.9-12.1,44.2,0,12.1,12.3,12.1,31.9,0,44.2Z"/>
+                            <path d="M54.6,35.7h-10.4v-10.4c0-2.3-1.9-4.2-4.2-4.2s-4.2,1.9-4.2,4.2v10.4h-10.4c-2.3,0-4.2,1.9-4.2,4.2s1.9,4.2,4.2,4.2h10.4v10.4c0,2.3,1.9,4.2,4.2,4.2s4.2-1.9,4.2-4.2v-10.4h10.4c2.3,0,4.2-1.9,4.2-4.2s-1.9-4.2-4.2-4.2Z"/>
+                        </svg>
+                    </a>
+                </div>
+                <div class="dashboard-card card-quicknav">
+                    <h2>Schnellnavigation</h2>
+                    <p class="card-subline">Direkt zu wichtigen Listen</p>
+                    <div class="quicknav-grid">
+                        <div class="quicknav-card">
+                            <a href="admin.php?page=produkt-verleih">
+                                <div class="quicknav-inner">
+                                    <div class="quicknav-icon-circle">🏠</div>
+                                    <div class="quicknav-label">Dashboard</div>
+                                </div>
+                            </a>
+                        </div>
+                        <div class="quicknav-card">
+                            <a href="admin.php?page=produkt-categories">
+                                <div class="quicknav-inner">
+                                    <div class="quicknav-icon-circle">🧩</div>
+                                    <div class="quicknav-label">Kategorien</div>
+                                </div>
+                            </a>
+                        </div>
+                        <div class="quicknav-card">
+                            <a href="admin.php?page=produkt-products">
+                                <div class="quicknav-inner">
+                                    <div class="quicknav-icon-circle">🏷️</div>
+                                    <div class="quicknav-label">Produkte</div>
+                                </div>
+                            </a>
+                        </div>
+                        <div class="quicknav-card">
+                            <a href="admin.php?page=produkt-variants&category=<?php echo $selected_category; ?>">
+                                <div class="quicknav-inner">
+                                    <div class="quicknav-icon-circle">🧩</div>
+                                    <div class="quicknav-label">Ausführungen</div>
+                                </div>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="dashboard-card">
+                <div class="card-header-flex">
+                    <div>
+                        <h2>Extras</h2>
+                        <p class="card-subline">Verfügbare Extras des Produkts</p>
+                    </div>
+                </div>
+                <table class="activity-table">
+                    <thead>
+                        <tr>
+                            <th>Bild</th>
+                            <th>Name</th>
+                            <th>Preis</th>
+                            <th>Aktionen</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php $modus = get_option('produkt_betriebsmodus', 'miete'); ?>
+                        <?php foreach ($extras as $extra): ?>
+                            <tr>
+                                <td>
+                                    <?php if (!empty($extra->image_url)): ?>
+                                        <img src="<?php echo esc_url($extra->image_url); ?>" style="width:60px;height:60px;object-fit:cover;border-radius:4px;" alt="<?php echo esc_attr($extra->name); ?>">
+                                    <?php else: ?>
+                                        <div style="width:60px;height:60px;background:#f0f0f0;border-radius:4px;display:flex;align-items:center;justify-content:center;">🎁</div>
+                                    <?php endif; ?>
+                                </td>
+                                <td><?php echo esc_html($extra->name); ?></td>
+                                <td>
+                                    <?php if ($modus === 'kauf'): ?>
+                                        <?php echo number_format($extra->price_sale ?? 0, 2, ',', '.'); ?>€
+                                    <?php else: ?>
+                                        <?php echo number_format($extra->price_rent ?? $extra->price, 2, ',', '.'); ?>€
+                                    <?php endif; ?>
+                                </td>
+                                <td>
+                                    <button type="button" class="icon-btn" aria-label="Bearbeiten" onclick="window.location.href='?page=produkt-extras&category=<?php echo $selected_category; ?>&tab=edit&edit=<?php echo $extra->id; ?>'">
+                                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80.8 80.1">
+                                            <path d="M54.7,4.8l-31.5,31.7c-.6.6-1,1.5-1.2,2.3l-3.3,18.3c-.2,1.2.2,2.7,1.2,3.8.8.8,1.9,1.2,2.9,1.2h.8l18.3-3.3c.8-.2,1.7-.6,2.3-1.2l31.7-31.7c5.8-5.8,5.8-15.2,0-21-6-5.8-15.4-5.8-21.2,0h0ZM69.9,19.8l-30.8,30.8-11,1.9,2.1-11.2,30.6-30.6c2.5-2.5,6.7-2.5,9.2,0,2.5,2.7,2.5,6.7,0,9.2Z"/>
+                                            <path d="M5.1,79.6h70.8c2.3,0,4.2-1.9,4.2-4.2v-35.4c0-2.3-1.9-4.2-4.2-4.2s-4.2,1.9-4.2,4.2v31.2H9.2V8.8h31.2c2.3,0,4.2-1.9,4.2-4.2s-1.9-4.2-4.2-4.2H5.1c-2.3,0-4.2,1.9-4.2,4.2v70.8c0,2.3,1.9,4.2,4.2,4.2h0Z"/>
+                                        </svg>
+                                    </button>
+                                    <button type="button" class="icon-btn" onclick="if(confirm('Wirklich löschen?')){window.location.href='?page=produkt-extras&category=<?php echo $selected_category; ?>&delete=<?php echo $extra->id; ?>&fw_nonce=<?php echo wp_create_nonce('produkt_admin_action'); ?>';}" aria-label="Löschen">
+                                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 79.9 80.1">
+                                            <path d="M39.8.4C18,.4.3,18.1.3,40s17.7,39.6,39.6,39.6,39.6-17.7,39.6-39.6S61.7.4,39.8.4ZM39.8,71.3c-17.1,0-31.2-14-31.2-31.2s14.2-31.2,31.2-31.2,31.2,14,31.2,31.2-14.2,31.2-31.2,31.2Z"/>
+                                            <path d="M53,26.9c-1.7-1.7-4.2-1.7-5.8,0l-7.3,7.3-7.3-7.3c-1.7-1.7-4.2-1.7-5.8,0-1.7,1.7-1.7,4.2,0,5.8l7.3,7.3-7.3,7.3c-1.7,1.7-1.7,4.2,0,5.8.8.8,1.9,1.2,2.9,1.2s2.1-.4,2.9-1.2l7.3-7.3,7.3,7.3c.8.8,1.9,1.2,2.9,1.2s2.1-.4,2.9-1.2c1.7-1.7,1.7-4.2,0-5.8l-7.3-7.3,7.3-7.3c1.7-1.7,1.7-4.4,0-5.8h0Z"/>
+                                        </svg>
+                                    </button>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
-    
-    <!-- Breadcrumb Navigation -->
-    <div class="produkt-breadcrumb">
-        <a href="<?php echo admin_url('admin.php?page=produkt-verleih'); ?>">Dashboard</a> 
-        <span>→</span> 
-        <strong>Extras</strong>
-    </div>
-    
-    <!-- Category Selection -->
-    <div class="produkt-category-selector">
-        <form method="get" action="">
-            <input type="hidden" name="page" value="produkt-extras">
-            <input type="hidden" name="tab" value="<?php echo esc_attr($active_tab); ?>">
-            <label for="category-select"><strong>🏷️ Produkt:</strong></label>
-            <select name="category" id="category-select" onchange="this.form.submit()">
-                <?php foreach ($categories as $category): ?>
-                <option value="<?php echo $category->id; ?>" <?php selected($selected_category, $category->id); ?>>
-                    <?php echo esc_html($category->name); ?>
-                </option>
-                <?php endforeach; ?>
-            </select>
-            <noscript><input type="submit" value="Wechseln" class="button"></noscript>
-        </form>
-        
-        <?php if ($current_category): ?>
-        <div class="produkt-category-info">
-            <code>[produkt_product category="<?php echo esc_html($current_category->shortcode); ?>"]</code>
-        </div>
-        <?php endif; ?>
-    </div>
-    
-    <!-- Tab Navigation -->
-    <div class="produkt-tab-nav">
-        <a href="<?php echo admin_url('admin.php?page=produkt-extras&category=' . $selected_category . '&tab=list'); ?>" 
-           class="produkt-tab <?php echo $active_tab === 'list' ? 'active' : ''; ?>">
-            📋 Übersicht
-        </a>
-        <a href="<?php echo admin_url('admin.php?page=produkt-extras&category=' . $selected_category . '&tab=add'); ?>" 
-           class="produkt-tab <?php echo $active_tab === 'add' ? 'active' : ''; ?>">
-            ➕ Neues Extra
-        </a>
-        <?php if ($edit_item): ?>
-        <a href="<?php echo admin_url('admin.php?page=produkt-extras&category=' . $selected_category . '&tab=edit&edit=' . $edit_item->id); ?>" 
-           class="produkt-tab <?php echo $active_tab === 'edit' ? 'active' : ''; ?>">
-            ✏️ Bearbeiten
-        </a>
-        <?php endif; ?>
-    </div>
-    
-    <!-- Tab Content -->
-    <div class="produkt-tab-content">
-        <?php
-        switch ($active_tab) {
-            case 'add':
-                include PRODUKT_PLUGIN_PATH . 'admin/tabs/extras-add-tab.php';
-                break;
-            case 'edit':
-                if ($edit_item) {
-                    include PRODUKT_PLUGIN_PATH . 'admin/tabs/extras-edit-tab.php';
-                } else {
-                    include PRODUKT_PLUGIN_PATH . 'admin/tabs/extras-list-tab.php';
-                }
-                break;
-            case 'list':
-            default:
-                include PRODUKT_PLUGIN_PATH . 'admin/tabs/extras-list-tab.php';
-        }
-        ?>
-    </div>
-    </div>
+<?php elseif ($active_tab === 'add'): ?>
+    <?php include PRODUKT_PLUGIN_PATH . 'admin/tabs/extras-add-tab.php'; ?>
+<?php elseif ($active_tab === 'edit' && $edit_item): ?>
+    <?php include PRODUKT_PLUGIN_PATH . 'admin/tabs/extras-edit-tab.php'; ?>
+<?php endif; ?>
 </div>

--- a/admin/main-page.php
+++ b/admin/main-page.php
@@ -51,7 +51,7 @@ $plugin_name = $branding_result ? esc_html($branding_result->setting_value) : 'H
 
 <div class="produkt-admin dashboard-wrapper">
 
-    <h1 class="dashboard-greeting">Hallo, <?php echo esc_html(wp_get_current_user()->display_name); ?> 👋</h1>
+    <h1 class="dashboard-greeting"><?php echo pv_get_time_greeting(); ?>, <?php echo esc_html(wp_get_current_user()->display_name); ?> 👋</h1>
     <p class="dashboard-subline">Willkommen in Ihrem Dashboard für Mietprodukte.</p>
 
     <div class="dashboard-grid">

--- a/admin/orders-page.php
+++ b/admin/orders-page.php
@@ -24,106 +24,70 @@ foreach ($branding_results as $result) {
     $branding[$result->setting_key] = $result->setting_value;
 }
 $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
+
+// Search term for filtering
+$search_term = isset($search_term) ? $search_term : (isset($_GET['s']) ? sanitize_text_field($_GET['s']) : '');
 ?>
 
-<div class="wrap" id="produkt-admin-orders">
-    <div class="produkt-admin-card">
-        <div class="produkt-admin-header-compact">
-            <div class="produkt-admin-logo-compact">
-                <span class="dashicons dashicons-clipboard"></span>
-            </div>
-            <div class="produkt-admin-title-compact">
-                <h1>Bestellungen</h1>
-                <p>Übersicht aller Kundenbestellungen mit detaillierten Produktinformationen</p>
-            </div>
-        </div>
-    
-    
-    <!-- Filter Section -->
-    <div class="orders-filter-box">
-        <h3>🔍 Filter & Zeitraum</h3>
-        <form method="get" action="" class="orders-filter-form">
-            <input type="hidden" name="page" value="produkt-orders">
-            
-            <div>
-                <label for="category-select"><strong>Produkt:</strong></label>
-                <select name="category" id="category-select">
-                    <option value="0" <?php selected($selected_category, 0); ?>>Alle Produkte</option>
-                    <?php foreach ($categories as $category): ?>
-                    <option value="<?php echo $category->id; ?>" <?php selected($selected_category, $category->id); ?>>
-                        <?php echo esc_html($category->name); ?>
-                    </option>
-                    <?php endforeach; ?>
-                </select>
-            </div>
-            
-            <div>
-                <label for="date-from"><strong>Von:</strong></label>
-                <input type="date" name="date_from" id="date-from" value="<?php echo esc_attr($date_from); ?>">
-            </div>
-            
-            <div>
-                <label for="date-to"><strong>Bis:</strong></label>
-                <input type="date" name="date_to" id="date-to" value="<?php echo esc_attr($date_to); ?>">
-            </div>
-            
-            <input type="submit" value="Filter anwenden" class="button button-primary">
-        </form>
-        
-        <?php if ($current_category): ?>
-        <div class="current-category-box">
-            <strong>📝 Aktuelle Produkt:</strong> <?php echo esc_html($current_category->name); ?>
-            <code>[produkt_product category="<?php echo esc_html($current_category->shortcode); ?>"]</code>
-        </div>
-        <?php endif; ?>
-    </div>
-    
-    <!-- Summary Statistics -->
-    <div class="produkt-summary-grid">
-        <div class="produkt-summary-card">
-            <h3>📋 Gesamt-Bestellungen</h3>
-            <div class="produkt-summary-value summary-green">
-                <?php echo number_format($total_orders); ?>
-            </div>
-            <p class="produkt-summary-note">Im gewählten Zeitraum</p>
-        </div>
+<div class="produkt-admin dashboard-wrapper">
+    <h1 class="dashboard-greeting"><?php echo pv_get_time_greeting(); ?>, <?php echo esc_html(wp_get_current_user()->display_name); ?> 👋</h1>
+    <p class="dashboard-subline">Bestellungen verwalten</p>
 
-        <div class="produkt-summary-card">
-            <h3>💰 Gesamt-Umsatz</h3>
-            <div class="produkt-summary-value summary-gray">
-                <?php echo number_format($total_revenue, 2, ',', '.'); ?>€
+    <div class="h2-rental-card">
+        <h2>Statistik</h2>
+        <p class="card-subline">Kennzahlen zum gewählten Zeitraum</p>
+        <div class="orders-info-grid-tight">
+            <div class="product-info-box bg-pastell-orange">
+                <span class="label">Gesamt-Umsatz</span>
+                <strong class="value orders-stat-value">€ <?php echo number_format($total_revenue, 2, ',', '.'); ?></strong>
             </div>
-            <p class="produkt-summary-note">Monatlicher Mietumsatz</p>
-        </div>
-
-        <div class="produkt-summary-card">
-            <h3>📊 Durchschnittswert</h3>
-            <div class="produkt-summary-value summary-red">
-                <?php echo number_format($avg_order_value, 2, ',', '.'); ?>€
+            <div class="product-info-box bg-pastell-mint">
+                <span class="label">Durchschnitt</span>
+                <strong class="value orders-stat-value">€ <?php echo number_format($avg_order_value, 2, ',', '.'); ?></strong>
             </div>
-            <p class="produkt-summary-note">Pro Bestellung</p>
-        </div>
-
-        <div class="produkt-summary-card">
-            <h3>📅 Zeitraum</h3>
-            <div class="produkt-summary-range">
-                <?php echo date('d.m.Y', strtotime($date_from)); ?><br>
-                <small>bis</small><br>
-                <?php echo date('d.m.Y', strtotime($date_to)); ?>
+            <div class="product-info-box bg-pastell-gruen">
+                <span class="label">Zeitraum</span>
+                <strong class="value orders-stat-value"><?php echo date('d.m.', strtotime($date_from)); ?>–<?php echo date('d.m.', strtotime($date_to)); ?></strong>
+            </div>
+            <div class="product-info-box bg-pastell-gelb">
+                <span class="label">Bestellungen</span>
+                <strong class="value orders-stat-value"><?php echo intval($total_orders); ?></strong>
             </div>
         </div>
     </div>
+
+    <div class="h2-rental-card">
+                <div class="card-header-flex">
+                    <div>
+                        <h2>Bestellübersicht</h2>
+                        <p class="card-subline">Kundenaufträge ansehen</p>
+                    </div>
+                    <form method="get" class="produkt-filter-form product-search-bar">
+                        <input type="hidden" name="page" value="produkt-orders">
+                        <div class="search-input-wrapper">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="search-icon">
+                                <path d="M10 2a8 8 0 105.3 14.1l4.3 4.3a1 1 0 101.4-1.4l-4.3-4.3A8 8 0 0010 2zm0 2a6 6 0 110 12 6 6 0 010-12z"/>
+                            </svg>
+                            <input type="text" name="s" placeholder="Suchen" value="<?php echo esc_attr($search_term); ?>">
+                        </div>
+                        <select name="category">
+                            <option value="0" <?php selected($selected_category, 0); ?>>Alle Produkte</option>
+                            <?php foreach ($categories as $category): ?>
+                                <option value="<?php echo $category->id; ?>" <?php selected($selected_category, $category->id); ?>><?php echo esc_html($category->name); ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                        <input type="date" name="date_from" value="<?php echo esc_attr($date_from); ?>">
+                        <input type="date" name="date_to" value="<?php echo esc_attr($date_to); ?>">
+                        <button type="submit" class="icon-btn filter-submit-btn" aria-label="Filtern">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 22.1">
+                                <path d="M16,0C7.2,0,0,4.9,0,11s7.2,11,16,11,16-4.9,16-11S24.8,0,16,0ZM16,20c-7.7,0-14-4-14-9S8.3,2,16,2s14,4,14,9-6.3,9-14,9ZM16,5c-3.3,0-6,2.7-6,6s2.7,6,6,6,6-2.7,6-6-2.7-6-6-6ZM16,15c-2.2,0-4-1.8-4-4s1.8-4,4-4,4,1.8,4,4-1.8,4-4,4Z"/>
+                            </svg>
+                        </button>
+                    </form>
+                </div>
     
     <!-- Orders Table -->
-    <div class="orders-table-container">
-        <h3>📋 Bestellübersicht</h3>
-        <?php if (!empty($orders)): ?>
-        <div class="orders-bulk-actions">
-            <button type="button" class="button" onclick="toggleSelectAll()">Alle auswählen</button>
-            <button type="button" class="button" onclick="deleteSelected()" class="text-red">Ausgewählte löschen</button>
-        </div>
-        <?php endif; ?>
-        
+    <div>
         <?php if (empty($orders)): ?>
         <div class="orders-empty">
             <p class="orders-empty-message">Keine Bestellungen im gewählten Zeitraum gefunden.</p>
@@ -131,11 +95,19 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
         </div>
         <?php else: ?>
         
-        <div class="table-responsive">
-            <table class="wp-list-table widefat fixed striped">
+        <form method="post" action="?page=produkt-orders&category=<?php echo $selected_category; ?>&date_from=<?php echo $date_from; ?>&date_to=<?php echo $date_to; ?>&s=<?php echo urlencode($search_term); ?>">
+        <table class="activity-table">
                 <thead>
                     <tr>
-                        <th class="col-checkbox"><input type="checkbox" id="select-all-orders"></th>
+                        <th class="col-checkbox">
+                            <input type="checkbox" id="select-all-orders">
+                            <button type="submit" class="icon-btn bulk-delete-btn" onclick="return confirm('Ausgewählte Bestellungen wirklich löschen?');" aria-label="Ausgewählte löschen">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 79.9 80.1">
+                                    <path d="M39.8.4C18,.4.3,18.1.3,40s17.7,39.6,39.6,39.6,39.6-17.7,39.6-39.6S61.7.4,39.8.4ZM39.8,71.3c-17.1,0-31.2-14-31.2-31.2s14.2-31.2,31.2-31.2,31.2,14,31.2,31.2-14.2,31.2-31.2,31.2Z"/>
+                                    <path d="M53,26.9c-1.7-1.7-4.2-1.7-5.8,0l-7.3,7.3-7.3-7.3c-1.7-1.7-4.2-1.7-5.8,0-1.7,1.7-1.7,4.2,0,5.8l7.3,7.3-7.3,7.3c-1.7,1.7-1.7,4.2,0,5.8.8.8,1.9,1.2,2.9,1.2s2.1-.4,2.9-1.2l7.3-7.3,7.3,7.3c.8.8,1.9,1.2,2.9,1.2s2.1-.4,2.9-1.2c1.7-1.7,1.7-4.2,0-5.8l-7.3-7.3,7.3-7.3c1.7-1.7,1.7-4.4,0-5.8h0Z"/>
+                                </svg>
+                            </button>
+                        </th>
                         <th class="col-id">ID</th>
                         <th class="col-date">Datum</th>
                         <th>Kunde</th>
@@ -143,7 +115,6 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
                         <th>Versandadresse</th>
                         <th>Rechnungsadresse</th>
                         <th class="col-type">Produkttyp</th>
-                        <th>Produktdetails</th>
                         <th class="col-price">Preis</th>
                         <th class="col-discount">Rabatt</th>
                         <th class="col-status">Status</th>
@@ -151,9 +122,11 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
                     </tr>
                 </thead>
                 <tbody>
-                    <?php foreach ($orders as $order): ?>
-                    <tr>
-                        <td><input type="checkbox" class="order-checkbox" value="<?php echo $order->id; ?>"></td>
+                    <?php foreach ($orders as $order):
+                        $due = ($order->mode === 'kauf' && $order->end_date && $order->inventory_reverted == 0 && $order->end_date <= current_time('Y-m-d'));
+                    ?>
+                    <tr<?php echo $due ? ' class="pending-return"' : ''; ?>>
+                        <td><input type="checkbox" class="order-checkbox" name="delete_orders[]" value="<?php echo $order->id; ?>"></td>
                         <td><strong>#<?php echo !empty($order->order_number) ? $order->order_number : $order->id; ?></strong></td>
                         <td>
                             <?php echo date('d.m.Y', strtotime($order->created_at)); ?><br>
@@ -197,34 +170,6 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
                         ?>
                         <td><?php echo esc_html($type); ?></td>
                         <td>
-                            <div class="order-details-info">
-                                <strong><?php echo esc_html($order->category_name); ?></strong><br>
-                                <span class="text-gray">📦 <?php echo esc_html($order->variant_name); ?></span><br>
-                                <span class="text-gray">🎁 <?php echo esc_html($order->extra_names); ?></span><br>
-                                <?php if ($type === 'Verkauf'): ?>
-                                    <span class="text-gray">⏰ Miettage: <?php echo esc_html($order->rental_days ?? $order->duration_name); ?></span><br>
-                                <?php else: ?>
-                                    <span class="text-gray">⏰ Mietdauer: <?php echo esc_html($order->duration_name); ?></span><br>
-                                <?php endif; ?>
-                                <?php list($sd,$ed) = pv_get_order_period($order); ?>
-                                <?php if ($sd && $ed): ?>
-                                    <span class="text-gray">📅 <?php echo date('d.m.Y', strtotime($sd)); ?> - <?php echo date('d.m.Y', strtotime($ed)); ?></span><br>
-                                <?php endif; ?>
-                                
-                                <?php if ($order->condition_name): ?>
-                                    <span class="text-gray">🔄 <?php echo esc_html($order->condition_name); ?></span><br>
-                                <?php endif; ?>
-                                
-                                <?php if ($order->product_color_name): ?>
-                                    <span class="text-gray">🎨 Produkt: <?php echo esc_html($order->product_color_name); ?></span><br>
-                                <?php endif; ?>
-                                
-                                <?php if ($order->frame_color_name): ?>
-                                    <span class="text-gray">🖼️ Gestell: <?php echo esc_html($order->frame_color_name); ?></span><br>
-                                <?php endif; ?>
-                            </div>
-                        </td>
-                        <td>
                             <strong class="order-price">
                                 <?php echo number_format($order->final_price, 2, ',', '.'); ?>€
                             </strong><br>
@@ -248,183 +193,57 @@ $primary_color = $branding['admin_color_primary'] ?? '#5f7f5f';
                             <?php elseif ($order->status === 'gekündigt'): ?>
                                 <span class="badge badge-danger">Gekündigt</span>
                             <?php else: ?>
-                                <span class="badge badge-success">Abgeschlossen</span>
+                                <span class="badge badge-success">Bezahlt</span>
                             <?php endif; ?>
                         </td>
                         <td>
-                            <button type="button" class="button button-small" onclick="showOrderDetails(<?php echo $order->id; ?>)" title="Details anzeigen">
-                                👁️ Details
+                            <button type="button" class="icon-btn icon-btn-no-stroke view-details-link" data-order-id="<?php echo $order->id; ?>" aria-label="Details">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 22.1">
+                                    <path d="M16,0C7.2,0,0,4.9,0,11s7.2,11,16,11,16-4.9,16-11S24.8,0,16,0ZM16,20c-7.7,0-14-4-14-9S8.3,2,16,2s14,4,14,9-6.3,9-14,9ZM16,5c-3.3,0-6,2.7-6,6s2.7,6,6,6,6-2.7,6-6-2.7-6-6-6ZM16,15c-2.2,0-4-1.8-4-4s1.8-4,4-4,4,1.8,4,4-1.8,4-4,4Z"/>
+                                </svg>
                             </button>
-                            <?php
-                                $due = ($order->mode === 'kauf' && $order->end_date && $order->inventory_reverted == 0 && $order->end_date <= current_time('Y-m-d'));
-                                if ($due):
-                            ?>
-                                <br><br>
-                                <button type="button" class="button button-small produkt-return-confirm" data-id="<?php echo $order->id; ?>">Alles i.O.</button>
+                            <?php if ($due): ?>
+                                <button type="button" class="icon-btn produkt-return-confirm" data-id="<?php echo $order->id; ?>" aria-label="Bestätigung">
+                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80.3 80.3">
+                                        <path d="M32,53.4c.8.8,1.9,1.2,2.9,1.2s2.1-.4,2.9-1.2l20.8-20.8c1.7-1.7,1.7-4.2,0-5.8-1.7-1.7-4.2-1.7-5.8,0l-17.9,17.9-7.7-7.7c-1.7-1.7-4.2-1.7-5.8,0-1.7,1.7-1.7,4.2,0,5.8l10.6,10.6Z"/>
+                                        <path d="M40.2,79.6c21.9,0,39.6-17.7,39.6-39.6S62,.5,40.2.5.6,18.2.6,40.1s17.7,39.6,39.6,39.6ZM40.2,8.8c17.1,0,31.2,14,31.2,31.2s-14,31.2-31.2,31.2-31.2-14.2-31.2-31.2,14.2-31.2,31.2-31.2Z"/>
+                                    </svg>
+                                </button>
                             <?php endif; ?>
-                            <br><br>
-                            <a href="<?php echo admin_url('admin.php?page=produkt-orders&category=' . $selected_category . '&delete_order=' . $order->id . '&date_from=' . $date_from . '&date_to=' . $date_to); ?>"
-                               class="button button-small text-red"
-                               onclick="return confirm('Sind Sie sicher, dass Sie diese Bestellung löschen möchten?\n\nBestellung #<?php echo !empty($order->order_number) ? $order->order_number : $order->id; ?> wird unwiderruflich gelöscht!')">
-                                🗑️ Löschen
-                            </a>
+                            <button type="button" class="icon-btn" onclick="if(confirm('Wirklich löschen?')){window.location.href='?page=produkt-orders&category=<?php echo $selected_category; ?>&delete_order=<?php echo $order->id; ?>&date_from=<?php echo $date_from; ?>&date_to=<?php echo $date_to; ?>';}" aria-label="Löschen">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 79.9 80.1">
+                                    <path d="M39.8.4C18,.4.3,18.1.3,40s17.7,39.6,39.6,39.6,39.6-17.7,39.6-39.6S61.7.4,39.8.4ZM39.8,71.3c-17.1,0-31.2-14-31.2-31.2s14.2-31.2,31.2-31.2,31.2,14,31.2,31.2-14.2,31.2-31.2,31.2Z"/>
+                                    <path d="M53,26.9c-1.7-1.7-4.2-1.7-5.8,0l-7.3,7.3-7.3-7.3c-1.7-1.7-4.2-1.7-5.8,0-1.7,1.7-1.7,4.2,0,5.8l7.3,7.3-7.3,7.3c-1.7,1.7-1.7,4.2,0,5.8.8.8,1.9,1.2,2.9,1.2s2.1-.4,2.9-1.2l7.3-7.3,7.3,7.3c.8.8,1.9,1.2,2.9,1.2s2.1-.4,2.9-1.2c1.7-1.7,1.7-4.2,0-5.8l-7.3-7.3,7.3-7.3c1.7-1.7,1.7-4.4,0-5.8h0Z"/>
+                                </svg>
+                            </button>
                         </td>
                     </tr>
                     <?php endforeach; ?>
                 </tbody>
             </table>
-        </div>
-        
+        </form>
+
         <?php endif; ?>
     </div>
     
-    <!-- Export Section -->
-    <div class="orders-export-box">
-        <h3>📤 Export & Aktionen</h3>
-        <div class="orders-export-actions">
-            <button type="button" class="button" onclick="exportOrders('csv')">
-                📊 Als CSV exportieren
-            </button>
-            <button type="button" class="button" onclick="exportOrders('excel')">
-                📈 Als Excel exportieren
-            </button>
-            <button type="button" class="button" onclick="printOrders()">
-                🖨️ Drucken
-            </button>
-        </div>
-        <p class="orders-export-note">
-            Exportiert werden alle Bestellungen im aktuell gewählten Filter-Zeitraum und der ausgewählten Produkt.
-        </p>
-    </div>
-    
-    <!-- Info Box -->
-    <div class="info-box">
-        <h3>📋 Bestellungen-System</h3>
-        <div class="info-box-grid">
-            <div>
-                <h4>🎯 Was wird erfasst:</h4>
-                <ul>
-                    <li><strong>Produktauswahl:</strong> Alle gewählten Optionen</li>
-                    <li><strong>Kundendaten:</strong> E-Mail, Name, Telefon und Adresse (falls angegeben)</li>
-                    <li><strong>Preisberechnung:</strong> Finaler Mietpreis pro Monat</li>
-                    <li><strong>Zeitstempel:</strong> Exakte Bestellzeit</li>
-                    <li><strong>Tracking-Daten:</strong> IP-Adresse und Browser</li>
-                </ul>
-            </div>
-            <div>
-                <h4>📊 Verwendung der Daten:</h4>
-                <ul>
-                    <li><strong>Bestellverfolgung:</strong> Nachvollziehung aller Anfragen</li>
-                    <li><strong>Kundenservice:</strong> Support bei Fragen</li>
-                    <li><strong>Analytics:</strong> Beliebte Produktkombinationen</li>
-                    <li><strong>Umsatzanalyse:</strong> Monatliche Einnahmen</li>
-                    <li><strong>Produktoptimierung:</strong> Welche Optionen werden gewählt</li>
-                    <li><strong>E-Mail-Marketing:</strong> Kundenkommunikation</li>
-                </ul>
-            </div>
-        </div>
-        
-        <div class="tip-box">
-            <strong>💡 Tipp:</strong> Nutzen Sie die Filterfunktionen um spezifische Zeiträume oder Produkte zu analysieren. Die Export-Funktion hilft bei der weiteren Datenverarbeitung in Excel oder anderen Tools.
-        </div>
-        
-        <div class="privacy-box">
-            <strong>🔒 Datenschutz:</strong> Alle Kundendaten werden sicher gespeichert und nur für die Bestellabwicklung verwendet. IP-Adressen dienen der Fraud-Prevention und werden nach 30 Tagen anonymisiert.
-        </div>
-    </div>
-    </div>
-</div>
 
-<!-- Order Details Modal -->
-<div id="order-details-modal" class="modal-overlay">
-    <div class="modal-content">
-        <button type="button" class="modal-close" onclick="closeOrderDetails()">&times;</button>
-        <h3 class="modal-heading">📋 Bestelldetails</h3>
-        <div id="order-details-content"></div>
-        <div class="order-modal-footer">
-            <button type="button" class="button-primary" onclick="closeOrderDetails()">Schließen</button>
+    </div> <!-- end orders card -->
+
+    <!-- Sidebar-Overlay für Bestelldetails -->
+    <div id="order-details-sidebar" class="order-details-sidebar">
+        <div class="order-details-header">
+            <h3>Bestelldetails</h3>
+            <button class="close-sidebar">&times;</button>
+        </div>
+        <div class="order-details-content">
+            <p>Lade Details…</p>
         </div>
     </div>
+    <div id="order-details-overlay" class="order-details-overlay"></div>
 </div>
-
 
 
 <script>
-function showOrderDetails(orderId) {
-    // Find order data from PHP
-    const orders = <?php echo json_encode($orders); ?>;
-    const orderLogs = <?php echo json_encode($order_logs); ?>;
-    const order = orders.find(o => o.id == orderId);
-    
-    if (!order) return;
-    
-    let detailsHtml = `
-        <div class="details-grid">
-            <div>
-                <h4>📋 Bestellinformationen</h4>
-                <p><strong>Bestellnummer:</strong> #${order.order_number ? order.order_number : order.id}</p>
-                <p><strong>Datum:</strong> ${new Date(order.created_at).toLocaleString('de-DE')}</p>
-                <p><strong>Preis:</strong> ${parseFloat(order.final_price).toFixed(2).replace('.', ',')}€${order.mode === 'kauf' ? '' : '/Monat'}</p>
-                ${(order.shipping_name || order.shipping_cost > 0) ? `<p><strong>Versand:</strong> ${order.shipping_name ? order.shipping_name : 'Versand'}${order.shipping_cost > 0 ? ' - ' + parseFloat(order.shipping_cost).toFixed(2).replace('.', ',') + '€' : ''}</p>` : ''}
-                <p><strong>Rabatt:</strong> ${order.discount_amount > 0 ? '-'+parseFloat(order.discount_amount).toFixed(2).replace('.', ',')+'€' : '–'}</p>
-            </div>
-            <div>
-                <h4>👤 Kundendaten</h4>
-                <p><strong>Name:</strong> ${order.customer_name || 'Nicht angegeben'}</p>
-                <p><strong>E-Mail:</strong> ${order.customer_email || 'Nicht angegeben'}</p>
-                <p><strong>Telefon:</strong> ${order.customer_phone || 'Nicht angegeben'}</p>
-                <p><strong>Versandadresse:</strong> ${order.customer_street ? order.customer_street + ', ' + order.customer_postal + ' ' + order.customer_city + ', ' + order.customer_country : 'Nicht angegeben'}</p>
-                <p><strong>Rechnungsadresse:</strong> ${order.customer_street ? order.customer_street + ', ' + order.customer_postal + ' ' + order.customer_city + ', ' + order.customer_country : 'Nicht angegeben'}</p>
-                <p><strong>IP-Adresse:</strong> ${order.user_ip}</p>
-            </div>
-        </div>
-        
-        <h4>🛍️ Produktauswahl</h4>
-        <ul>
-            <li><strong>Ausführung:</strong> ${order.variant_name}</li>
-            <li><strong>Extra:</strong> ${order.extra_names}</li>
-            <li><strong>${order.mode === 'kauf' ? 'Miettage' : 'Mietdauer'}:</strong> ${order.rental_days ? order.rental_days : order.duration_name}</li>
-            ${order.start_date && order.end_date ? `<li><strong>Zeitraum:</strong> ${new Date(order.start_date).toLocaleDateString('de-DE')} - ${new Date(order.end_date).toLocaleDateString('de-DE')}</li>` : ''}
-    `;
-    
-    if (order.condition_name) {
-        detailsHtml += `<li><strong>Zustand:</strong> ${order.condition_name}</li>`;
-    }
-    
-    if (order.product_color_name) {
-        detailsHtml += `<li><strong>Produktfarbe:</strong> ${order.product_color_name}</li>`;
-    }
-    
-    if (order.frame_color_name) {
-        detailsHtml += `<li><strong>Gestellfarbe:</strong> ${order.frame_color_name}</li>`;
-    }
-    
-    detailsHtml += `
-        </ul>
-
-
-        <h4>🖥️ Technische Daten</h4>
-        <p><strong>User Agent:</strong> ${order.user_agent}</p>
-    `;
-
-    const logs = orderLogs[order.id] || [];
-    if (logs.length) {
-        detailsHtml += '<h4>📑 Verlauf</h4><ul>';
-        logs.forEach(l => {
-            const date = new Date(l.created_at).toLocaleString('de-DE');
-            detailsHtml += `<li>[${date}] ${l.event}${l.message ? ' - ' + l.message : ''}</li>`;
-        });
-        detailsHtml += '</ul>';
-    }
-    
-    document.getElementById('order-details-content').innerHTML = detailsHtml;
-    document.getElementById('order-details-modal').style.display = 'block';
-}
-
-function closeOrderDetails() {
-    document.getElementById('order-details-modal').style.display = 'none';
-}
-
 function exportOrders(format) {
     const params = new URLSearchParams(window.location.search);
     params.set('export', format);
@@ -440,43 +259,6 @@ function printOrders() {
     window.print();
 }
 
-function toggleSelectAll() {
-    const selectAllCheckbox = document.getElementById('select-all-orders');
-    const orderCheckboxes = document.querySelectorAll('.order-checkbox');
-
-    const allChecked = Array.from(orderCheckboxes).every(cb => cb.checked);
-
-    orderCheckboxes.forEach(cb => cb.checked = !allChecked);
-    selectAllCheckbox.checked = !allChecked;
-}
-
-function deleteSelected() {
-    const selectedOrders = Array.from(document.querySelectorAll('.order-checkbox:checked')).map(cb => cb.value);
-
-    if (selectedOrders.length === 0) {
-        alert('Bitte wählen Sie mindestens eine Bestellung aus.');
-        return;
-    }
-
-    if (!confirm(`Sind Sie sicher, dass Sie ${selectedOrders.length} Bestellung(en) löschen möchten?\n\nDieser Vorgang kann nicht rückgängig gemacht werden!`)) {
-        return;
-    }
-
-    const form = document.createElement('form');
-    form.method = 'POST';
-    form.action = window.location.href;
-
-    selectedOrders.forEach(id => {
-        const input = document.createElement('input');
-        input.type = 'hidden';
-        input.name = 'delete_orders[]';
-        input.value = id;
-        form.appendChild(input);
-    });
-
-    document.body.appendChild(form);
-    form.submit();
-}
 
 const selectAllOrders = document.getElementById('select-all-orders');
 if (selectAllOrders) {
@@ -485,11 +267,4 @@ if (selectAllOrders) {
         orderCheckboxes.forEach(cb => cb.checked = this.checked);
     });
 }
-
-// Close modal when clicking outside
-document.getElementById('order-details-modal').addEventListener('click', function(e) {
-    if (e.target === this) {
-        closeOrderDetails();
-    }
-});
 </script>

--- a/admin/product-categories-page.php
+++ b/admin/product-categories-page.php
@@ -54,6 +54,12 @@ $counts = [];
 foreach ($raw_cats as $r) { $counts[$r->id] = $r->product_count; }
 foreach ($categories as $c) { $c->product_count = $counts[$c->id] ?? 0; }
 
+// Statistiken für Info-Boxen
+$category_count = $wpdb->get_var("SELECT COUNT(*) FROM {$wpdb->prefix}produkt_product_categories WHERE parent_id IS NULL OR parent_id = 0");
+$subcategory_count = $wpdb->get_var("SELECT COUNT(*) FROM {$wpdb->prefix}produkt_product_categories WHERE parent_id IS NOT NULL AND parent_id != 0");
+$total_category_count = $wpdb->get_var("SELECT COUNT(*) FROM {$wpdb->prefix}produkt_product_categories");
+$products_with_category = $wpdb->get_var("SELECT COUNT(DISTINCT produkt_id) FROM {$wpdb->prefix}produkt_product_to_category");
+
 // Wenn Bearbeiten
 $edit_category = null;
 if (isset($_GET['edit'])) {
@@ -111,16 +117,35 @@ if (isset($_GET['edit'])) {
     </div>
 
 <div class="produkt-admin dashboard-wrapper">
-    <h1 class="dashboard-greeting">Hallo, <?php echo esc_html(wp_get_current_user()->display_name); ?> 👋</h1>
+    <h1 class="dashboard-greeting"><?php echo pv_get_time_greeting(); ?>, <?php echo esc_html(wp_get_current_user()->display_name); ?> 👋</h1>
     <p class="dashboard-subline">Kategorien verwalten</p>
 
-    <div class="h2-rental-card card-category-list">
-        <div style="display:flex;justify-content:space-between;align-items:center;">
+    <div class="product-info-grid cols-4">
+        <div class="product-info-box bg-pastell-gelb">
+            <span class="label">Kategorien</span>
+            <strong class="value"><?php echo intval($category_count); ?></strong>
+        </div>
+        <div class="product-info-box bg-pastell-gruen">
+            <span class="label">Subkategorien</span>
+            <strong class="value"><?php echo intval($subcategory_count); ?></strong>
+        </div>
+        <div class="product-info-box bg-pastell-mint">
+            <span class="label">Gesamt</span>
+            <strong class="value"><?php echo intval($total_category_count); ?></strong>
+        </div>
+        <div class="product-info-box bg-pastell-orange">
+            <span class="label">Produkte zugeordnet</span>
+            <strong class="value"><?php echo intval($products_with_category); ?></strong>
+        </div>
+    </div>
+
+    <div class="dashboard-card card-category-list">
+        <div class="card-header-flex">
             <div>
                 <h2>Bestehende Kategorien</h2>
                 <p class="card-subline">Verwalten Sie Ihre Kategorien</p>
             </div>
-            <button id="add-category-btn" type="button" class="icon-btn" style="margin-right:20px;" aria-label="Hinzufügen">
+            <button id="add-category-btn" type="button" class="icon-btn add-category-btn" aria-label="Hinzufügen">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80.3">
                     <path d="M12.1,12c-15.4,15.4-15.4,40.4,0,55.8,7.7,7.7,17.7,11.7,27.9,11.7s20.2-3.8,27.9-11.5c15.4-15.4,15.4-40.4,0-55.8-15.4-15.6-40.4-15.6-55.8-.2h0ZM62.1,62c-12.1,12.1-31.9,12.1-44.2,0-12.1-12.1-12.1-31.9,0-44.2,12.1-12.1,31.9-12.1,44.2,0,12.1,12.3,12.1,31.9,0,44.2Z"/>
                     <path d="M54.6,35.7h-10.4v-10.4c0-2.3-1.9-4.2-4.2-4.2s-4.2,1.9-4.2,4.2v10.4h-10.4c-2.3,0-4.2,1.9-4.2,4.2s1.9,4.2,4.2,4.2h10.4v10.4c0,2.3,1.9,4.2,4.2,4.2s4.2-1.9,4.2-4.2v-10.4h10.4c2.3,0,4.2-1.9,4.2-4.2s-1.9-4.2-4.2-4.2Z"/>

--- a/admin/variants-page.php
+++ b/admin/variants-page.php
@@ -305,84 +305,165 @@ foreach ($branding_results as $result) {
 }
 ?>
 
-<div class="wrap">
-    <div class="produkt-admin-card">
-        <!-- Kompakter Header -->
-        <div class="produkt-admin-header-compact">
-        <div class="produkt-admin-logo-compact">🖼️</div>
-        <div class="produkt-admin-title-compact">
-            <h1>Ausführungen verwalten</h1>
-            <p>Produktvarianten mit Bildergalerie</p>
+<div class="produkt-admin dashboard-wrapper">
+    <h1 class="dashboard-greeting"><?php echo pv_get_time_greeting(); ?>, <?php echo esc_html(wp_get_current_user()->display_name); ?> 👋</h1>
+    <p class="dashboard-subline">Ausführungen verwalten</p>
+
+<?php if ($active_tab === 'list'): ?>
+    <div class="dashboard-grid">
+        <div class="dashboard-left">
+            <div class="dashboard-card card-product-selector">
+                <h2>Produkt auswählen</h2>
+                <p class="card-subline">Für welches Produkt möchten Sie eine Ausführung bearbeiten?</p>
+                <form method="get" action="" class="produkt-category-selector" style="background:none;border:none;padding:0;">
+                    <input type="hidden" name="page" value="produkt-variants">
+                    <input type="hidden" name="tab" value="<?php echo esc_attr($active_tab); ?>">
+                    <select name="category" id="category-select" onchange="this.form.submit()">
+                        <?php foreach ($categories as $category): ?>
+                            <option value="<?php echo $category->id; ?>" <?php selected($selected_category, $category->id); ?>><?php echo esc_html($category->name); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                    <noscript><input type="submit" value="Wechseln" class="button"></noscript>
+                </form>
+                <?php if ($current_category): ?>
+                <div class="selected-product-preview">
+                    <?php if (!empty($current_category->default_image)): ?>
+                        <img src="<?php echo esc_url($current_category->default_image); ?>" alt="<?php echo esc_attr($current_category->name); ?>">
+                    <?php else: ?>
+                        <div class="placeholder-icon">🏷️</div>
+                    <?php endif; ?>
+                    <div class="tile-overlay"><span><?php echo esc_html($current_category->name); ?></span></div>
+                </div>
+                <?php endif; ?>
+            </div>
+        </div>
+        <div class="dashboard-right">
+            <div class="dashboard-row">
+                <div class="dashboard-card card-new-product">
+                    <h2>Neue Ausführung</h2>
+                    <p class="card-subline">Ausführung erstellen</p>
+                    <a href="<?php echo admin_url('admin.php?page=produkt-variants&category=' . $selected_category . '&tab=add'); ?>" class="icon-btn add-product-btn" aria-label="Hinzufügen">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80.3">
+                            <path d="M12.1,12c-15.4,15.4-15.4,40.4,0,55.8,7.7,7.7,17.7,11.7,27.9,11.7s20.2-3.8,27.9-11.5c15.4-15.4,15.4-40.4,0-55.8-15.4-15.6-40.4-15.6-55.8-.2h0ZM62.1,62c-12.1,12.1-31.9,12.1-44.2,0-12.1-12.1-12.1-31.9,0-44.2,12.1-12.1,31.9-12.1,44.2,0,12.1,12.3,12.1,31.9,0,44.2Z"/>
+                            <path d="M54.6,35.7h-10.4v-10.4c0-2.3-1.9-4.2-4.2-4.2s-4.2,1.9-4.2,4.2v10.4h-10.4c-2.3,0-4.2,1.9-4.2,4.2s1.9,4.2,4.2,4.2h10.4v10.4c0,2.3,1.9,4.2,4.2,4.2s4.2-1.9,4.2-4.2v-10.4h10.4c2.3,0,4.2-1.9,4.2-4.2s-1.9-4.2-4.2-4.2Z"/>
+                        </svg>
+                    </a>
+                </div>
+                <div class="dashboard-card card-quicknav">
+                    <h2>Schnellnavigation</h2>
+                    <p class="card-subline">Direkt zu wichtigen Listen</p>
+                    <div class="quicknav-grid">
+                        <div class="quicknav-card">
+                            <a href="admin.php?page=produkt-verleih">
+                                <div class="quicknav-inner">
+                                    <div class="quicknav-icon-circle">🏠</div>
+                                    <div class="quicknav-label">Dashboard</div>
+                                </div>
+                            </a>
+                        </div>
+                        <div class="quicknav-card">
+                            <a href="admin.php?page=produkt-categories">
+                                <div class="quicknav-inner">
+                                    <div class="quicknav-icon-circle">🧩</div>
+                                    <div class="quicknav-label">Kategorien</div>
+                                </div>
+                            </a>
+                        </div>
+                        <div class="quicknav-card">
+                            <a href="admin.php?page=produkt-products">
+                                <div class="quicknav-inner">
+                                    <div class="quicknav-icon-circle">🏷️</div>
+                                    <div class="quicknav-label">Produkte</div>
+                                </div>
+                            </a>
+                        </div>
+                        <div class="quicknav-card">
+                            <a href="admin.php?page=produkt-extras">
+                                <div class="quicknav-inner">
+                                    <div class="quicknav-icon-circle">✨</div>
+                                    <div class="quicknav-label">Extras</div>
+                                </div>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="dashboard-card">
+                <div class="card-header-flex">
+                    <div>
+                        <h2>Ausführungen</h2>
+                        <p class="card-subline">Vorhandene Varianten des Produkts</p>
+                    </div>
+                </div>
+                <table class="activity-table">
+                    <thead>
+                        <tr>
+                            <th>Bild</th>
+                            <th>Name</th>
+                            <th>Verfügbar</th>
+                            <th>Preis</th>
+                            <th>Bilder</th>
+                            <th>Aktionen</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php $modus = get_option('produkt_betriebsmodus', 'miete'); ?>
+                        <?php foreach ($variants as $variant): ?>
+                            <?php
+                                $image_count = 0;
+                                $main_image = '';
+                                for ($i = 1; $i <= 5; $i++) {
+                                    $field = 'image_url_' . $i;
+                                    if (!empty($variant->$field)) {
+                                        $image_count++;
+                                        if (!$main_image) {
+                                            $main_image = $variant->$field;
+                                        }
+                                    }
+                                }
+                            ?>
+                            <tr>
+                                <td>
+                                    <?php if ($main_image): ?>
+                                        <img src="<?php echo esc_url($main_image); ?>" style="width:60px;height:60px;object-fit:cover;border-radius:4px;" alt="<?php echo esc_attr($variant->name); ?>">
+                                    <?php else: ?>
+                                        <div style="width:60px;height:60px;background:#f0f0f0;border-radius:4px;display:flex;align-items:center;justify-content:center;">📦</div>
+                                    <?php endif; ?>
+                                </td>
+                                <td><?php echo esc_html($variant->name); ?></td>
+                                <td><?php echo ($variant->available ?? 1) ? '✅' : '❌'; ?></td>
+                                <td>
+                                    <?php if ($modus === 'kauf'): ?>
+                                        <?php echo number_format($variant->verkaufspreis_einmalig, 2, ',', '.'); ?>€
+                                    <?php else: ?>
+                                        <?php echo number_format($variant->mietpreis_monatlich, 2, ',', '.'); ?>€
+                                    <?php endif; ?>
+                                </td>
+                                <td><?php echo $image_count; ?></td>
+                                <td>
+                                    <button type="button" class="icon-btn" aria-label="Bearbeiten" onclick="window.location.href='?page=produkt-variants&category=<?php echo $selected_category; ?>&tab=edit&edit=<?php echo $variant->id; ?>'">
+                                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80.8 80.1">
+                                            <path d="M54.7,4.8l-31.5,31.7c-.6.6-1,1.5-1.2,2.3l-3.3,18.3c-.2,1.2.2,2.7,1.2,3.8.8.8,1.9,1.2,2.9,1.2h.8l18.3-3.3c.8-.2,1.7-.6,2.3-1.2l31.7-31.7c5.8-5.8,5.8-15.2,0-21-6-5.8-15.4-5.8-21.2,0h0ZM69.9,19.8l-30.8,30.8-11,1.9,2.1-11.2,30.6-30.6c2.5-2.5,6.7-2.5,9.2,0,2.5,2.7,2.5,6.7,0,9.2Z"/>
+                                            <path d="M5.1,79.6h70.8c2.3,0,4.2-1.9,4.2-4.2v-35.4c0-2.3-1.9-4.2-4.2-4.2s-4.2,1.9-4.2,4.2v31.2H9.2V8.8h31.2c2.3,0,4.2-1.9,4.2-4.2s-1.9-4.2-4.2-4.2H5.1c-2.3,0-4.2,1.9-4.2,4.2v70.8c0,2.3,1.9,4.2,4.2,4.2h0Z"/>
+                                        </svg>
+                                    </button>
+                                    <button type="button" class="icon-btn" onclick="if(confirm('Wirklich löschen?')){window.location.href='?page=produkt-variants&category=<?php echo $selected_category; ?>&delete=<?php echo $variant->id; ?>&fw_nonce=<?php echo wp_create_nonce('produkt_admin_action'); ?>';}" aria-label="Löschen">
+                                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 79.9 80.1">
+                                            <path d="M39.8.4C18,.4.3,18.1.3,40s17.7,39.6,39.6,39.6,39.6-17.7,39.6-39.6S61.7.4,39.8.4ZM39.8,71.3c-17.1,0-31.2-14-31.2-31.2s14.2-31.2,31.2-31.2,31.2,14,31.2,31.2-14.2,31.2-31.2,31.2Z"/>
+                                            <path d="M53,26.9c-1.7-1.7-4.2-1.7-5.8,0l-7.3,7.3-7.3-7.3c-1.7-1.7-4.2-1.7-5.8,0-1.7,1.7-1.7,4.2,0,5.8l7.3,7.3-7.3,7.3c-1.7,1.7-1.7,4.2,0,5.8.8.8,1.9,1.2,2.9,1.2s2.1-.4,2.9-1.2l7.3-7.3,7.3,7.3c.8.8,1.9,1.2,2.9,1.2s2.1-.4,2.9-1.2c1.7-1.7,1.7-4.2,0-5.8l-7.3-7.3,7.3-7.3c1.7-1.7,1.7-4.4,0-5.8h0Z"/>
+                                        </svg>
+                                    </button>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
-    
-    <!-- Breadcrumb Navigation -->
-    <div class="produkt-breadcrumb">
-        <a href="<?php echo admin_url('admin.php?page=produkt-verleih'); ?>">Dashboard</a> 
-        <span>→</span> 
-        <strong>Ausführungen</strong>
-    </div>
-    
-    <!-- Category Selection -->
-    <div class="produkt-category-selector">
-        <form method="get" action="">
-            <input type="hidden" name="page" value="produkt-variants">
-            <input type="hidden" name="tab" value="<?php echo esc_attr($active_tab); ?>">
-            <label for="category-select"><strong>🏷️ Produkt:</strong></label>
-            <select name="category" id="category-select" onchange="this.form.submit()">
-                <?php foreach ($categories as $category): ?>
-                <option value="<?php echo $category->id; ?>" <?php selected($selected_category, $category->id); ?>>
-                    <?php echo esc_html($category->name); ?>
-                </option>
-                <?php endforeach; ?>
-            </select>
-            <noscript><input type="submit" value="Wechseln" class="button"></noscript>
-        </form>
-        
-        <?php if ($current_category): ?>
-        <div class="produkt-category-info">
-            <code>[produkt_product category="<?php echo esc_html($current_category->shortcode); ?>"]</code>
-        </div>
-        <?php endif; ?>
-    </div>
-    
-    <!-- Tab Navigation -->
-    <div class="produkt-tab-nav">
-        <a href="<?php echo admin_url('admin.php?page=produkt-variants&category=' . $selected_category . '&tab=list'); ?>" 
-           class="produkt-tab <?php echo $active_tab === 'list' ? 'active' : ''; ?>">
-            📋 Übersicht
-        </a>
-        <a href="<?php echo admin_url('admin.php?page=produkt-variants&category=' . $selected_category . '&tab=add'); ?>" 
-           class="produkt-tab <?php echo $active_tab === 'add' ? 'active' : ''; ?>">
-            ➕ Neue Ausführung
-        </a>
-        <?php if ($edit_item): ?>
-        <a href="<?php echo admin_url('admin.php?page=produkt-variants&category=' . $selected_category . '&tab=edit&edit=' . $edit_item->id); ?>" 
-           class="produkt-tab <?php echo $active_tab === 'edit' ? 'active' : ''; ?>">
-            ✏️ Bearbeiten
-        </a>
-        <?php endif; ?>
-    </div>
-    
-    <!-- Tab Content -->
-    <div class="produkt-tab-content">
-        <?php
-        switch ($active_tab) {
-            case 'add':
-                include PRODUKT_PLUGIN_PATH . 'admin/tabs/variants-add-tab.php';
-                break;
-            case 'edit':
-                if ($edit_item) {
-                    include PRODUKT_PLUGIN_PATH . 'admin/tabs/variants-edit-tab.php';
-                } else {
-                    include PRODUKT_PLUGIN_PATH . 'admin/tabs/variants-list-tab.php';
-                }
-                break;
-            case 'list':
-            default:
-                include PRODUKT_PLUGIN_PATH . 'admin/tabs/variants-list-tab.php';
-        }
-        ?>
-    </div>
-    </div>
+<?php elseif ($active_tab === 'add'): ?>
+    <?php include PRODUKT_PLUGIN_PATH . 'admin/tabs/variants-add-tab.php'; ?>
+<?php elseif ($active_tab === 'edit' && $edit_item): ?>
+    <?php include PRODUKT_PLUGIN_PATH . 'admin/tabs/variants-edit-tab.php'; ?>
+<?php endif; ?>
 </div>

--- a/assets/admin-script.js
+++ b/assets/admin-script.js
@@ -21,6 +21,8 @@ jQuery(document).ready(function($) {
             success: function(response) {
                 if (response.success) {
                     content.html(response.data.html);
+                    // Re-initialize accordions for dynamically loaded content
+                    produktInitAccordions();
                 } else {
                     content.html('<p>Details konnten nicht geladen werden.</p>');
                 }
@@ -243,6 +245,176 @@ document.addEventListener('click', function(e) {
                     }
                 } else {
                     alert('Fehler beim Bestätigen');
+                }
+            });
+    }
+});
+
+// Order note functionality
+document.addEventListener('click', function(e) {
+    if (e.target.closest('.note-icon')) {
+        e.preventDefault();
+        var form = document.getElementById('order-note-form');
+        if (form) {
+            form.classList.toggle('visible');
+            var ta = form.querySelector('textarea');
+            if (ta) ta.focus();
+        }
+    }
+    if (e.target.classList.contains('note-cancel')) {
+        e.preventDefault();
+        document.getElementById('order-note-form').classList.remove('visible');
+    }
+    if (e.target.classList.contains('note-save')) {
+        e.preventDefault();
+        var form = document.getElementById('order-note-form');
+        var note = form.querySelector('textarea').value.trim();
+        if (!note) return;
+        var orderIdEl = document.querySelector('.sidebar-wrapper');
+        var orderId = orderIdEl ? orderIdEl.getAttribute('data-order-id') : 0;
+        var data = new URLSearchParams();
+        data.append('action', 'pv_save_order_note');
+        data.append('nonce', produkt_admin.nonce);
+        data.append('order_id', orderId);
+        data.append('note', note);
+        fetch(produkt_admin.ajax_url, {method:'POST', body:data})
+            .then(r => r.json())
+            .then(res => {
+                if (res.success) {
+                    var container = document.querySelector('.order-notes-section');
+                    if (container) {
+                        var div = document.createElement('div');
+                        div.className = 'order-note';
+                        div.setAttribute('data-note-id', res.data.id);
+                        div.innerHTML = '<div class="note-text"></div><div class="note-date"></div><button type="button" class="icon-btn note-delete-btn" title="Notiz löschen"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 79.9 80.1"><path d="M39.8.4C18,.4.3,18.1.3,40s17.7,39.6,39.6,39.6,39.6-17.7,39.6-39.6S61.7.4,39.8.4ZM39.8,71.3c-17.1,0-31.2-14-31.2-31.2s14.2-31.2,31.2-31.2,31.2,14,31.2,31.2-14.2,31.2-31.2,31.2Z"/><path d="M53,26.9c-1.7-1.7-4.2-1.7-5.8,0l-7.3,7.3-7.3-7.3c-1.7-1.7-4.2-1.7-5.8,0-1.7,1.7-1.7,4.2,0,5.8l7.3,7.3-7.3,7.3c-1.7,1.7-1.7,4.2,0,5.8.8.8,1.9,1.2,2.9,1.2s2.1-.4,2.9-1.2l7.3-7.3,7.3,7.3c.8.8,1.9,1.2,2.9,1.2s2.1-.4,2.9-1.2c1.7-1.7,1.7-4.2,0-5.8l-7.3-7.3,7.3-7.3c1.7-1.7,1.7-4.4,0-5.8h0Z"/></svg></button>';
+                        div.querySelector('.note-text').textContent = note;
+                        div.querySelector('.note-date').textContent = res.data.date;
+                        container.prepend(div);
+                    }
+                    form.querySelector('textarea').value = '';
+                    form.classList.remove('visible');
+                } else {
+                    alert('Fehler beim Speichern');
+                }
+            });
+    }
+});
+
+document.addEventListener('click', function(e) {
+    if (e.target.closest('.note-delete-btn')) {
+        e.preventDefault();
+        var btn = e.target.closest('.note-delete-btn');
+        var noteEl = btn.closest('.order-note');
+        if (!noteEl) return;
+        var noteId = noteEl.getAttribute('data-note-id');
+        var data = new URLSearchParams();
+        data.append('action', 'pv_delete_order_note');
+        data.append('nonce', produkt_admin.nonce);
+        data.append('note_id', noteId);
+        fetch(produkt_admin.ajax_url, {method:'POST', body:data})
+            .then(r => r.json())
+            .then(res => {
+                if (res.success) {
+                    noteEl.remove();
+                } else {
+                    alert('Fehler beim Löschen');
+                }
+            });
+    }
+});
+
+document.addEventListener('click', function(e) {
+    if (e.target.closest('.customer-note-icon')) {
+        var form = document.getElementById('customer-note-form');
+        if (form) form.classList.add('visible');
+    }
+    if (e.target.classList.contains('customer-note-cancel')) {
+        var form = document.getElementById('customer-note-form');
+        if (form) form.classList.remove('visible');
+    }
+    if (e.target.classList.contains('customer-note-save')) {
+        var form = document.getElementById('customer-note-form');
+        var note = form.querySelector('textarea').value.trim();
+        if (!note) return;
+        var customerId = form.getAttribute('data-customer-id');
+        var data = new URLSearchParams();
+        data.append('action', 'pv_save_customer_note');
+        data.append('nonce', produkt_admin.nonce);
+        data.append('customer_id', customerId);
+        data.append('note', note);
+        fetch(produkt_admin.ajax_url, {method:'POST', body:data})
+            .then(r => r.json())
+            .then(res => {
+                if (res.success) {
+                    var container = document.querySelector('.customer-notes-section');
+                    if (container) {
+                        var div = document.createElement('div');
+                        div.className = 'order-note';
+                        div.setAttribute('data-note-id', res.data.id);
+                        div.innerHTML = '<div class="note-text"></div><div class="note-date"></div><button type="button" class="icon-btn customer-note-delete-btn" title="Notiz löschen"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 79.9 80.1"><path d="M39.8.4C18,.4.3,18.1.3,40s17.7,39.6,39.6,39.6,39.6-17.7,39.6-39.6S61.7.4,39.8.4ZM39.8,71.3c-17.1,0-31.2-14-31.2-31.2s14.2-31.2,31.2-31.2,31.2,14,31.2,31.2-14.2,31.2-31.2,31.2Z"/><path d="M53,26.9c-1.7-1.7-4.2-1.7-5.8,0l-7.3,7.3-7.3-7.3c-1.7-1.7-4.2-1.7-5.8,0-1.7,1.7-1.7,4.2,0,5.8l7.3,7.3-7.3,7.3c-1.7,1.7-1.7,4.2,0,5.8.8.8,1.9,1.2,2.9,1.2s2.1-.4,2.9-1.2l7.3-7.3,7.3,7.3c.8.8,1.9,1.2,2.9,1.2s2.1-.4,2.9-1.2c1.7-1.7,1.7-4.2,0-5.8l-7.3-7.3,7.3-7.3c1.7-1.7,1.7-4.4,0-5.8h0Z"/></svg></button>';
+                        div.querySelector('.note-text').textContent = note;
+                        div.querySelector('.note-date').textContent = res.data.date;
+                        container.prepend(div);
+                    }
+                    form.querySelector('textarea').value = '';
+                    form.classList.remove('visible');
+                } else {
+                    alert('Fehler beim Speichern');
+                }
+            });
+    }
+});
+
+document.addEventListener('click', function(e) {
+    if (e.target.closest('.customer-note-delete-btn')) {
+        e.preventDefault();
+        var btn = e.target.closest('.customer-note-delete-btn');
+        var noteEl = btn.closest('.order-note');
+        if (!noteEl) return;
+        var noteId = noteEl.getAttribute('data-note-id');
+        var data = new URLSearchParams();
+        data.append('action', 'pv_delete_customer_note');
+        data.append('nonce', produkt_admin.nonce);
+        data.append('note_id', noteId);
+        fetch(produkt_admin.ajax_url, {method:'POST', body:data})
+            .then(r => r.json())
+            .then(res => {
+                if (res.success) {
+                    noteEl.remove();
+                } else {
+                    alert('Fehler beim Löschen');
+                }
+            });
+    }
+});
+
+document.addEventListener('click', function(e) {
+    var btn = e.target.closest('.customer-log-load-more');
+    if (btn) {
+        e.preventDefault();
+        var offset = parseInt(btn.getAttribute('data-offset')) || 0;
+        var total = parseInt(btn.getAttribute('data-total')) || 0;
+        var orderIds = btn.getAttribute('data-order-ids').split(',');
+        var data = new URLSearchParams();
+        data.append('action', 'pv_load_customer_logs');
+        data.append('nonce', produkt_admin.nonce);
+        data.append('offset', offset);
+        orderIds.forEach(function(id){ data.append('order_ids[]', id); });
+        fetch(produkt_admin.ajax_url, {method:'POST', body:data})
+            .then(r => r.json())
+            .then(res => {
+                if (res.success) {
+                    var list = document.querySelector('.order-log-list');
+                    if (list && res.data.html) {
+                        var temp = document.createElement('div');
+                        temp.innerHTML = res.data.html;
+                        Array.from(temp.children).forEach(function(li){ list.appendChild(li); });
+                        offset += res.data.count;
+                        btn.setAttribute('data-offset', offset);
+                        if (offset >= total || res.data.count < 5) {
+                            btn.remove();
+                        }
+                    }
                 }
             });
     }

--- a/assets/admin-style.css
+++ b/assets/admin-style.css
@@ -2466,6 +2466,7 @@ body.category-modal-open {
     border: 1px solid #e9ecef;
     border-radius: 8px;
     padding: 15px;
+    position: relative;
 }
 
 .produkt-category-card h4 {
@@ -2662,13 +2663,6 @@ body.category-modal-open {
     background: #fff;
     border-radius: 4px;
 }
-.orders-table-container {
-    background: #fff;
-    border: 1px solid #ddd;
-    border-radius: 8px;
-    padding: 20px;
-    margin-bottom: 30px;
-}
 .orders-bulk-actions { margin:10px 0; }
 .orders-empty { text-align:center; padding:40px; }
 .orders-empty-message { font-size:18px; color:#666; }
@@ -2677,44 +2671,18 @@ body.category-modal-open {
 .text-green-dark { color:#2a372a; }
 .text-blue { color:#0073aa; font-weight:bold; }
 .order-details-info { line-height:1.4; }
-.order-price { color:#666666; font-size:16px; }
-.orders-export-box {
-    background: #f8f9fa;
-    border: 1px solid #e9ecef;
-    border-radius: 8px;
-    padding: 20px;
-    margin-bottom: 30px;
+.order-price {
+    color: #000000;
+    font-size: 14px;
 }
-.orders-export-actions { display:flex; gap:15px; flex-wrap:wrap; }
-.orders-export-note { margin-top:10px; color:#666; font-size:13px; }
-.info-box {
-    background: #d1ecf1;
-    border: 1px solid #bee5eb;
-    padding: 20px;
-    border-radius: 8px;
-}
-.info-box-grid { display:grid; grid-template-columns:1fr 1fr; gap:20px; }
-.tip-box {
-    margin-top: 15px;
-    padding: 15px;
-    background: #d4edda;
-    border: 1px solid #c3e6cb;
-    border-radius: 4px;
-}
-.privacy-box {
-    margin-top: 10px;
-    padding: 15px;
-    background: #fff3cd;
-    border: 1px solid #ffeaa7;
-    border-radius: 4px;
-}
+.orders-stat-value { font-size:2rem !important; }
 .modal-heading { margin-top:0; }
 .order-modal-footer { text-align:right; margin-top:20px; }
 .details-grid { display:grid; grid-template-columns:1fr 1fr; gap:20px; }
 .summary-green { color:#2a372a; }
 .summary-red { color:#dc3232; }
 .summary-gray { color:#666666; }
-.col-checkbox{width:40px;}
+.col-checkbox{width:60px; white-space:nowrap;}
 .col-id{width:80px;}
 .col-date{width:120px;}
 .col-type{width:80px;}
@@ -2758,18 +2726,29 @@ body.category-modal-open {
 
 
 /* Customers grid */
-#produkt-admin-customers .produkt-items-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(320px,1fr));gap:20px;margin-top:2rem;}
-#produkt-admin-customers .produkt-item-card{background:#fff;border:1px solid #e5e5e5;border-radius:12px;padding:20px;box-shadow:0 4px 12px rgba(0,0,0,0.05);display:flex;flex-direction:column;justify-content:space-between;}
-#produkt-admin-customers .produkt-item-content h5{margin-top:0;font-size:18px;font-weight:600;}
-#produkt-admin-customers .produkt-item-content p{margin:6px 0;font-size:14px;color:#444;}
-#produkt-admin-customers .produkt-item-meta{margin-top:10px;display:flex;justify-content:space-between;align-items:center;}
-#produkt-admin-customers .produkt-item-actions{margin-top:1rem;display:flex;gap:10px;flex-wrap:wrap;}
+#produkt-admin-customers .customers-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(400px,1fr));gap:20px;margin-top:2rem;margin-right:20px;}
+#produkt-admin-customers .customer-card{background:#fff;border-radius:20px;padding:1.5rem;}
+#produkt-admin-customers .customer-header{display:flex;align-items:center;margin-bottom:12px;}
+#produkt-admin-customers .customer-avatar{width:50px;height:50px;border-radius:50%;background:#1d2327;color:#fff;font-weight:700;font-size:18px;display:flex;align-items:center;justify-content:center;margin-right:12px;text-transform:uppercase;}
+#produkt-admin-customers .customer-name{margin:0;font-size:16px;font-weight:600;}
+#produkt-admin-customers .customer-email{margin:2px 0 0;font-size:14px;color:#444;}
+#produkt-admin-customers .customer-phone{margin:0 0 8px;font-size:14px;}
+#produkt-admin-customers .customer-orders-row{display:flex;justify-content:space-between;font-size:14px;margin-bottom:8px;}
+#produkt-admin-customers .customer-actions{text-align:right;margin-top:2rem;}
+#produkt-admin-customers .customer-actions .icon-btn svg{width:20px;height:20px;}
 
 /* Customer detail layout */
-.produkt-customer-grid{display:grid;grid-template-columns:1fr 2fr;gap:2rem;margin-top:2rem;}
+.customer-detail-grid{display:flex;gap:2rem;align-items:flex-start;margin-top:2rem;}
+.customer-left{flex:1;display:flex;flex-direction:column;gap:2rem;}
+.customer-right{flex:1;display:flex;flex-direction:column;gap:2rem;padding-right:20px;box-sizing:border-box;}
+.customer-row{display:flex;gap:2rem;align-items:flex-start;}
+.customer-row > .dashboard-card{flex:1;}
 .produkt-customer-details p{margin:6px 0;}
 .produkt-customer-orders{background:#f8f9fb;padding:20px;border-radius:12px;border:1px solid #e1e1e1;}
 .produkt-accordion-item + .produkt-accordion-item{margin-top:10px;}
+#produkt-admin-customers .customer-tech-card{background:linear-gradient(210deg,#3858e9,#08154f);color:#fff;}
+#produkt-admin-customers .customer-tech-card h2,#produkt-admin-customers .customer-tech-card p,#produkt-admin-customers .customer-tech-card strong{color:#fff;}
+#produkt-admin-customers .customer-log-load-more{display:block;margin:10px auto 0;}
 	
 /* === Allgemeines Dashboard Layout === */
 
@@ -2777,7 +2756,7 @@ body.category-modal-open {
     display: flex;
     gap: 2rem;
     align-items: flex-start;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
 }
 
 .dashboard-card h2 {
@@ -2802,6 +2781,9 @@ body.category-modal-open {
     display: flex;
     gap: 2rem;
 }
+.dashboard-row > .dashboard-card {
+    flex: 1;
+}
 
 .card-products, .card-quicknav {
     flex: 1;
@@ -2818,6 +2800,7 @@ body.category-modal-open {
     border-radius: 20px;
     padding: 1.5rem;
     margin-right: 20px;
+    margin-bottom: 2rem;
 }
 .h2-rental-card h2 {
     margin: 0 0 0.5rem 0;
@@ -2855,6 +2838,34 @@ body.category-modal-open {
     grid-template-columns: 1fr 1fr;
     gap: 1rem;
 }
+.product-info-grid.cols-4 {
+    grid-template-columns: repeat(4, 1fr);
+    margin-bottom: 2rem;
+}
+.product-info-grid.cols-4 .product-info-box:last-child {
+    margin-right: 20px;
+}
+
+/* Orders page stats grid without bottom margin */
+.orders-info-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1rem;
+    margin-bottom: 0;
+}
+.orders-info-grid .product-info-box:last-child {
+    margin-right: 20px;
+}
+
+.orders-info-grid-tight {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1rem;
+    margin-bottom: 0;
+}
+.orders-info-grid-tight .product-info-box:last-child {
+    margin-right: 0;
+}
 
 .product-info-box {
     background: #f9f9f9;
@@ -2867,22 +2878,92 @@ body.category-modal-open {
 }
 
 .product-info-box .label {
-    font-size: 1rem;
-    font-weight: 500;
-    color: #2b2b2b;
+    font-size: 0.9rem;
+    font-weight: 700;
+    color: #fff;
+    background: #1d2327;
+    max-width: fit-content;
+    padding: 8px 20px;
+    border-radius: 999px;
 }
 
 .product-info-box .value {
     font-size: 3.5rem;
     font-weight: 700;
-    color: #000000;
+    color: #ffffff;
+    text-shadow: 3px 4px #252525;
 }
 
 
 .bg-pastell-orange { background-color: #eee3cc; }
+.product-info-box.bg-pastell-orange {
+    background-image: url("data:image/svg+xml;base64,PHN2ZyBpZD0idmlzdWFsIiB2aWV3Qm94PSIwIDAgOTAwIDY3NSIgd2lkdGg9IjkwMCIgaGVpZ2h0PSI2NzUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHZlcnNpb249IjEuMSI+PHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjkwMCIgaGVpZ2h0PSI2NzUiIGZpbGw9IiNlZWUzY2MiPjwvcmVjdD48ZGVmcz48bGluZWFyR3JhZGllbnQgaWQ9ImdyYWQxXzAiIHgxPSIyNSUiIHkxPSIwJSIgeDI9IjEwMCUiIHkyPSIxMDAlIj48c3RvcCBvZmZzZXQ9IjIzLjMzMzMzMzMzMzMzMzMzNiUiIHN0b3AtY29sb3I9IiNlZWUzY2MiIHN0b3Atb3BhY2l0eT0iMSI+PC9zdG9wPjxzdG9wIG9mZnNldD0iNzYuNjY2NjY2NjY2NjY2NjYlIiBzdG9wLWNvbG9yPSIjZWVlM2NjIiBzdG9wLW9wYWNpdHk9IjEiPjwvc3RvcD48L2xpbmVhckdyYWRpZW50PjwvZGVmcz48ZGVmcz48bGluZWFyR3JhZGllbnQgaWQ9ImdyYWQyXzAiIHgxPSIwJSIgeTE9IjAlIiB4Mj0iNzUlIiB5Mj0iMTAwJSI+PHN0b3Agb2Zmc2V0PSIyMy4zMzMzMzMzMzMzMzMzMzYlIiBzdG9wLWNvbG9yPSIjZWVlM2NjIiBzdG9wLW9wYWNpdHk9IjEiPjwvc3RvcD48c3RvcCBvZmZzZXQ9Ijc2LjY2NjY2NjY2NjY2NjY2JSIgc3RvcC1jb2xvcj0iI2VlZTNjYyIgc3RvcC1vcGFjaXR5PSIxIj48L3N0b3A+PC9saW5lYXJHcmFkaWVudD48L2RlZnM+PGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoOTAwLCAwKSI+PHBhdGggZD0iTTAgNDUwQy04Mi44IDQ0MC42IC0xNjUuNSA0MzEuMiAtMjI1IDM4OS43Qy0yODQuNSAzNDguMyAtMzIwLjYgMjc0LjggLTM1NC4yIDIwNC41Qy0zODcuOCAxMzQuMiAtNDE4LjkgNjcuMSAtNDUwIDBMMCAwWiIgZmlsbD0iI0M2MjM2OCI+PC9wYXRoPjwvZz48ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgwLCA2NzUpIj48cGF0aCBkPSJNMCAtNDUwQzY5LjggLTQyMy41IDEzOS41IC0zOTcuMSAyMDkuNSAtMzYyLjlDMjc5LjUgLTMyOC43IDM0OS42IC0yODYuOCAzODkuNyAtMjI1QzQyOS44IC0xNjMuMiA0MzkuOSAtODEuNiA0NTAgMEwwIDBaIiBmaWxsPSIjQzYyMzY4Ij48L3BhdGg+PC9nPjwvc3ZnPg==");
+    background-size: cover;
+    background-repeat: no-repeat;
+}
 .bg-pastell-mint   { background-color: #ddf6f5; }
+.product-info-box.bg-pastell-mint {
+    background-image: url("data:image/svg+xml;base64,PHN2ZyBpZD0idmlzdWFsIiB2aWV3Qm94PSIwIDAgOTAwIDY3NSIgd2lkdGg9IjkwMCIgaGVpZ2h0PSI2\
+NzUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93\
+d3cudzMub3JnLzE5OTkveGxpbmsiIHZlcnNpb249IjEuMSI+PHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9\
+IjkwMCIgaGVpZ2h0PSI2NzUiIGZpbGw9IiM4Y2IzZDAiPjwvcmVjdD48ZGVmcz48bGluZWFyR3JhZGll\
+bnQgaWQ9ImdyYWQxXzAiIHgxPSIyNSUiIHkxPSIwJSIgeDI9IjEwMCUiIHkyPSIxMDAlIj48c3RvcCBv\
+ZmZzZXQ9IjIzLjMzMzMzMzMzMzMzMzMzNiUiIHN0b3AtY29sb3I9IiM4Y2IzZDAiIHN0b3Atb3BhY2l0\
+eT0iMSI+PC9zdG9wPjxzdG9wIG9mZnNldD0iNzYuNjY2NjY2NjY2NjY2NjYlIiBzdG9wLWNvbG9yPSIj\
+OGNiM2QwIiBzdG9wLW9wYWNpdHk9IjEiPjwvc3RvcD48L2xpbmVhckdyYWRpZW50PjwvZGVmcz48ZGVm\
+cz48bGluZWFyR3JhZGllbnQgaWQ9ImdyYWQyXzAiIHgxPSIwJSIgeTE9IjAlIiB4Mj0iNzUlIiB5Mj0i\
+MTAwJSI+PHN0b3Agb2Zmc2V0PSIyMy4zMzMzMzMzMzMzMzMzMzYlIiBzdG9wLWNvbG9yPSIjOGNiM2Qw\
+IiBzdG9wLW9wYWNpdHk9IjEiPjwvc3RvcD48c3RvcCBvZmZzZXQ9Ijc2LjY2NjY2NjY2NjY2NjY2JSIg\
+c3RvcC1jb2xvcj0iIzhjYjNkMCIgc3RvcC1vcGFjaXR5PSIxIj48L3N0b3A+PC9saW5lYXJHcmFkaWVu\
+dD48L2RlZnM+PGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoOTAwLCAwKSI+PHBhdGggZD0iTTAgNDIxLjlD\
+LTYwLjEgNDIyLjMgLTEyMC4yIDQyMi43IC0xNjEuNCAzODkuOEMtMjAyLjcgMzU2LjggLTIyNS4yIDI5\
+MC40IC0yNDEuMSAyNDEuMUMtMjU3LjEgMTkxLjkgLTI2Ni42IDE1OS44IC0yOTUuNiAxMjIuNUMtMzI0\
+LjcgODUuMSAtMzczLjMgNDIuNiAtNDIxLjkgMEwwIDBaIiBmaWxsPSIjZDJhZjdiIj48L3BhdGg+PC9n\
+PjxnIHRyYW5zZm9ybT0idHJhbnNsYXRlKDAsIDY3NSkiPjxwYXRoIGQ9Ik0wIC00MjEuOUM2OC4zIC00\
+MjkuMSAxMzYuNSAtNDM2LjMgMTYxLjQgLTM4OS44QzE4Ni40IC0zNDMuMyAxNjggLTI0My4xIDIwMC44\
+IC0yMDAuOEMyMzMuNyAtMTU4LjYgMzE3LjcgLTE3NC4yIDM2My4xIC0xNTAuNEM0MDguNSAtMTI2LjYg\
+NDE1LjIgLTYzLjMgNDIxLjkgMEwwIDBaIiBmaWxsPSIjZDJhZjdiIj48L3BhdGg+PC9nPjwvc3ZnPg==");
+    background-size: cover;
+    background-repeat: no-repeat;
+}
 .bg-pastell-gruen  { background-color: #e6f6ce; }
+.product-info-box.bg-pastell-gruen {
+    background-image: url("data:image/svg+xml;base64,\
+PHN2ZyBpZD0idmlzdWFsIiB2aWV3Qm94PSIwIDAgOTAwIDY3NSIgd2lkdGg9Ijkw\
+MCIgaGVpZ2h0PSI2NzUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2\
+ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHZl\
+cnNpb249IjEuMSI+PHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjkwMCIgaGVpZ2h0\
+PSI2NzUiIGZpbGw9IiNlNmY2Y2UiPjwvcmVjdD48ZGVmcz48bGluZWFyR3JhZGll\
+bnQgaWQ9ImdyYWQxXzAiIHgxPSIyNSUiIHkxPSIxMDAlIiB4Mj0iMTAwJSIgeTI9\
+IjAlIj48c3RvcCBvZmZzZXQ9IjIzLjMzMzMzMzMzMzMzMzMzNiUiIHN0b3AtY29s\
+b3I9IiNlNmY2Y2UiIHN0b3Atb3BhY2l0eT0iMSI+PC9zdG9wPjxzdG9wIG9mZnNl\
+dD0iNzYuNjY2NjY2NjY2NjY2NjYlIiBzdG9wLWNvbG9yPSIjZTZmNmNlIiBzdG9w\
+LW9wYWNpdHk9IjEiPjwvc3RvcD48L2xpbmVhckdyYWRpZW50PjwvZGVmcz48ZGVm\
+cz48bGluZWFyR3JhZGllbnQgaWQ9ImdyYWQyXzAiIHgxPSIwJSIgeTE9IjEwMCUi\
+IHgyPSI3NSUiIHkyPSIwJSI+PHN0b3Agb2Zmc2V0PSIyMy4zMzMzMzMzMzMzMzMz\
+MzYlIiBzdG9wLWNvbG9yPSIjZTZmNmNlIiBzdG9wLW9wYWNpdHk9IjEiPjwvc3Rv\
+cD48c3RvcCBvZmZzZXQ9Ijc2LjY2NjY2NjY2NjY2NjY2JSIgc3RvcC1jb2xvcj0i\
+I2U2ZjZjZSIgc3RvcC1vcGFjaXR5PSIxIj48L3N0b3A+PC9saW5lYXJHcmFkaWVu\
+dD48L2RlZnM+PGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoOTAwLCA2NzUpIj48cGF0\
+aCBkPSJNLTQyMS45IDBDLTQwOS43IC01OC45IC0zOTcuNCAtMTE3LjkgLTM1OS40\
+IC0xNDguOUMtMzIxLjMgLTE3OS45IC0yNTcuNSAtMTgyLjkgLTIyNS42IC0yMjUu\
+NkMtMTkzLjcgLTI2OC4yIC0xOTMuNyAtMzUwLjQgLTE2MS40IC0zODkuOEMtMTI5\
+LjIgLTQyOS4xIC02NC42IC00MjUuNSAwIC00MjEuOUwwIDBaIiBmaWxsPSIjNjkx\
+M2U5Ij48L3BhdGg+PC9nPjxnIHRyYW5zZm9ybT0idHJhbnNsYXRlKDAsIDApIj48\
+cGF0aCBkPSJNNDIxLjkgMEM0MTkuOCA1Ny42IDQxNy42IDExNS4zIDM4OS44IDE2\
+MS40QzM2MS45IDIwNy42IDMwOC4zIDI0Mi40IDI1OS41IDI1OS41QzIxMC43IDI3\
+Ni42IDE2Ni44IDI3Ni4xIDEyNC40IDMwMC4zQzgxLjkgMzI0LjQgNDEgMzczLjEg\
+MCA0MjEuOUwwIDBaIiBmaWxsPSIjNjkxM2U5Ij48L3BhdGg+PC9nPjwvc3ZnPg==\
+");
+    background-size: cover;
+    background-repeat: no-repeat;
+}
 .bg-pastell-gelb   { background-color: #f8f3cd; }
+.product-info-box.bg-pastell-gelb {
+    background-image: url("data:image/svg+xml;base64,PHN2ZyBpZD0idmlzdWFsIiB2aWV3Qm94PSIwIDAgOTAwIDY3NSIgd2lkdGg9IjkwMCIgaGVpZ2h0PSI2NzUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHZlcnNpb249IjEuMSI+PHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjkwMCIgaGVpZ2h0PSI2NzUiIGZpbGw9IiNmOGYzY2QiPjwvcmVjdD48ZGVmcz48bGluZWFyR3JhZGllbnQgaWQ9ImdyYWQxXzAiIHgxPSIyNSUiIHkxPSIwJSIgeDI9IjEwMCUiIHkyPSIxMDAlIj48c3RvcCBvZmZzZXQ9IjIzLjMzMzMzMzMzMzMzMzMzNiUiIHN0b3AtY29sb3I9IiNmOGYzY2QiIHN0b3Atb3BhY2l0eT0iMSI+PC9zdG9wPjxzdG9wIG9mZnNldD0iNzYuNjY2NjY2NjY2NjY2NjYlIiBzdG9wLWNvbG9yPSIjZjhmM2NkIiBzdG9wLW9wYWNpdHk9IjEiPjwvc3RvcD48L2xpbmVhckdyYWRpZW50PjwvZGVmcz48ZGVmcz48bGluZWFyR3JhZGllbnQgaWQ9ImdyYWQyXzAiIHgxPSIwJSIgeTE9IjAlIiB4Mj0iNzUlIiB5Mj0iMTAwJSI+PHN0b3Agb2Zmc2V0PSIyMy4zMzMzMzMzMzMzMzMzMzYlIiBzdG9wLWNvbG9yPSIjZjhmM2NkIiBzdG9wLW9wYWNpdHk9IjEiPjwvc3RvcD48c3RvcCBvZmZzZXQ9Ijc2LjY2NjY2NjY2NjY2NjY2JSIgc3RvcC1jb2xvcj0iI2Y4ZjNjZCIgc3RvcC1vcGFjaXR5PSIxIj48L3N0b3A+PC9saW5lYXJHcmFkaWVudD48L2RlZnM+PGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoOTAwLCAwKSI+PHBhdGggZD0iTTAgNDUwQy04Mi44IDQ0MC42IC0xNjUuNSA0MzEuMiAtMjI1IDM4OS43Qy0yODQuNSAzNDguMyAtMzIwLjYgMjc0LjggLTM1NC4yIDIwNC41Qy0zODcuOCAxMzQuMiAtNDE4LjkgNjcuMSAtNDUwIDBMMCAwWiIgZmlsbD0iIzBkNjI1MCI+PC9wYXRoPjwvZz48ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgwLCA2NzUpIj48cGF0aCBkPSJNMCAtNDUwQzY5LjggLTQyMy41IDEzOS41IC0zOTcuMSAyMDkuNSAtMzYyLjlDMjc5LjUgLTMyOC43IDM0OS42IC0yODYuOCAzODkuNyAtMjI1QzQyOS44IC0xNjMuMiA0MzkuOSAtODEuNiA0NTAgMEwwIDBaIiBmaWxsPSIjMGQ2MjUwIj48L3BhdGg+PC9nPjwvc3ZnPg==");
+    background-size: cover;
+    background-repeat: no-repeat;
+}
 
 .quicknav-list {
     list-style: none;
@@ -2916,6 +2997,12 @@ body.category-modal-open {
     color: #fff;
     font-size: 0.85rem;
 }
+.activity-table tr.pending-return { background-color: #efffec; }
+
+
+.activity-table td.details-cell {
+    text-align: center;
+}
 
 .status-offen { background: #f39c12; }
 .status-abgeschlossen {
@@ -2932,9 +3019,128 @@ body.category-modal-open {
     margin-top: 20px;
 }
 
+.card-new-product {
+    background: linear-gradient(210deg, #315143, #062216);
+    color: #ffffff !important;
+    border-radius: 20px;
+    padding: 1.5rem;
+    position: relative;
+}
+.card-new-product h2,
+.card-new-product p {
+    color: #ffffff;
+}
+.add-product-btn {
+    position: absolute;
+    bottom: 15px;
+    right: 15px;
+}
+.add-product-btn svg {
+    width: 48px !important;
+    height: 48px !important;
+    fill: #ffffff !important;
+    stroke: none !important;
+}
+.add-category-btn {
+    margin-right: 20px;
+}
+
+.card-product-selector {
+    background: #fff;
+    border-radius: 20px;
+    padding: 1.5rem;
+}
+.selected-product-preview {
+    margin-top: 1rem;
+    position: relative;
+    overflow: hidden;
+    border-radius: 8px;
+}
+.selected-product-preview img,
+.selected-product-preview .placeholder-icon {
+    width: 100%;
+    height: 300px;
+    display: block;
+    object-fit: cover;
+}
+.selected-product-preview .placeholder-icon {
+    background: #f0f0f0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 2rem;
+    color: #777;
+}
+.selected-product-preview .tile-overlay {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.6);
+    color: #fff;
+    padding: 0.3rem 0.5rem;
+    font-size: 14px;
+}
+.selected-product-preview .tile-overlay span {
+    color: #ffffff !important;
+}
+
+.prod-card-title {
+    margin-top: 20px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 18px;
+}
+.card-header-flex {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+.card-header-actions {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+/* Search/filter bar within product list */
+.product-search-bar {
+    background: #fdfaf1;
+    border-radius: 999px;
+    padding: 0.3rem 2.5rem;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    height: 50px;
+}
+.search-input-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+.product-search-bar .search-icon {
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
+    display: block;
+    fill: #15287a;
+}
+.product-search-bar input[type="text"] {
+    border: none;
+    background: transparent;
+    flex: 1;
+    padding: 0 0.5rem;
+}
+.product-search-bar select {
+    border: none;
+    background: transparent;
+    min-width: 150px;
+    padding: 0;
+}
+
 .card-company a {
     color: #ffffff;
-    text-decoration: underline;
+    text-decoration: none;
 }
 	
 .card-company h2 {
@@ -2951,6 +3157,80 @@ body.category-modal-open {
 }
 .card-company strong {
     color: #ffffff;
+}
+
+/* Mini tiles for recent products */
+.recent-product-tiles {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    gap: 15px;
+}
+
+.recent-product-tile {
+    position: relative;
+    height: 160px;
+    border-radius: 12px;
+    overflow: hidden;
+    background-size: cover;
+    background-position: center;
+    transition: transform 0.3s ease;
+    cursor: pointer;
+}
+
+.recent-product-tile:hover {
+    transform: scale(1.05);
+}
+
+.recent-product-tile .tile-overlay {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 25%;
+    background: rgba(0, 0, 0, 0.6);
+    color: #ffffff;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 0.5rem;
+    font-size: 14px;
+    transition: background 0.3s ease;
+}
+
+.recent-product-tile .tile-overlay span {
+    color: #ffffff !important;
+}
+
+.recent-product-tile:hover .tile-overlay {
+    background: rgba(0, 0, 0, 0.4);
+}
+
+.recent-product-tile .edit-btn {
+    display: none;
+}
+
+.recent-product-tile:hover .edit-btn {
+    display: block;
+}
+
+.recent-product-tile.no-image {
+    background: #f0f0f0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #777;
+    font-size: 2rem;
+}
+
+.recent-product-tile .placeholder-icon {
+    pointer-events: none;
+}
+
+.recent-product-tile .edit-btn svg {
+    fill: #ffffff;
+    stroke: none;
+    width: 15px;
+    height: 15px;
 }
 	
 .quicknav-grid {
@@ -3169,6 +3449,18 @@ body.category-modal-open {
     grid-template-columns: 1fr;
   }
 }
+@media (max-width: 1500px) {
+  .dashboard-grid {
+    flex-wrap: wrap;
+  }
+  .dashboard-left,
+  .dashboard-right {
+    flex-basis: 100%;
+  }
+  .dashboard-right {
+    padding-right: 0;
+  }
+}
 /* === Erweiterung: Sidebar Order Details Struktur === */
 
 /* Header mit Auftragsnummer */
@@ -3220,11 +3512,12 @@ body.category-modal-open {
 .customer-icons {
     display: flex;
     gap: 8px;
-    font-size: 1.1rem;
-    color: #666;
 }
-.customer-icons .icon {
-    cursor: pointer;
+.customer-icons .icon-btn svg {
+    width: 20px;
+    height: 20px;
+    fill: #666;
+    stroke: none;
 }
 
 /* Mietzeit-Box */
@@ -3357,6 +3650,74 @@ body.category-modal-open {
     stroke: white;
     stroke-width: 3px;
 }
+.icon-btn-no-stroke svg {
+    stroke: none;
+    stroke-width: 0;
+}
 .icon-btn + .icon-btn {
     margin-left: 8px;
+}
+.bulk-delete-btn {
+    margin-left: 4px;
+}
+.filter-submit-btn svg {
+    width: 24px;
+    height: 24px;
+    stroke: none;
+    stroke-width: 0;
+}
+.bulk-delete-btn svg {
+    width: 16px;
+    height: 16px;
+}
+
+/* Sidebar order details extras */
+
+.order-log-list {
+    list-style: disc;
+    margin: 0 0 0 1.2rem;
+    padding: 0;
+    font-size: 0.85rem;
+}
+.order-log-list li {
+    margin: 0.25rem 0;
+}
+
+.order-note-form {
+    display: none;
+    margin-top: 1rem;
+}
+.order-note-form.visible {
+    display: block;
+}
+.order-note-form textarea {
+    width: 100%;
+    height: 80px;
+    margin-bottom: 0.5rem;
+}
+.order-note {
+    background: #fff8b5;
+    padding: 0.5rem 0.75rem;
+    border-radius: 6px;
+    margin-top: 0.5rem;
+    font-size: 0.9rem;
+    position: relative;
+}
+.order-note .note-date {
+    text-align: right;
+    font-size: 0.75rem;
+    color: #666;
+}
+.order-note .note-delete-btn {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+}
+.order-note .note-delete-btn svg {
+    width: 12px;
+    height: 12px;
 }

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -923,6 +923,7 @@ class Admin {
 
         $categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}produkt_categories ORDER BY sort_order, name");
         $selected_category = isset($_GET['category']) ? intval($_GET['category']) : 0;
+        $search_term = isset($_GET['s']) ? sanitize_text_field($_GET['s']) : '';
 
         $date_from = isset($_GET['date_from']) ? sanitize_text_field($_GET['date_from']) : date('Y-m-d', strtotime('-30 days'));
         $date_to = isset($_GET['date_to']) ? sanitize_text_field($_GET['date_to']) : date('Y-m-d');
@@ -937,6 +938,12 @@ class Admin {
         if ($selected_category > 0) {
             $where_conditions[] = "o.category_id = %d";
             $where_values[] = $selected_category;
+        }
+        if ($search_term !== '') {
+            $like = '%' . $wpdb->esc_like(ltrim($search_term, '#')) . '%';
+            $where_conditions[] = "(o.order_number LIKE %s OR CAST(o.id AS CHAR) LIKE %s)";
+            $where_values[] = $like;
+            $where_values[] = $like;
         }
         $where_clause = implode(' AND ', $where_conditions);
 
@@ -999,6 +1006,7 @@ class Admin {
             'date_from',
             'date_to',
             'current_category',
+            'search_term',
             'orders',
             'order_logs',
             'total_orders',

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -1797,7 +1797,7 @@ function pv_load_order_sidebar_details() {
     require_once PRODUKT_PLUGIN_PATH . 'includes/account-helpers.php';
 
     global $wpdb;
-    global $order; // make $order available globally for the template
+    global $order, $order_logs, $order_notes, $sd, $ed, $days; // make variables available to the template
 
     $order_array = pv_get_order_by_id($order_id);
     $order = $order_array ? (object) $order_array : null;
@@ -1814,19 +1814,161 @@ function pv_load_order_sidebar_details() {
     error_log('DEBUG $order in Sidebar: ' . print_r($order, true));
 
     // Logs abrufen
-    $logs = $wpdb->get_results($wpdb->prepare("
-        SELECT * FROM {$wpdb->prefix}produkt_order_logs
-        WHERE order_id = %d ORDER BY created_at DESC
-    ", $order_id));
+    $logs = $wpdb->get_results($wpdb->prepare(
+        "SELECT * FROM {$wpdb->prefix}produkt_order_logs
+         WHERE order_id = %d ORDER BY created_at DESC",
+        $order_id
+    ));
+    $order_logs = $logs;
+
+    $order_notes = $wpdb->get_results($wpdb->prepare(
+        "SELECT id, message, created_at FROM {$wpdb->prefix}produkt_order_logs
+         WHERE order_id = %d AND event = 'Notiz' ORDER BY created_at DESC",
+        $order_id
+    ));
 
     // HTML generieren (Template einbinden)
-    global $order; // macht $order im Template sichtbar
+    global $order, $order_logs, $order_notes, $sd, $ed, $days; // macht $order im Template sichtbar
     ob_start();
-$order_data = $order;
-include PRODUKT_PLUGIN_PATH . 'admin/dashboard/sidebar-order-details.php';
-$html = ob_get_clean();
+    $order_data = $order;
+    include PRODUKT_PLUGIN_PATH . 'admin/dashboard/sidebar-order-details.php';
+    $html = ob_get_clean();
 
     wp_send_json_success([
         'html' => $html,
     ]);
+}
+
+add_action('wp_ajax_pv_save_order_note', __NAMESPACE__ . '\\pv_save_order_note');
+function pv_save_order_note() {
+    check_ajax_referer('produkt_admin_action', 'nonce');
+    if (!current_user_can('manage_options')) {
+        wp_send_json_error('forbidden', 403);
+    }
+
+    $order_id = intval($_POST['order_id'] ?? 0);
+    $note = sanitize_textarea_field($_POST['note'] ?? '');
+    if (!$order_id || $note === '') {
+        wp_send_json_error('missing');
+    }
+
+    global $wpdb;
+    $table = $wpdb->prefix . 'produkt_order_logs';
+    $wpdb->insert($table, [
+        'order_id'   => $order_id,
+        'event'      => 'Notiz',
+        'message'    => $note,
+        'created_at' => current_time('mysql'),
+    ], [
+        '%d', '%s', '%s', '%s'
+    ]);
+
+    $note_id = $wpdb->insert_id;
+    $date = date_i18n('d.m.Y H:i', current_time('timestamp'));
+    wp_send_json_success(['date' => $date, 'id' => $note_id]);
+}
+
+add_action('wp_ajax_pv_delete_order_note', __NAMESPACE__ . '\\pv_delete_order_note');
+function pv_delete_order_note() {
+    check_ajax_referer('produkt_admin_action', 'nonce');
+    if (!current_user_can('manage_options')) {
+        wp_send_json_error('forbidden', 403);
+    }
+
+    $note_id = intval($_POST['note_id'] ?? 0);
+    if (!$note_id) {
+        wp_send_json_error('missing');
+    }
+
+    global $wpdb;
+    $table = $wpdb->prefix . 'produkt_order_logs';
+    $deleted = $wpdb->delete($table, ['id' => $note_id], ['%d']);
+
+    if ($deleted !== false) {
+        wp_send_json_success();
+    } else {
+        wp_send_json_error('db');
+    }
+}
+
+add_action('wp_ajax_pv_save_customer_note', __NAMESPACE__ . '\\pv_save_customer_note');
+function pv_save_customer_note() {
+    check_ajax_referer('produkt_admin_action', 'nonce');
+    if (!current_user_can('manage_options')) {
+        wp_send_json_error('forbidden', 403);
+    }
+
+    $customer_id = intval($_POST['customer_id'] ?? 0);
+    $note = sanitize_textarea_field($_POST['note'] ?? '');
+    if (!$customer_id || $note === '') {
+        wp_send_json_error('missing');
+    }
+
+    global $wpdb;
+    $table = $wpdb->prefix . 'produkt_customer_notes';
+    $inserted = $wpdb->insert($table, [
+        'customer_id' => $customer_id,
+        'message'     => $note,
+        'created_at'  => current_time('mysql'),
+    ], ['%d','%s','%s']);
+
+    if (!$inserted) {
+        wp_send_json_error('db');
+    }
+
+    $note_id = $wpdb->insert_id;
+    $date = date_i18n('d.m.Y H:i', current_time('timestamp'));
+    wp_send_json_success(['date' => $date, 'id' => $note_id]);
+}
+
+add_action('wp_ajax_pv_delete_customer_note', __NAMESPACE__ . '\\pv_delete_customer_note');
+function pv_delete_customer_note() {
+    check_ajax_referer('produkt_admin_action', 'nonce');
+    if (!current_user_can('manage_options')) {
+        wp_send_json_error('forbidden', 403);
+    }
+
+    $note_id = intval($_POST['note_id'] ?? 0);
+    if (!$note_id) {
+        wp_send_json_error('missing');
+    }
+
+    global $wpdb;
+    $table = $wpdb->prefix . 'produkt_customer_notes';
+    $deleted = $wpdb->delete($table, ['id' => $note_id], ['%d']);
+
+    if ($deleted !== false) {
+        wp_send_json_success();
+    } else {
+        wp_send_json_error('db');
+    }
+}
+
+add_action('wp_ajax_pv_load_customer_logs', __NAMESPACE__ . '\\pv_load_customer_logs');
+function pv_load_customer_logs() {
+    check_ajax_referer('produkt_admin_action', 'nonce');
+    if (!current_user_can('manage_options')) {
+        wp_send_json_error('forbidden', 403);
+    }
+
+    $order_ids = isset($_POST['order_ids']) ? array_map('intval', (array)$_POST['order_ids']) : [];
+    $offset = intval($_POST['offset'] ?? 0);
+    if (!$order_ids) {
+        wp_send_json_error('missing');
+    }
+
+    global $wpdb;
+    $placeholders = implode(',', array_fill(0, count($order_ids), '%d'));
+    $params = $order_ids;
+    $params[] = $offset;
+    $sql = "SELECT event, message, created_at FROM {$wpdb->prefix}produkt_order_logs WHERE order_id IN ($placeholders) ORDER BY created_at DESC LIMIT 5 OFFSET %d";
+    $logs = $wpdb->get_results($wpdb->prepare($sql, $params));
+
+    ob_start();
+    foreach ($logs as $log) {
+        echo '<li>' . esc_html(date_i18n('d.m.Y H:i', strtotime($log->created_at)) . ' – ' . $log->event . ($log->message ? ': ' . $log->message : '')) . '</li>';
+    }
+    $html = ob_get_clean();
+
+    wp_send_json_success(['html' => $html, 'count' => count($logs)]);
 }

--- a/includes/Database.php
+++ b/includes/Database.php
@@ -765,6 +765,24 @@ class Database {
             dbDelta($sql);
         }
 
+        // Create customer notes table if it doesn't exist
+        $table_cnotes = $wpdb->prefix . 'produkt_customer_notes';
+        $cnotes_exists = $wpdb->get_var("SHOW TABLES LIKE '$table_cnotes'");
+        if (!$cnotes_exists) {
+            $charset_collate = $wpdb->get_charset_collate();
+            $sql = "CREATE TABLE $table_cnotes (
+                id mediumint(9) NOT NULL AUTO_INCREMENT,
+                customer_id mediumint(9) NOT NULL,
+                message text NOT NULL,
+                created_at datetime DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (id),
+                KEY customer_id (customer_id)
+            ) $charset_collate;";
+
+            require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
+            dbDelta($sql);
+        }
+
         // Create webhook logs table if it doesn't exist
         $table_webhooks = $wpdb->prefix . 'produkt_webhook_logs';
         $webhook_exists = $wpdb->get_var("SHOW TABLES LIKE '$table_webhooks'");
@@ -1981,6 +1999,12 @@ class Database {
         global $wpdb;
         $table = $wpdb->prefix . 'produkt_product_categories';
         return (bool) $wpdb->get_var("SHOW COLUMNS FROM $table LIKE 'parent_id'");
+    }
+
+    public function customer_notes_table_exists() {
+        global $wpdb;
+        $table = $wpdb->prefix . 'produkt_customer_notes';
+        return (bool) $wpdb->get_var("SHOW TABLES LIKE '$table'");
     }
     /**
      * Get orders whose rental period has ended and inventory has not yet been returned.

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -124,7 +124,7 @@ class Plugin {
 
     public function check_for_updates() {
         $current_version = get_option('produkt_version', '1.0.0');
-        $needs_schema = !$this->db->categories_table_has_parent_column();
+        $needs_schema = !$this->db->categories_table_has_parent_column() || !$this->db->customer_notes_table_exists();
         if (version_compare($current_version, PRODUKT_VERSION, '<') || $needs_schema) {
             $this->db->update_database();
             update_option('produkt_version', PRODUKT_VERSION);

--- a/includes/Webhook.php
+++ b/includes/Webhook.php
@@ -247,7 +247,7 @@ function send_admin_order_email(array $order, int $order_id, string $session_id)
     $bestellnr = !empty($order['order_number']) ? $order['order_number'] : $order_id;
     $message .= '<tr><td style="padding:4px 0;"><strong>Bestellnummer:</strong></td><td>' . esc_html($bestellnr) . '</td></tr>';
     $message .= '<tr><td style="padding:4px 0;"><strong>Datum:</strong></td><td>' . esc_html($order_date) . '</td></tr>';
-    $message .= '<tr><td style="padding:4px 0;"><strong>Status:</strong></td><td>Abgeschlossen</td></tr>';
+    $message .= '<tr><td style="padding:4px 0;"><strong>Status:</strong></td><td>Bezahlt</td></tr>';
     $message .= '</table>';
 
     $message .= '<h3>Kundendaten</h3>';

--- a/includes/account-helpers.php
+++ b/includes/account-helpers.php
@@ -390,3 +390,22 @@ function pv_generate_invoice_pdf($order_id) {
 
     return $path;
 }
+
+/**
+ * Return a German greeting based on the current time of day.
+ *
+ * @return string Greeting like "Guten Morgen" or "Guten Abend".
+ */
+function pv_get_time_greeting() {
+    $hour = (int) current_time('H');
+
+    if ($hour >= 6 && $hour < 12) {
+        return 'Guten Morgen';
+    }
+
+    if ($hour >= 12 && $hour < 19) {
+        return 'Hallo';
+    }
+
+    return 'Guten Abend';
+}


### PR DESCRIPTION
## Summary
- Fix customer statistics to query finished orders correctly and compute annual activity score
- Persist customer notes with a schema check and database error handling
- Style technical data card with a blue gradient and replace log "Mehr sehen" button with a plus icon
- Add inline order-detail link in customer overview with sidebar support
- Add sublines for technical data, history, and notes sections in order sidebar

## Testing
- `php -l admin/customers-page.php`
- `php -l includes/Ajax.php`
- `php -l includes/Plugin.php`
- `php -l includes/Database.php`
- `php -l admin/dashboard/sidebar-order-details.php`


------
https://chatgpt.com/codex/tasks/task_b_688bd54aa0bc8330ac8b14da1de529e6