### PR TITLE
Use floating SVG save button in branding settings

### DIFF
--- a/admin/tabs/branding-tab.php
+++ b/admin/tabs/branding-tab.php
@@ -79,6 +79,12 @@ if (isset($_POST['submit_branding'])) {
 <div class="produkt-branding-tab">
     <form method="post" action="">
         <?php wp_nonce_field('produkt_admin_action', 'produkt_admin_nonce'); ?>
+        <button type="submit" name="submit_branding" class="icon-btn branding-save-btn" aria-label="Speichern">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80.3 80.3">
+                <path d="M32,53.4c.8.8,1.9,1.2,2.9,1.2s2.1-.4,2.9-1.2l20.8-20.8c1.7-1.7,1.7-4.2,0-5.8-1.7-1.7-4.2-1.7-5.8,0l-17.9,17.9-7.7-7.7c-1.7-1.7-4.2-1.7-5.8,0-1.7,1.7-1.7,4.2,0,5.8l10.6,10.6Z"/>
+                <path d="M40.2,79.6c21.9,0,39.6-17.7,39.6-39.6S62,.5,40.2.5.6,18.2.6,40.1s17.7,39.6,39.6,39.6ZM40.2,8.8c17.1,0,31.2,14,31.2,31.2s-14,31.2-31.2,31.2-31.2-14.2-31.2-31.2,14.2-31.2,31.2-31.2Z"/>
+            </svg>
+        </button>
         <div class="produkt-form-sections">
             <!-- Plugin Information -->
             <div class="dashboard-card">
@@ -215,9 +221,6 @@ if (isset($_POST['submit_branding'])) {
             </div>
         </div>
         
-        <div class="produkt-form-actions">
-            <?php submit_button('💾 Branding-Einstellungen speichern', 'primary', 'submit_branding', false); ?>
-        </div>
     </form>
 <script>
 document.addEventListener('DOMContentLoaded', function() {

--- a/assets/admin-style.css
+++ b/assets/admin-style.css
@@ -3740,6 +3740,17 @@ MCA0MjEuOUwwIDBaIiBmaWxsPSIjNjkxM2U5Ij48L3BhdGg+PC9nPjwvc3ZnPg==\
     height: 16px;
 }
 
+.branding-save-btn {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    z-index: 1000;
+}
+.branding-save-btn svg {
+    width: 48px;
+    height: 48px;
+}
+
 /* Sidebar order details extras */
 
 .order-log-list {


### PR DESCRIPTION
## Summary
- Replace branding tab's bottom submit button with a floating SVG icon
- Style floating save button to stay visible during scrolling

## Testing
- `php -l admin/tabs/branding-tab.php`


------
https://chatgpt.com/codex/tasks/task_b_68926804639483308932697b7ea71fca