### PR TITLE
Add weekend tariff pricing for one-time purchases

### DIFF
--- a/admin/dashboard/sidebar-order-details.php
+++ b/admin/dashboard/sidebar-order-details.php
@@ -129,6 +129,9 @@ $produkte = $order->produkte ?? [$order]; // fallback
                     <?php if (!empty($p->extra_names)) : ?>
                         <div>Extras: <?php echo esc_html($p->extra_names); ?></div>
                     <?php endif; ?>
+                    <?php if (!empty($p->weekend_tariff)) : ?>
+                        <div>Hinweis: Wochenendtarif</div>
+                    <?php endif; ?>
                     <div>Miettage: <?php echo esc_html($days !== null ? $days : ($p->dauer_text ?? '–')); ?></div>
                 </div>
 

--- a/admin/tabs/buttons-tab.php
+++ b/admin/tabs/buttons-tab.php
@@ -52,7 +52,7 @@ $last_order_nr = get_option('produkt_last_order_number', '');
                 <p class="card-subline">Beschriftung und Preisinformationen</p>
                 <div class="form-grid">
                     <div class="produkt-form-group">
-                        <label>Button-Text</label>
+                        <label>Jetzt mieten Text</label>
                         <input type="text" name="button_text" value="<?php echo esc_attr($ui['button_text']); ?>">
                     </div>
                     <div class="produkt-form-group">
@@ -86,11 +86,11 @@ $last_order_nr = get_option('produkt_last_order_number', '');
                         <label>Preiszeitraum</label>
                         <select name="price_period">
                             <option value="month" <?php selected($ui['price_period'], 'month'); ?>>pro Monat</option>
-                            <option value="one-time" <?php selected($ui['price_period'], 'one-time'); ?>>einmalig</option>
+                            <option value="one-time" <?php selected($ui['price_period'], 'one-time'); ?>>pro Tag</option>
                         </select>
                     </div>
                     <div class="produkt-form-group">
-                        <label>Mit MwSt.</label>
+                        <label>MwSt label anzeigen?</label>
                         <label class="produkt-toggle-label">
                             <input type="checkbox" name="vat_included" value="1" <?php checked($ui['vat_included'], 1); ?>>
                             <span class="produkt-toggle-slider"></span>
@@ -128,8 +128,17 @@ $last_order_nr = get_option('produkt_last_order_number', '');
                 </div>
             </div>
             <div class="dashboard-card">
-                <h2>Tooltips</h2>
-                <p class="card-subline">Hilfetexte auf der Produktseite</p>
+                <div class="card-header-flex">
+                    <div>
+                        <h2>Tooltips</h2>
+                        <p class="card-subline">Hilfetexte auf der Produktseite</p>
+                    </div>
+                    <label class="produkt-toggle-label">
+                        <input type="checkbox" name="show_tooltips" value="1" <?php checked($ui['show_tooltips'], 1); ?>>
+                        <span class="produkt-toggle-slider"></span>
+                        <span>Tooltips auf Produktseite anzeigen</span>
+                    </label>
+                </div>
                 <div class="form-grid">
                     <div class="produkt-form-group">
                         <label>Mietdauer-Tooltip</label>
@@ -138,13 +147,6 @@ $last_order_nr = get_option('produkt_last_order_number', '');
                     <div class="produkt-form-group">
                         <label>Zustand-Tooltip</label>
                         <textarea name="condition_tooltip" rows="4"><?php echo esc_textarea($ui['condition_tooltip']); ?></textarea>
-                    </div>
-                    <div class="produkt-form-group full-width">
-                        <label>Tooltips auf Produktseite anzeigen</label>
-                        <label class="produkt-toggle-label">
-                            <input type="checkbox" name="show_tooltips" value="1" <?php checked($ui['show_tooltips'], 1); ?>>
-                            <span class="produkt-toggle-slider"></span>
-                        </label>
                     </div>
                 </div>
             </div>

--- a/admin/tabs/variants-add-tab.php
+++ b/admin/tabs/variants-add-tab.php
@@ -35,6 +35,12 @@ $modus = get_option('produkt_betriebsmodus', 'miete');
                         <label><?php echo ($modus === 'kauf') ? 'Preis / Tag (EUR) *' : 'Einmaliger Verkaufspreis'; ?></label>
                         <input type="number" step="0.01" name="verkaufspreis_einmalig" placeholder="0.00">
                     </div>
+                    <?php if ($modus === 'kauf'): ?>
+                    <div class="produkt-form-group">
+                        <label>Preis / Tag / Wochenende (EUR)</label>
+                        <input type="number" step="0.01" name="weekend_price" placeholder="0.00">
+                    </div>
+                    <?php endif; ?>
                 </div>
                 <div class="produkt-form-group full-width">
                     <label>Beschreibung</label>
@@ -43,16 +49,18 @@ $modus = get_option('produkt_betriebsmodus', 'miete');
             </div>
 
             <div class="dashboard-card">
-                <h2>Verfügbarkeit</h2>
-                <p class="card-subline">Buchbarkeit</p>
-                <div class="form-grid">
-                    <div class="produkt-form-group">
-                        <label class="produkt-toggle-label">
-                            <input type="checkbox" name="available" value="1" checked>
-                            <span class="produkt-toggle-slider"></span>
-                            <span>Verfügbar</span>
-                        </label>
+                <div class="card-header-flex">
+                    <div>
+                        <h2>Verfügbarkeit</h2>
+                        <p class="card-subline">Buchbarkeit</p>
                     </div>
+                    <label class="produkt-toggle-label">
+                        <input type="checkbox" name="available" value="1" checked>
+                        <span class="produkt-toggle-slider"></span>
+                        <span>Verfügbar</span>
+                    </label>
+                </div>
+                <div class="form-grid">
                     <div class="produkt-form-group">
                         <label>Text wenn nicht verfügbar</label>
                         <input type="text" name="availability_note" placeholder="z.B. Wieder verfügbar ab 15.03.2024">

--- a/admin/tabs/variants-edit-tab.php
+++ b/admin/tabs/variants-edit-tab.php
@@ -4,6 +4,8 @@ $verkaufspreis_einmalig = floatval($edit_item->verkaufspreis_einmalig);
 $modus = get_option('produkt_betriebsmodus', 'miete');
 $mietpreis_monatlich = number_format((float)$edit_item->mietpreis_monatlich, 2, '.', '');
 $verkaufspreis_formatted = number_format((float)$verkaufspreis_einmalig, 2, '.', '');
+$weekend_price = floatval($edit_item->weekend_price);
+$weekend_price_formatted = number_format((float)$weekend_price, 2, '.', '');
 ?>
 
 <div class="produkt-edit-variant">
@@ -47,6 +49,12 @@ $verkaufspreis_formatted = number_format((float)$verkaufspreis_einmalig, 2, '.',
                         <label><?php echo ($modus === 'kauf') ? 'Preis / Tag (EUR) *' : 'Einmaliger Verkaufspreis'; ?></label>
                         <input type="number" step="0.01" name="verkaufspreis_einmalig" value="<?php echo esc_attr($verkaufspreis_formatted); ?>">
                     </div>
+                    <?php if ($modus === 'kauf'): ?>
+                    <div class="produkt-form-group">
+                        <label>Preis / Tag / Wochenende (EUR)</label>
+                        <input type="number" step="0.01" name="weekend_price" value="<?php echo esc_attr($weekend_price_formatted); ?>">
+                    </div>
+                    <?php endif; ?>
                 </div>
                 <div class="produkt-form-group full-width">
                     <label>Beschreibung</label>
@@ -55,16 +63,18 @@ $verkaufspreis_formatted = number_format((float)$verkaufspreis_einmalig, 2, '.',
             </div>
 
             <div class="dashboard-card">
-                <h2>Verfügbarkeit</h2>
-                <p class="card-subline">Buchbarkeit</p>
-                <div class="form-grid">
-                    <div class="produkt-form-group">
-                        <label class="produkt-toggle-label">
-                            <input type="checkbox" name="available" value="1" <?php echo ($edit_item->available ?? 1) ? 'checked' : ''; ?>>
-                            <span class="produkt-toggle-slider"></span>
-                            <span>Verfügbar</span>
-                        </label>
+                <div class="card-header-flex">
+                    <div>
+                        <h2>Verfügbarkeit</h2>
+                        <p class="card-subline">Buchbarkeit</p>
                     </div>
+                    <label class="produkt-toggle-label">
+                        <input type="checkbox" name="available" value="1" <?php echo ($edit_item->available ?? 1) ? 'checked' : ''; ?>>
+                        <span class="produkt-toggle-slider"></span>
+                        <span>Verfügbar</span>
+                    </label>
+                </div>
+                <div class="form-grid">
                     <div class="produkt-form-group">
                         <label>Text wenn nicht verfügbar</label>
                         <input type="text" name="availability_note" value="<?php echo esc_attr($edit_item->availability_note ?? ''); ?>">

--- a/admin/variants-page.php
+++ b/admin/variants-page.php
@@ -77,7 +77,7 @@ if (isset($_POST['submit'])) {
     $stripe_price_id   = '';
     if (!empty($_POST['id'])) {
         $existing_variant = $wpdb->get_row($wpdb->prepare(
-            "SELECT name, mietpreis_monatlich, verkaufspreis_einmalig, stripe_product_id, stripe_price_id FROM $table_name WHERE id = %d",
+            "SELECT name, mietpreis_monatlich, verkaufspreis_einmalig, weekend_price, stripe_product_id, stripe_price_id, stripe_weekend_price_id FROM $table_name WHERE id = %d",
             intval($_POST['id'])
         ));
         if ($existing_variant) {
@@ -96,6 +96,7 @@ if (isset($_POST['submit'])) {
     $description = sanitize_textarea_field($_POST['description']);
     $mietpreis_monatlich    = floatval($_POST['mietpreis_monatlich']);
     $verkaufspreis_einmalig = isset($_POST['verkaufspreis_einmalig']) ? floatval($_POST['verkaufspreis_einmalig']) : 0;
+    $weekend_price = isset($_POST['weekend_price']) ? floatval($_POST['weekend_price']) : 0;
     $available = isset($_POST['available']) ? 1 : 0;
     $availability_note = sanitize_text_field($_POST['availability_note']);
     $delivery_time    = sanitize_text_field(trim($_POST['delivery_time'] ?? ''));
@@ -120,6 +121,7 @@ if (isset($_POST['submit'])) {
             'description'            => $description,
             'mietpreis_monatlich'    => $mietpreis_monatlich,
             'verkaufspreis_einmalig' => $verkaufspreis_einmalig,
+            'weekend_price'         => $weekend_price,
             'base_price'             => $mietpreis_monatlich,
             'available'              => $available,
             'availability_note'      => $availability_note,
@@ -135,7 +137,7 @@ if (isset($_POST['submit'])) {
             $update_data,
             array('id' => intval($_POST['id'])),
             array_merge(
-                array('%d','%s','%s','%f','%f','%f','%d','%s','%s','%d','%d','%d','%d'),
+                array('%d','%s','%s','%f','%f','%f','%f','%d','%s','%s','%d','%d','%d','%d'),
                 array_fill(0, 5, '%s')
             ),
             array('%d')
@@ -197,6 +199,7 @@ if (isset($_POST['submit'])) {
 
             require_once PRODUKT_PLUGIN_PATH . 'includes/stripe-sync.php';
             produkt_sync_sale_price($variant_id, $verkaufspreis_einmalig, $product_id, $mode);
+            produkt_sync_weekend_price($variant_id, $weekend_price, $product_id);
 
             \ProduktVerleih\StripeService::delete_lowest_price_cache_for_category($category_id);
         } else {
@@ -210,6 +213,7 @@ if (isset($_POST['submit'])) {
             'description'            => $description,
             'mietpreis_monatlich'    => $mietpreis_monatlich,
             'verkaufspreis_einmalig' => $verkaufspreis_einmalig,
+            'weekend_price'         => $weekend_price,
             'base_price'             => $mietpreis_monatlich,
             'available'              => $available,
             'availability_note'      => $availability_note,
@@ -224,7 +228,7 @@ if (isset($_POST['submit'])) {
             $table_name,
             $insert_data,
             array_merge(
-                array('%d','%s','%s','%f','%f','%f','%d','%s','%s','%d','%d','%d','%d'),
+                array('%d','%s','%s','%f','%f','%f','%f','%d','%s','%s','%d','%d','%d','%d'),
                 array_fill(0, 5, '%s')
             )
         );
@@ -253,6 +257,7 @@ if (isset($_POST['submit'])) {
 
             require_once PRODUKT_PLUGIN_PATH . 'includes/stripe-sync.php';
             produkt_sync_sale_price($variant_id, $verkaufspreis_einmalig, $product_id, $mode);
+            produkt_sync_weekend_price($variant_id, $weekend_price, $product_id);
 
             \ProduktVerleih\StripeService::delete_lowest_price_cache_for_category($category_id);
         } else {

--- a/assets/admin-style.css
+++ b/assets/admin-style.css
@@ -9,7 +9,7 @@
 }
 
 #wpwrap {
-    background-image: url('main-page-bg.svg');
+    background-image: url('bg.jpg');
     background-position: center;
     background-repeat: no-repeat;
     background-size: cover;

--- a/assets/script.js
+++ b/assets/script.js
@@ -23,6 +23,7 @@ jQuery(document).ready(function($) {
     let selectedDays = 0;
     let variantWeekendOnly = false;
     let variantMinDays = 0;
+    let weekendTariff = false;
     let calendarMonth = new Date();
     let colorNotificationTimeout = null;
     let cart = JSON.parse(localStorage.getItem('produkt_cart') || '[]');
@@ -96,6 +97,9 @@ jQuery(document).ready(function($) {
             }
             if (period) {
                 details.append($('<div>', {class: 'cart-item-period'}).text(period));
+            }
+            if (item.weekend_tarif) {
+                details.append($('<div>', {class: 'cart-item-weekend'}).text('Wochenendtarif'));
             }
             const price = $('<div>', {class: 'cart-item-price'}).text(formatPrice(item.final_price) + '€');
             const rem = $('<span>', {class: 'cart-item-remove', 'data-index': idx}).text('×');
@@ -367,6 +371,7 @@ jQuery(document).ready(function($) {
                 product_color_id: selectedProductColor,
                 frame_color_id: selectedFrameColor,
                 final_price: currentPrice,
+                weekend_tarif: weekendTariff ? 1 : 0,
                 image: (function(){
                     let img = '';
                     const variantOption = $('.produkt-option[data-type="variant"].selected');
@@ -419,6 +424,7 @@ jQuery(document).ready(function($) {
             if (selectedCondition) params.set('condition_id', selectedCondition);
             if (selectedProductColor) params.set('product_color_id', selectedProductColor);
             if (selectedFrameColor) params.set('frame_color_id', selectedFrameColor);
+            if (weekendTariff) params.set('weekend_tarif', 1);
             if (currentPrice) params.set('final_price', currentPrice);
 
             const produktName = $('.produkt-option[data-type="variant"].selected h4').text().trim();
@@ -955,6 +961,8 @@ jQuery(document).ready(function($) {
                     product_color_id: selectedProductColor,
                     frame_color_id: selectedFrameColor,
                     days: selectedDays,
+                    start_date: startDate,
+                    end_date: endDate,
                     nonce: produkt_ajax.nonce
                 },
                 success: function(response) {
@@ -972,6 +980,13 @@ jQuery(document).ready(function($) {
                             $('#produkt-original-price').hide();
                         }
                         $('#produkt-savings').hide();
+                        if (data.weekend_applied) {
+                            weekendTariff = true;
+                            $('#produkt-weekend-note').text('Wochenendtarif').show();
+                        } else {
+                            weekendTariff = false;
+                            $('#produkt-weekend-note').hide();
+                        }
 
                         // Update button based on availability
                         currentPriceId = data.price_id || '';

--- a/includes/Database.php
+++ b/includes/Database.php
@@ -37,6 +37,8 @@ class Database {
             'stripe_product_id'      => 'VARCHAR(255) DEFAULT NULL',
             'mietpreis_monatlich'    => 'DECIMAL(10,2) DEFAULT 0',
             'verkaufspreis_einmalig' => 'DECIMAL(10,2) DEFAULT 0',
+            'weekend_price'         => 'DECIMAL(10,2) DEFAULT 0',
+            'stripe_weekend_price_id'=> 'VARCHAR(255) DEFAULT NULL',
             'price_from'             => 'DECIMAL(10,2) DEFAULT 0',
             'mode'                   => "VARCHAR(10) DEFAULT 'miete'",
             'image_url_1' => 'TEXT',
@@ -69,6 +71,10 @@ class Database {
                     $after = 'stripe_product_id';
                 } elseif ($column === 'verkaufspreis_einmalig') {
                     $after = 'mietpreis_monatlich';
+                } elseif ($column === 'weekend_price') {
+                    $after = 'verkaufspreis_einmalig';
+                } elseif ($column === 'stripe_weekend_price_id') {
+                    $after = 'weekend_price';
                 } elseif ($column === 'mode') {
                     $after = 'price_from';
                 } elseif ($column === 'sku') {
@@ -566,6 +572,7 @@ class Database {
                 start_date date DEFAULT NULL,
                 end_date date DEFAULT NULL,
                 inventory_reverted tinyint(1) DEFAULT 0,
+                weekend_tariff tinyint(1) DEFAULT 0,
                 stripe_session_id varchar(255) DEFAULT '',
                 stripe_subscription_id varchar(255) DEFAULT '',
                 amount_total int DEFAULT 0,
@@ -614,6 +621,7 @@ class Database {
                 'start_date'        => 'date DEFAULT NULL',
                 'end_date'          => 'date DEFAULT NULL',
                 'inventory_reverted'=> 'tinyint(1) DEFAULT 0',
+                'weekend_tariff'    => 'tinyint(1) DEFAULT 0',
                 'status'            => "varchar(20) DEFAULT 'offen'",
                 'invoice_url'       => "varchar(255) DEFAULT ''"
             );
@@ -1036,6 +1044,8 @@ class Database {
             stripe_archived tinyint(1) DEFAULT 0,
             mietpreis_monatlich decimal(10,2) DEFAULT 0,
             verkaufspreis_einmalig decimal(10,2) DEFAULT 0,
+            weekend_price decimal(10,2) DEFAULT 0,
+            stripe_weekend_price_id varchar(255) DEFAULT NULL,
             base_price decimal(10,2) NOT NULL,
             price_from decimal(10,2) DEFAULT 0,
             mode varchar(10) DEFAULT 'miete',

--- a/includes/StripeService.php
+++ b/includes/StripeService.php
@@ -902,6 +902,7 @@ class StripeService {
             $start_date    = $start_date_raw !== '' ? $start_date_raw : null;
             $end_date      = $end_date_raw !== '' ? $end_date_raw : null;
             $days          = intval($metadata['days'] ?? 0);
+            $weekend_tarif  = intval($metadata['weekend_tarif'] ?? ($existing_orders[0]->weekend_tariff ?? 0));
             $user_ip       = sanitize_text_field($metadata['user_ip'] ?? '');
             $user_agent    = sanitize_text_field($metadata['user_agent'] ?? '');
 
@@ -1008,6 +1009,7 @@ class StripeService {
                 'mode'              => ($mode === 'payment' ? 'kauf' : 'miete'),
                 'start_date'        => $start_date,
                 'end_date'          => $end_date,
+                'weekend_tariff'    => $weekend_tarif,
                 'inventory_reverted'=> 0,
                 'user_ip'           => $user_ip,
                 'user_agent'        => $user_agent,

--- a/includes/render-order.php
+++ b/includes/render-order.php
@@ -41,6 +41,9 @@ if (!defined('ABSPATH')) { exit; }
             <p><strong>Miettage:</strong> <?php echo esc_html($order->dauer_text); ?></p>
         <?php endif; ?>
         <p><strong>Preis:</strong> <?php echo esc_html(number_format((float) $order->final_price, 2, ',', '.')); ?>€</p>
+        <?php if (!empty($order->weekend_tariff)) : ?>
+            <p><strong>Hinweis:</strong> Wochenendtarif</p>
+        <?php endif; ?>
         <?php if ($order->shipping_cost > 0 || !empty($order->shipping_name)) : ?>
             <p><strong>Versand:</strong> <?php echo esc_html($order->shipping_name ?: 'Versand'); ?> <?php if ($order->shipping_cost > 0) : ?>- <?php echo esc_html(number_format((float) $order->shipping_cost, 2, ',', '.')); ?>€<?php endif; ?></p>
         <?php endif; ?>

--- a/includes/stripe-sync.php
+++ b/includes/stripe-sync.php
@@ -128,6 +128,29 @@ function produkt_sync_sale_price($variant_id, $verkaufspreis_einmalig, $stripe_p
     }
 }
 
+function produkt_sync_weekend_price($variant_id, $weekend_price, $stripe_product_id) {
+    if ($weekend_price > 0 && $stripe_product_id) {
+        try {
+            $stripe_price = \Stripe\Price::create([
+                'unit_amount' => intval($weekend_price * 100),
+                'currency'    => 'eur',
+                'product'     => $stripe_product_id,
+                'nickname'    => 'Wochenendtarif',
+                'metadata'    => ['type' => 'weekend']
+            ]);
+
+            global $wpdb;
+            $wpdb->update(
+                $wpdb->prefix . 'produkt_variants',
+                ['stripe_weekend_price_id' => $stripe_price->id],
+                ['id' => $variant_id]
+            );
+        } catch (\Exception $e) {
+            // ignore Stripe weekend price error
+        }
+    }
+}
+
 function produkt_hard_delete($produkt_id) {
     if (!$produkt_id) {
         return;

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -268,6 +268,7 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
                             <?php endif; ?>
                         </div>
                         <p class="produkt-savings" id="produkt-savings" style="display: none;"></p>
+                        <p class="produkt-weekend-note" id="produkt-weekend-note" style="display:none;"></p>
                         <p class="produkt-vat-note"><?php echo $vat_included ? 'inkl. MwSt.' : 'Kein Ausweis der Umsatzsteuer gemäß § 19 UStG.'; ?></p>
                     </div>
                 </div>
@@ -343,6 +344,7 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
                              data-delivery="<?php echo esc_attr($variant->delivery_time ?? ''); ?>"
                              data-weekend="<?php echo intval($variant->weekend_only ?? 0); ?>"
                              data-min-days="<?php echo intval($variant->min_rental_days ?? 0); ?>"
+                             data-weekend-price="<?php echo esc_attr($variant->weekend_price ?? 0); ?>"
                              data-images="<?php echo esc_attr(json_encode(array(
                                  $variant->image_url_1 ?? '',
                                  $variant->image_url_2 ?? '',
@@ -367,6 +369,9 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
                                     }
                                 ?>
                                 <p class="produkt-option-price"><?php echo number_format($display_price, 2, ',', '.'); ?>€<?php echo $modus === 'kauf' ? '' : ($price_period === 'month' ? '/Monat' : ''); ?></p>
+                                <?php if ($modus === 'kauf' && floatval($variant->weekend_price) > 0): ?>
+                                    <div class="produkt-weekend-info">Wochenendpreis: <?php echo number_format((float)$variant->weekend_price, 2, ',', '.'); ?>€</div>
+                                <?php endif; ?>
                                 <?php if (!($variant->available ?? 1)): ?>
                                     <div class="produkt-availability-notice">
                                         <span class="produkt-unavailable-badge"><span class="produkt-emoji">❌</span> Nicht verfügbar</span>


### PR DESCRIPTION
## Summary
- allow variants to define a weekend-specific daily rate and sync a dedicated Stripe price
- apply weekend tariff automatically for Friday–Sunday bookings and surface the note in cart and orders
- persist weekend tariff flag in orders and enforce Europe/Berlin timezone for price checks

## Testing
- `php -l includes/Database.php`
- `php -l admin/tabs/variants-add-tab.php`
- `php -l admin/tabs/variants-edit-tab.php`
- `php -l admin/variants-page.php`
- `php -l includes/stripe-sync.php`
- `php -l includes/Ajax.php`
- `php -l includes/StripeService.php`
- `php -l templates/product-page.php`
- `php -l includes/render-order.php`
- `php -l admin/dashboard/sidebar-order-details.php`


------
https://chatgpt.com/codex/tasks/task_b_689a501dfcec83309df2a0bee6a91108