### PR TITLE
feat: add floating save icon for branding

### DIFF
--- a/admin/branding-page.php
+++ b/admin/branding-page.php
@@ -150,6 +150,12 @@ foreach ($results as $result) {
     
     <form method="post" action="">
         <?php wp_nonce_field('produkt_admin_action', 'produkt_admin_nonce'); ?>
+        <button type="submit" name="submit_branding" class="icon-btn branding-save-btn" aria-label="Speichern">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80.3 80.3">
+                <path d="M32,53.4c.8.8,1.9,1.2,2.9,1.2s2.1-.4,2.9-1.2l20.8-20.8c1.7-1.7,1.7-4.2,0-5.8-1.7-1.7-4.2-1.7-5.8,0l-17.9,17.9-7.7-7.7c-1.7-1.7-4.2-1.7-5.8,0-1.7,1.7-1.7,4.2,0,5.8l10.6,10.6Z"/>
+                <path d="M40.2,79.6c21.9,0,39.6-17.7,39.6-39.6S62,.5,40.2.5.6,18.2.6,40.1s17.7,39.6,39.6,39.6ZM40.2,8.8c17.1,0,31.2,14,31.2,31.2s-14,31.2-31.2,31.2-31.2-14.2-31.2-31.2,14.2-31.2,31.2-31.2Z"/>
+            </svg>
+        </button>
         <h2>🏢 Plugin-Informationen</h2>
         <table class="form-table">
             <tr>
@@ -254,7 +260,6 @@ foreach ($results as $result) {
             </tr>
         </table>
         
-        <?php submit_button('💾 Branding-Einstellungen speichern', 'primary', 'submit_branding', false, array('style' => 'font-size: 16px; padding: 10px 20px;')); ?>
     </form>
     
     <div style="margin-top: 30px; padding: 20px; background: #f8f9fa; border: 1px solid #e9ecef; border-radius: 8px;">

--- a/admin/tabs/branding-tab.php
+++ b/admin/tabs/branding-tab.php
@@ -105,6 +105,12 @@ if (isset($_POST['submit_branding'])) {
     
     <form method="post" action="" class="produkt-branding-form">
         <?php wp_nonce_field('produkt_admin_action', 'produkt_admin_nonce'); ?>
+        <button type="submit" name="submit_branding" class="icon-btn branding-save-btn" aria-label="Speichern">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80.3 80.3">
+                <path d="M32,53.4c.8.8,1.9,1.2,2.9,1.2s2.1-.4,2.9-1.2l20.8-20.8c1.7-1.7,1.7-4.2,0-5.8-1.7-1.7-4.2-1.7-5.8,0l-17.9,17.9-7.7-7.7c-1.7-1.7-4.2-1.7-5.8,0-1.7,1.7-1.7,4.2,0,5.8l10.6,10.6Z"/>
+                <path d="M40.2,79.6c21.9,0,39.6-17.7,39.6-39.6S62,.5,40.2.5.6,18.2.6,40.1s17.7,39.6,39.6,39.6ZM40.2,8.8c17.1,0,31.2,14,31.2,31.2s-14,31.2-31.2,31.2-31.2-14.2-31.2-31.2,14.2-31.2,31.2-31.2Z"/>
+            </svg>
+        </button>
         <div class="produkt-form-sections">
             <!-- Plugin Information -->
             <div class="produkt-form-section">
@@ -227,9 +233,6 @@ if (isset($_POST['submit_branding'])) {
             </div>
         </div>
         
-        <div class="produkt-form-actions">
-            <?php submit_button('💾 Branding-Einstellungen speichern', 'primary', 'submit_branding', false); ?>
-        </div>
     </form>
     
     <!-- Preview Section -->

--- a/assets/admin-style.css
+++ b/assets/admin-style.css
@@ -3360,3 +3360,15 @@ body.category-modal-open {
 .icon-btn + .icon-btn {
     margin-left: 8px;
 }
+
+.branding-save-btn {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    z-index: 1000;
+}
+
+.branding-save-btn svg {
+    width: 40px;
+    height: 40px;
+}


### PR DESCRIPTION
## Summary
- replace branding page submit button with floating icon
- add persistent save icon for branding tab
- style save button with fixed positioning

## Testing
- `php -l admin/branding-page.php`
- `php -l admin/tabs/branding-tab.php`


------
https://chatgpt.com/codex/tasks/task_b_688bd54aa0bc8330ac8b14da1de529e6