### PR TITLE
Refine button labels and order numbering

### DIFF
--- a/admin/tabs/buttons-tab.php
+++ b/admin/tabs/buttons-tab.php
@@ -52,7 +52,7 @@ $last_order_nr = get_option('produkt_last_order_number', '');
                 <p class="card-subline">Beschriftung und Preisinformationen</p>
                 <div class="form-grid">
                     <div class="produkt-form-group">
-                        <label>Button-Text</label>
+                        <label>Jetzt mieten Text</label>
                         <input type="text" name="button_text" value="<?php echo esc_attr($ui['button_text']); ?>">
                     </div>
                     <div class="produkt-form-group">
@@ -86,11 +86,11 @@ $last_order_nr = get_option('produkt_last_order_number', '');
                         <label>Preiszeitraum</label>
                         <select name="price_period">
                             <option value="month" <?php selected($ui['price_period'], 'month'); ?>>pro Monat</option>
-                            <option value="one-time" <?php selected($ui['price_period'], 'one-time'); ?>>einmalig</option>
+                            <option value="one-time" <?php selected($ui['price_period'], 'one-time'); ?>>pro Tag</option>
                         </select>
                     </div>
                     <div class="produkt-form-group">
-                        <label>Mit MwSt.</label>
+                        <label>MwSt label anzeigen?</label>
                         <label class="produkt-toggle-label">
                             <input type="checkbox" name="vat_included" value="1" <?php checked($ui['vat_included'], 1); ?>>
                             <span class="produkt-toggle-slider"></span>
@@ -128,8 +128,17 @@ $last_order_nr = get_option('produkt_last_order_number', '');
                 </div>
             </div>
             <div class="dashboard-card">
-                <h2>Tooltips</h2>
-                <p class="card-subline">Hilfetexte auf der Produktseite</p>
+                <div class="card-header-flex">
+                    <div>
+                        <h2>Tooltips</h2>
+                        <p class="card-subline">Hilfetexte auf der Produktseite</p>
+                    </div>
+                    <label class="produkt-toggle-label">
+                        <input type="checkbox" name="show_tooltips" value="1" <?php checked($ui['show_tooltips'], 1); ?>>
+                        <span class="produkt-toggle-slider"></span>
+                        <span>Tooltips auf Produktseite anzeigen</span>
+                    </label>
+                </div>
                 <div class="form-grid">
                     <div class="produkt-form-group">
                         <label>Mietdauer-Tooltip</label>
@@ -138,13 +147,6 @@ $last_order_nr = get_option('produkt_last_order_number', '');
                     <div class="produkt-form-group">
                         <label>Zustand-Tooltip</label>
                         <textarea name="condition_tooltip" rows="4"><?php echo esc_textarea($ui['condition_tooltip']); ?></textarea>
-                    </div>
-                    <div class="produkt-form-group full-width">
-                        <label>Tooltips auf Produktseite anzeigen</label>
-                        <label class="produkt-toggle-label">
-                            <input type="checkbox" name="show_tooltips" value="1" <?php checked($ui['show_tooltips'], 1); ?>>
-                            <span class="produkt-toggle-slider"></span>
-                        </label>
                     </div>
                 </div>
             </div>

--- a/admin/tabs/variants-add-tab.php
+++ b/admin/tabs/variants-add-tab.php
@@ -43,16 +43,18 @@ $modus = get_option('produkt_betriebsmodus', 'miete');
             </div>
 
             <div class="dashboard-card">
-                <h2>Verfügbarkeit</h2>
-                <p class="card-subline">Buchbarkeit</p>
-                <div class="form-grid">
-                    <div class="produkt-form-group">
-                        <label class="produkt-toggle-label">
-                            <input type="checkbox" name="available" value="1" checked>
-                            <span class="produkt-toggle-slider"></span>
-                            <span>Verfügbar</span>
-                        </label>
+                <div class="card-header-flex">
+                    <div>
+                        <h2>Verfügbarkeit</h2>
+                        <p class="card-subline">Buchbarkeit</p>
                     </div>
+                    <label class="produkt-toggle-label">
+                        <input type="checkbox" name="available" value="1" checked>
+                        <span class="produkt-toggle-slider"></span>
+                        <span>Verfügbar</span>
+                    </label>
+                </div>
+                <div class="form-grid">
                     <div class="produkt-form-group">
                         <label>Text wenn nicht verfügbar</label>
                         <input type="text" name="availability_note" placeholder="z.B. Wieder verfügbar ab 15.03.2024">

--- a/admin/tabs/variants-edit-tab.php
+++ b/admin/tabs/variants-edit-tab.php
@@ -55,16 +55,18 @@ $verkaufspreis_formatted = number_format((float)$verkaufspreis_einmalig, 2, '.',
             </div>
 
             <div class="dashboard-card">
-                <h2>Verfügbarkeit</h2>
-                <p class="card-subline">Buchbarkeit</p>
-                <div class="form-grid">
-                    <div class="produkt-form-group">
-                        <label class="produkt-toggle-label">
-                            <input type="checkbox" name="available" value="1" <?php echo ($edit_item->available ?? 1) ? 'checked' : ''; ?>>
-                            <span class="produkt-toggle-slider"></span>
-                            <span>Verfügbar</span>
-                        </label>
+                <div class="card-header-flex">
+                    <div>
+                        <h2>Verfügbarkeit</h2>
+                        <p class="card-subline">Buchbarkeit</p>
                     </div>
+                    <label class="produkt-toggle-label">
+                        <input type="checkbox" name="available" value="1" <?php echo ($edit_item->available ?? 1) ? 'checked' : ''; ?>>
+                        <span class="produkt-toggle-slider"></span>
+                        <span>Verfügbar</span>
+                    </label>
+                </div>
+                <div class="form-grid">
                     <div class="produkt-form-group">
                         <label>Text wenn nicht verfügbar</label>
                         <input type="text" name="availability_note" value="<?php echo esc_attr($edit_item->availability_note ?? ''); ?>">

--- a/assets/admin-style.css
+++ b/assets/admin-style.css
@@ -9,7 +9,7 @@
 }
 
 #wpwrap {
-    background-image: url('main-page-bg.svg');
+    background-image: url('bg.jpg');
     background-position: center;
     background-repeat: no-repeat;
     background-size: cover;


### PR DESCRIPTION
## Summary
- adjust button, price period and VAT labels in settings
- align tooltip and availability toggles to card headers
- generate custom order numbers for preliminary orders
- update admin background styling

## Testing
- `php -l admin/tabs/buttons-tab.php`
- `php -l admin/tabs/variants-edit-tab.php`
- `php -l admin/tabs/variants-add-tab.php`
- `php -l includes/Ajax.php`


------
https://chatgpt.com/codex/tasks/task_b_689a501dfcec83309df2a0bee6a91108