### PR TITLE
Add weekend tariff pricing for one-time purchases

### DIFF
--- a/admin/content-blocks-page.php
+++ b/admin/content-blocks-page.php
@@ -78,7 +78,7 @@ $sql_blocks .= ' ORDER BY position';
             <?php wp_nonce_field('produkt_admin_action', 'produkt_admin_nonce'); ?>
             <input type="hidden" name="id" value="<?php echo esc_attr($block->id ?? ''); ?>">
             <div class="form-grid">
-                <div class="form-field">
+                <div class="produkt-form-group">
                     <label for="category_id">Kategorie *</label>
                     <select name="category_id" id="category_id" required>
                         <?php foreach ($categories as $cat): ?>
@@ -86,30 +86,30 @@ $sql_blocks .= ' ORDER BY position';
                         <?php endforeach; ?>
                     </select>
                 </div>
-                <div class="form-field">
+                <div class="produkt-form-group">
                     <label for="style">Layout</label>
                     <select name="style" id="style">
                         <option value="compact" <?php selected($block->style ?? 'wide', 'compact'); ?>>Kompakt</option>
                         <option value="wide" <?php selected($block->style ?? 'wide', 'wide'); ?>>Weit</option>
                     </select>
                 </div>
-                <div class="form-field">
+                <div class="produkt-form-group">
                     <label for="position">Position Desktop *</label>
                     <input type="number" name="position" id="position" required value="<?php echo esc_attr($block->position ?? 9); ?>">
                 </div>
-                <div class="form-field">
+                <div class="produkt-form-group">
                     <label for="position_mobile">Position Mobil *</label>
                     <input type="number" name="position_mobile" id="position_mobile" required value="<?php echo esc_attr($block->position_mobile ?? 6); ?>">
                 </div>
-                <div class="form-field full">
+                <div class="produkt-form-group full-width">
                     <label for="title">Überschrift *</label>
                     <input type="text" name="title" id="title" required value="<?php echo esc_attr($block->title ?? ''); ?>">
                 </div>
-                <div class="form-field full">
+                <div class="produkt-form-group full-width">
                     <label for="content">Text *</label>
                     <textarea name="content" id="content" rows="4" required><?php echo esc_textarea($block->content ?? ''); ?></textarea>
                 </div>
-                <div class="form-field full">
+                <div class="produkt-form-group full-width">
                     <label>Bild</label>
                     <div class="image-field-row">
                         <div id="image_url_preview" class="image-preview">
@@ -133,15 +133,15 @@ $sql_blocks .= ' ORDER BY position';
                     </div>
                     <input type="hidden" name="image_url" id="image_url" value="<?php echo esc_attr($block->image_url ?? ''); ?>">
                 </div>
-                <div class="form-field">
+                <div class="produkt-form-group">
                     <label for="button_text">Button-Text</label>
                     <input type="text" name="button_text" id="button_text" value="<?php echo esc_attr($block->button_text ?? ''); ?>">
                 </div>
-                <div class="form-field">
+                <div class="produkt-form-group">
                     <label for="button_url">Button-Link</label>
                     <input type="url" name="button_url" id="button_url" value="<?php echo esc_attr($block->button_url ?? ''); ?>">
                 </div>
-                <div class="form-field">
+                <div class="produkt-form-group">
                     <label for="background_color">Hintergrundfarbe</label>
                     <div class="produkt-color-picker">
                         <?php $background_color = esc_attr($block->background_color ?? '#ffffff'); ?>
@@ -150,7 +150,7 @@ $sql_blocks .= ' ORDER BY position';
                         <input type="color" value="<?php echo $background_color; ?>" class="produkt-color-input">
                     </div>
                 </div>
-                <div class="form-field">
+                <div class="produkt-form-group">
                     <label for="badge_text">Badge-Text</label>
                     <input type="text" name="badge_text" id="badge_text" value="<?php echo esc_attr($block->badge_text ?? ''); ?>">
                 </div>

--- a/admin/customers-page.php
+++ b/admin/customers-page.php
@@ -257,7 +257,7 @@ if (!$customer_id) {
     $order_ids = wp_list_pluck($all_orders, 'id');
     if ($order_ids) {
         $placeholders = implode(',', array_fill(0, count($order_ids), '%d'));
-        $sql = "SELECT id, event, message, created_at FROM {$wpdb->prefix}produkt_order_logs WHERE order_id IN ($placeholders) ORDER BY created_at DESC LIMIT 5";
+        $sql = "SELECT id, order_id, event, message, created_at FROM {$wpdb->prefix}produkt_order_logs WHERE order_id IN ($placeholders) ORDER BY created_at DESC LIMIT 5";
         $customer_logs = $wpdb->get_results($wpdb->prepare($sql, $order_ids));
         $count_sql = "SELECT COUNT(*) FROM {$wpdb->prefix}produkt_order_logs WHERE order_id IN ($placeholders)";
         $total_logs = (int) $wpdb->get_var($wpdb->prepare($count_sql, $order_ids));
@@ -392,7 +392,7 @@ if (!$customer_id) {
                                 <div class="order-log-entry">
                                     <div class="log-avatar"><?php echo esc_html($avatar); ?></div>
                                     <div class="log-body">
-                                        <div class="log-date"><?php echo esc_html(date_i18n('d.m.Y H:i', strtotime($log->created_at))); ?></div>
+                                        <div class="log-date"><?php echo esc_html(date_i18n('d.m.Y H:i', strtotime($log->created_at)) . ' / #' . $log->order_id); ?></div>
                                         <div class="log-message"><?php echo esc_html($text); ?></div>
                                     </div>
                                 </div>

--- a/admin/customers-page.php
+++ b/admin/customers-page.php
@@ -289,6 +289,13 @@ if (!$customer_id) {
     $registered_date     = date_i18n('d.m.Y', strtotime($user->user_registered));
     $last_activity_date  = $customer_logs ? date_i18n('d.m.Y', strtotime($customer_logs[0]->created_at)) : '–';
     $last_order_date_card = $last_order ? date_i18n('d.m.Y', strtotime($last_order->created_at)) : '–';
+    $client_info = [];
+    if ($last_order && !empty($last_order->client_info)) {
+        $decoded = json_decode($last_order->client_info, true);
+        if (is_array($decoded)) {
+            $client_info = $decoded;
+        }
+    }
 ?>
     <h1 class="dashboard-greeting"><?php echo pv_get_time_greeting(); ?>, <?php echo esc_html(wp_get_current_user()->display_name); ?> 👋</h1>
     <p class="dashboard-subline">Kundendetails</p>
@@ -336,18 +343,63 @@ if (!$customer_id) {
                     <p class="card-subline">Technische Informationen zum Nutzer</p>
                     <p><strong>User Agent:</strong> <?php echo esc_html($last_order->user_agent ?? '–'); ?></p>
                     <p><strong>IP-Adresse:</strong> <?php echo esc_html($last_order->user_ip ?? '–'); ?></p>
+                    <?php if ($client_info) : ?>
+                        <?php if (!empty($client_info['language'])) : ?><p><strong>Sprache:</strong> <?php echo esc_html($client_info['language']); ?></p><?php endif; ?>
+                        <?php if (!empty($client_info['languages'])) : ?><p><strong>Weitere Sprachen:</strong> <?php echo esc_html($client_info['languages']); ?></p><?php endif; ?>
+                        <?php if (!empty($client_info['timezone'])) : ?><p><strong>Zeitzone:</strong> <?php echo esc_html($client_info['timezone']); ?></p><?php endif; ?>
+                        <?php if (!empty($client_info['screen'])) : ?><p><strong>Bildschirm:</strong> <?php echo esc_html($client_info['screen']); ?></p><?php endif; ?>
+                        <?php if (!empty($client_info['viewport'])) : ?><p><strong>Viewport:</strong> <?php echo esc_html($client_info['viewport']); ?></p><?php endif; ?>
+                        <?php if (!empty($client_info['colorDepth'])) : ?><p><strong>Farbtiefe:</strong> <?php echo esc_html($client_info['colorDepth']); ?></p><?php endif; ?>
+                        <?php if (!empty($client_info['browser'])) : ?><p><strong>Browser:</strong> <?php echo esc_html($client_info['browser']); ?></p><?php endif; ?>
+                        <?php if (!empty($client_info['os'])) : ?><p><strong>Betriebssystem:</strong> <?php echo esc_html($client_info['os']); ?></p><?php endif; ?>
+                        <?php if (!empty($client_info['hardwareConcurrency'])) : ?><p><strong>CPU-Kerne:</strong> <?php echo esc_html($client_info['hardwareConcurrency']); ?></p><?php endif; ?>
+                        <?php if (!empty($client_info['deviceMemory'])) : ?><p><strong>RAM:</strong> <?php echo esc_html($client_info['deviceMemory']); ?> GB</p><?php endif; ?>
+                        <?php if (isset($client_info['touch'])) : ?><p><strong>Touchscreen:</strong> <?php echo $client_info['touch'] ? 'ja' : 'nein'; ?></p><?php endif; ?>
+                        <?php if (!empty($client_info['connection'])) : ?><p><strong>Netzwerk:</strong> <?php echo esc_html($client_info['connection']); ?></p><?php endif; ?>
+                        <?php if (!empty($client_info['battery'])) : ?><p><strong>Batterie:</strong> <?php echo esc_html($client_info['battery']); ?></p><?php endif; ?>
+                    <?php endif; ?>
                 </div>
                 <div class="dashboard-card">
                     <h2>Verlauf</h2>
                     <p class="card-subline">Benutzerverlauf im Detail</p>
                     <?php if ($customer_logs) : ?>
-                        <ul class="order-log-list">
-                            <?php foreach ($customer_logs as $log) : ?>
-                                <li><?php echo esc_html(date_i18n('d.m.Y H:i', strtotime($log->created_at)) . ': ' . $log->id . ' / ' . $log->event . ($log->message ? ': ' . $log->message : '')); ?></li>
+                        <div class="order-log-list">
+                            <?php
+                            $system_events = ['inventory_returned_not_accepted','inventory_returned_accepted','welcome_email_sent','status_updated','checkout_completed'];
+                            foreach ($customer_logs as $log) :
+                                $is_customer = !in_array($log->event, $system_events, true);
+                                $avatar = $is_customer ? $initials : 'H2';
+                                switch ($log->event) {
+                                    case 'inventory_returned_not_accepted':
+                                        $text = 'Miete zuende aber noch nicht akzeptiert.';
+                                        break;
+                                    case 'inventory_returned_accepted':
+                                        $text = 'Rückgabe wurde akzeptiert.';
+                                        break;
+                                    case 'welcome_email_sent':
+                                        $text = 'Bestellbestätigung an Kunden gesendet.';
+                                        break;
+                                    case 'status_updated':
+                                        $text = ($log->message ? $log->message . ': ' : '') . 'Kauf abgeschlossen.';
+                                        break;
+                                    case 'checkout_completed':
+                                        $text = 'Checkout abgeschlossen.';
+                                        break;
+                                    default:
+                                        $text = $log->message ?: $log->event;
+                                }
+                                ?>
+                                <div class="order-log-entry">
+                                    <div class="log-avatar"><?php echo esc_html($avatar); ?></div>
+                                    <div class="log-body">
+                                        <div class="log-date"><?php echo esc_html(date_i18n('d.m.Y H:i', strtotime($log->created_at))); ?></div>
+                                        <div class="log-message"><?php echo esc_html($text); ?></div>
+                                    </div>
+                                </div>
                             <?php endforeach; ?>
-                        </ul>
+                        </div>
                         <?php if ($total_logs > 5) : ?>
-                            <button type="button" class="icon-btn icon-btn-no-stroke customer-log-load-more" title="Mehr anzeigen" data-offset="5" data-total="<?php echo intval($total_logs); ?>" data-order-ids="<?php echo esc_attr(implode(',', $order_ids)); ?>">
+                            <button type="button" class="icon-btn icon-btn-no-stroke customer-log-load-more" title="Mehr anzeigen" data-offset="5" data-total="<?php echo intval($total_logs); ?>" data-order-ids="<?php echo esc_attr(implode(',', $order_ids)); ?>" data-initials="<?php echo esc_attr($initials); ?>">
                                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 5c-.6 0-1 .4-1 1v5H6c-.6 0-1 .4-1 1s.4 1 1 1h5v5c0 .6.4 1 1 1s1-.4 1-1v-5h5c.6 0 1-.4 1-1s-.4-1-1-1h-5V6c0-.6-.4-1-1-1z"/></svg>
                             </button>
                         <?php endif; ?>

--- a/admin/customers-page.php
+++ b/admin/customers-page.php
@@ -257,8 +257,8 @@ if (!$customer_id) {
     $order_ids = wp_list_pluck($all_orders, 'id');
     if ($order_ids) {
         $placeholders = implode(',', array_fill(0, count($order_ids), '%d'));
-        $sql = "SELECT id, order_id, event, message, created_at FROM {$wpdb->prefix}produkt_order_logs WHERE order_id IN ($placeholders) ORDER BY created_at DESC LIMIT 5";
-        $customer_logs = $wpdb->get_results($wpdb->prepare($sql, $order_ids));
+        $logs_sql = "SELECT l.id, l.order_id, o.order_number, l.event, l.message, l.created_at FROM {$wpdb->prefix}produkt_order_logs l JOIN {$wpdb->prefix}produkt_orders o ON l.order_id = o.id WHERE l.order_id IN ($placeholders) ORDER BY l.created_at DESC LIMIT 5";
+        $customer_logs = $wpdb->get_results($wpdb->prepare($logs_sql, $order_ids));
         $count_sql = "SELECT COUNT(*) FROM {$wpdb->prefix}produkt_order_logs WHERE order_id IN ($placeholders)";
         $total_logs = (int) $wpdb->get_var($wpdb->prepare($count_sql, $order_ids));
     } else {
@@ -392,7 +392,8 @@ if (!$customer_id) {
                                 <div class="order-log-entry">
                                     <div class="log-avatar"><?php echo esc_html($avatar); ?></div>
                                     <div class="log-body">
-                                        <div class="log-date"><?php echo esc_html(date_i18n('d.m.Y H:i', strtotime($log->created_at)) . ' / #' . $log->order_id); ?></div>
+                                        <?php $order_no = !empty($log->order_number) ? $log->order_number : $log->order_id; ?>
+                                        <div class="log-date"><?php echo esc_html(date_i18n('d.m.Y H:i', strtotime($log->created_at)) . ' / #' . $order_no); ?></div>
                                         <div class="log-message"><?php echo esc_html($text); ?></div>
                                     </div>
                                 </div>

--- a/admin/dashboard/sidebar-order-details.php
+++ b/admin/dashboard/sidebar-order-details.php
@@ -193,7 +193,8 @@ $produkte = $order->produkte ?? [$order]; // fallback
                                 default:
                                     $text = $log->message ?: $log->event;
                             }
-                            $date_id = date_i18n('d.m.Y H:i', strtotime($log->created_at)) . ' / #' . $log->order_id;
+                            $order_no = !empty($order->order_number) ? $order->order_number : $order->id;
+                            $date_id = date_i18n('d.m.Y H:i', strtotime($log->created_at)) . ' / #' . $order_no;
                             ?>
                             <div class="order-log-entry">
                                 <div class="log-avatar"><?php echo esc_html($avatar); ?></div>

--- a/admin/dashboard/sidebar-order-details.php
+++ b/admin/dashboard/sidebar-order-details.php
@@ -129,6 +129,9 @@ $produkte = $order->produkte ?? [$order]; // fallback
                     <?php if (!empty($p->extra_names)) : ?>
                         <div>Extras: <?php echo esc_html($p->extra_names); ?></div>
                     <?php endif; ?>
+                    <?php if (!empty($p->weekend_tariff)) : ?>
+                        <div>Hinweis: Wochenendtarif</div>
+                    <?php endif; ?>
                     <div>Miettage: <?php echo esc_html($days !== null ? $days : ($p->dauer_text ?? '–')); ?></div>
                 </div>
 

--- a/admin/dashboard/sidebar-order-details.php
+++ b/admin/dashboard/sidebar-order-details.php
@@ -168,11 +168,42 @@ $produkte = $order->produkte ?? [$order]; // fallback
             <button type="button" class="produkt-accordion-header">Verlauf</button>
             <div class="produkt-accordion-content">
                 <?php if (!empty($order_logs)) : ?>
-                    <ul class="order-log-list">
-                        <?php foreach ($order_logs as $log) : ?>
-                            <li><?php echo esc_html(date_i18n('d.m.Y H:i', strtotime($log->created_at)) . ': ' . $log->id . ' / ' . $log->event . ($log->message ? ': ' . $log->message : '')); ?></li>
+                    <div class="order-log-list">
+                        <?php
+                        $system_events = ['inventory_returned_not_accepted','inventory_returned_accepted','welcome_email_sent','status_updated','checkout_completed'];
+                        foreach ($order_logs as $log) :
+                            $is_customer = !in_array($log->event, $system_events, true);
+                            $avatar = $is_customer ? $initials : 'H2';
+                            switch ($log->event) {
+                                case 'inventory_returned_not_accepted':
+                                    $text = 'Miete zuende aber noch nicht akzeptiert.';
+                                    break;
+                                case 'inventory_returned_accepted':
+                                    $text = 'Rückgabe wurde akzeptiert.';
+                                    break;
+                                case 'welcome_email_sent':
+                                    $text = 'Bestellbestätigung an Kunden gesendet.';
+                                    break;
+                                case 'status_updated':
+                                    $text = ($log->message ? $log->message . ': ' : '') . 'Kauf abgeschlossen.';
+                                    break;
+                                case 'checkout_completed':
+                                    $text = 'Checkout abgeschlossen.';
+                                    break;
+                                default:
+                                    $text = $log->message ?: $log->event;
+                            }
+                            $date_id = date_i18n('d.m.Y H:i', strtotime($log->created_at)) . ' / #' . $log->order_id;
+                            ?>
+                            <div class="order-log-entry">
+                                <div class="log-avatar"><?php echo esc_html($avatar); ?></div>
+                                <div class="log-body">
+                                    <div class="log-date"><?php echo esc_html($date_id); ?></div>
+                                    <div class="log-message"><?php echo esc_html($text); ?></div>
+                                </div>
+                            </div>
                         <?php endforeach; ?>
-                    </ul>
+                    </div>
                 <?php else : ?>
                     <p>Keine Einträge</p>
                 <?php endif; ?>

--- a/admin/extras-page.php
+++ b/admin/extras-page.php
@@ -18,7 +18,7 @@ $active_tab = isset($_GET['tab']) ? sanitize_text_field($_GET['tab']) : 'list';
 
 // Get variants for toggles
 $variants = $wpdb->get_results($wpdb->prepare(
-    "SELECT id, name FROM {$wpdb->prefix}produkt_variants WHERE category_id = %d ORDER BY sort_order, name",
+    "SELECT id, name, description, image_url_1, verkaufspreis_einmalig, weekend_price, mietpreis_monatlich FROM {$wpdb->prefix}produkt_variants WHERE category_id = %d ORDER BY sort_order, name",
     $selected_category
 ));
 
@@ -62,10 +62,15 @@ if (isset($_POST['submit'])) {
     $category_id = intval($_POST['category_id']);
     $name        = sanitize_text_field($_POST['name']);
     $modus       = get_option('produkt_betriebsmodus', 'miete');
-    $sale_price  = isset($_POST['sale_price']) ? floatval($_POST['sale_price']) : 0;
-    $price       = isset($_POST['price']) ? floatval($_POST['price']) : 0;
-    $price_input = $modus === 'kauf' ? ($_POST['sale_price'] ?? '') : ($_POST['price'] ?? '');
-    $stripe_price = floatval($price_input);
+    if ($modus === 'kauf') {
+        $sale_price  = isset($_POST['sale_price']) ? intval($_POST['sale_price']) / 100 : 0;
+        $price       = 0;
+        $stripe_price = $sale_price;
+    } else {
+        $price       = isset($_POST['price']) ? intval($_POST['price']) / 100 : 0;
+        $sale_price  = 0;
+        $stripe_price = $price;
+    }
     $image_url = esc_url_raw($_POST['image_url']);
     $active = isset($_POST['active']) ? 1 : 0;
     $sort_order = intval($_POST['sort_order']);

--- a/admin/orders-page.php
+++ b/admin/orders-page.php
@@ -225,6 +225,7 @@ $search_term = isset($search_term) ? $search_term : (isset($_GET['s']) ? sanitiz
                 </tbody>
             </table>
         </form>
+        <button type="button" id="orders-load-more" class="button" style="display:none;margin-top:1rem;">Mehr anzeigen</button>
 
         <?php endif; ?>
     </div>

--- a/admin/product-categories-page.php
+++ b/admin/product-categories-page.php
@@ -76,15 +76,15 @@ if (isset($_GET['edit'])) {
             <?php wp_nonce_field('produkt_admin_action', 'produkt_admin_nonce'); ?>
             <input type="hidden" name="category_id" value="<?php echo esc_attr($edit_category->id ?? ''); ?>">
             <div class="form-grid">
-                <div class="form-field">
+                <div class="produkt-form-group">
                     <label for="name">Name</label>
-                    <input name="name" type="text" required value="<?php echo esc_attr($edit_category->name ?? ''); ?>" class="regular-text">
+                    <input name="name" type="text" required value="<?php echo esc_attr($edit_category->name ?? ''); ?>">
                 </div>
-                <div class="form-field">
+                <div class="produkt-form-group">
                     <label for="slug">Slug</label>
-                    <input name="slug" type="text" required value="<?php echo esc_attr($edit_category->slug ?? ''); ?>" class="regular-text">
+                    <input name="slug" type="text" required value="<?php echo esc_attr($edit_category->slug ?? ''); ?>">
                 </div>
-                <div class="form-field">
+                <div class="produkt-form-group">
                     <label for="parent_id">Übergeordnete Kategorie</label>
                     <select name="parent_id">
                         <option value="0">Keine</option>
@@ -97,9 +97,9 @@ if (isset($_GET['edit'])) {
                         <?php endforeach; ?>
                     </select>
                 </div>
-                <div class="form-field full">
+                <div class="produkt-form-group full-width">
                     <label for="description">Beschreibung</label>
-                    <textarea name="description" class="large-text"><?php echo esc_textarea($edit_category->description ?? ''); ?></textarea>
+                    <textarea name="description" rows="3"><?php echo esc_textarea($edit_category->description ?? ''); ?></textarea>
                 </div>
             </div>
             <p>

--- a/admin/shipping-page.php
+++ b/admin/shipping-page.php
@@ -129,15 +129,15 @@ $providers = [
             <?php wp_nonce_field('save_shipping_action', 'save_shipping_nonce'); ?>
             <input type="hidden" name="shipping_id" value="<?php echo esc_attr($edit_shipping->id ?? ''); ?>">
             <div class="form-grid">
-                <div class="form-field">
+                <div class="produkt-form-group">
                     <label for="shipping_name">Name</label>
                     <input type="text" id="shipping_name" name="shipping_name" required value="<?php echo esc_attr($edit_shipping->name ?? ''); ?>">
                 </div>
-                <div class="form-field">
+                <div class="produkt-form-group">
                     <label for="shipping_price">Versandkosten (€)</label>
                     <input type="number" id="shipping_price" name="shipping_price" step="0.01" required value="<?php echo esc_attr($edit_shipping->price ?? ''); ?>">
                 </div>
-                <div class="form-field">
+                <div class="produkt-form-group">
                     <label for="shipping_provider">Dienstleister</label>
                     <select id="shipping_provider" name="shipping_provider" required>
                         <?php foreach ($providers as $val => $label): ?>
@@ -145,9 +145,9 @@ $providers = [
                         <?php endforeach; ?>
                     </select>
                 </div>
-                <div class="form-field full">
+                <div class="produkt-form-group full-width">
                     <label for="shipping_description">Beschreibung</label>
-                    <textarea id="shipping_description" name="shipping_description"><?php echo esc_textarea($edit_shipping->description ?? ''); ?></textarea>
+                    <textarea id="shipping_description" name="shipping_description" rows="3"><?php echo esc_textarea($edit_shipping->description ?? ''); ?></textarea>
                 </div>
             </div>
             <p>

--- a/admin/tabs/buttons-tab.php
+++ b/admin/tabs/buttons-tab.php
@@ -52,7 +52,7 @@ $last_order_nr = get_option('produkt_last_order_number', '');
                 <p class="card-subline">Beschriftung und Preisinformationen</p>
                 <div class="form-grid">
                     <div class="produkt-form-group">
-                        <label>Button-Text</label>
+                        <label>Jetzt mieten Text</label>
                         <input type="text" name="button_text" value="<?php echo esc_attr($ui['button_text']); ?>">
                     </div>
                     <div class="produkt-form-group">
@@ -86,11 +86,11 @@ $last_order_nr = get_option('produkt_last_order_number', '');
                         <label>Preiszeitraum</label>
                         <select name="price_period">
                             <option value="month" <?php selected($ui['price_period'], 'month'); ?>>pro Monat</option>
-                            <option value="one-time" <?php selected($ui['price_period'], 'one-time'); ?>>einmalig</option>
+                            <option value="one-time" <?php selected($ui['price_period'], 'one-time'); ?>>pro Tag</option>
                         </select>
                     </div>
                     <div class="produkt-form-group">
-                        <label>Mit MwSt.</label>
+                        <label>MwSt label anzeigen?</label>
                         <label class="produkt-toggle-label">
                             <input type="checkbox" name="vat_included" value="1" <?php checked($ui['vat_included'], 1); ?>>
                             <span class="produkt-toggle-slider"></span>
@@ -128,8 +128,17 @@ $last_order_nr = get_option('produkt_last_order_number', '');
                 </div>
             </div>
             <div class="dashboard-card">
-                <h2>Tooltips</h2>
-                <p class="card-subline">Hilfetexte auf der Produktseite</p>
+                <div class="card-header-flex">
+                    <div>
+                        <h2>Tooltips</h2>
+                        <p class="card-subline">Hilfetexte auf der Produktseite</p>
+                    </div>
+                    <label class="produkt-toggle-label">
+                        <input type="checkbox" name="show_tooltips" value="1" <?php checked($ui['show_tooltips'], 1); ?>>
+                        <span class="produkt-toggle-slider"></span>
+                        <span>Tooltips auf Produktseite anzeigen</span>
+                    </label>
+                </div>
                 <div class="form-grid">
                     <div class="produkt-form-group">
                         <label>Mietdauer-Tooltip</label>
@@ -138,13 +147,6 @@ $last_order_nr = get_option('produkt_last_order_number', '');
                     <div class="produkt-form-group">
                         <label>Zustand-Tooltip</label>
                         <textarea name="condition_tooltip" rows="4"><?php echo esc_textarea($ui['condition_tooltip']); ?></textarea>
-                    </div>
-                    <div class="produkt-form-group full-width">
-                        <label>Tooltips auf Produktseite anzeigen</label>
-                        <label class="produkt-toggle-label">
-                            <input type="checkbox" name="show_tooltips" value="1" <?php checked($ui['show_tooltips'], 1); ?>>
-                            <span class="produkt-toggle-slider"></span>
-                        </label>
                     </div>
                 </div>
             </div>

--- a/admin/tabs/categories-add-tab.php
+++ b/admin/tabs/categories-add-tab.php
@@ -74,26 +74,55 @@ foreach ($filter_groups as $g) {
             <div class="dashboard-card">
                 <h2>SEO-Einstellungen</h2>
                 <p class="card-subline">Meta-Angaben</p>
-                <div class="form-grid">
-                    <div class="produkt-form-group">
-                        <label>SEO-Titel</label>
-                        <input type="text" name="meta_title" maxlength="60" placeholder="Optimiert für Suchmaschinen">
-                        <small>Max. 60 Zeichen für Google <span id="meta_title_counter" class="produkt-char-counter"></span></small>
-                    </div>
-                    <div class="produkt-form-group">
-                        <label>Layout-Stil</label>
-                        <select name="layout_style">
-                            <option value="default">Standard (Horizontal)</option>
-                            <option value="grid">Grid (Karten-Layout)</option>
-                            <option value="list">Liste (Vertikal)</option>
-                        </select>
-                    </div>
+                <div class="produkt-form-group">
+                    <label>SEO-Titel</label>
+                    <input type="text" name="meta_title" maxlength="60" placeholder="Optimiert für Suchmaschinen">
+                    <small>Max. 60 Zeichen für Google <span id="meta_title_counter" class="produkt-char-counter"></span></small>
                 </div>
 
                 <div class="produkt-form-group full-width">
                     <label>SEO-Beschreibung</label>
                     <textarea name="meta_description" rows="3" maxlength="160" placeholder="Beschreibung für Suchmaschinen (max. 160 Zeichen)"></textarea>
                     <div id="meta_description_counter" class="produkt-char-counter"></div>
+                </div>
+            </div>
+
+            <div class="dashboard-card">
+                <h2>Layout</h2>
+                <p class="card-subline">Darstellung im Frontend</p>
+                <input type="hidden" name="layout_style" value="default">
+                <div class="layout-option-grid">
+                    <div class="layout-option-card" data-value="default">
+                        <div class="layout-option-name">Standard (Horizontal)</div>
+                        <div class="layout-option-preview">
+                            <svg viewBox="0 0 100 60" xmlns="http://www.w3.org/2000/svg">
+                                <rect x="5" y="5" width="27" height="50" fill="#e5e7eb"/>
+                                <rect x="36" y="5" width="27" height="50" fill="#e5e7eb"/>
+                                <rect x="67" y="5" width="27" height="50" fill="#e5e7eb"/>
+                            </svg>
+                        </div>
+                    </div>
+                    <div class="layout-option-card" data-value="grid">
+                        <div class="layout-option-name">Grid (Karten-Layout)</div>
+                        <div class="layout-option-preview">
+                            <svg viewBox="0 0 100 60" xmlns="http://www.w3.org/2000/svg">
+                                <rect x="5" y="5" width="40" height="25" fill="#e5e7eb"/>
+                                <rect x="55" y="5" width="40" height="25" fill="#e5e7eb"/>
+                                <rect x="5" y="30" width="40" height="25" fill="#e5e7eb"/>
+                                <rect x="55" y="30" width="40" height="25" fill="#e5e7eb"/>
+                            </svg>
+                        </div>
+                    </div>
+                    <div class="layout-option-card" data-value="list">
+                        <div class="layout-option-name">Liste (Vertikal)</div>
+                        <div class="layout-option-preview">
+                            <svg viewBox="0 0 100 60" xmlns="http://www.w3.org/2000/svg">
+                                <rect x="5" y="5" width="90" height="15" fill="#e5e7eb"/>
+                                <rect x="5" y="25" width="90" height="15" fill="#e5e7eb"/>
+                                <rect x="5" y="45" width="90" height="15" fill="#e5e7eb"/>
+                            </svg>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/admin/tabs/categories-edit-tab.php
+++ b/admin/tabs/categories-edit-tab.php
@@ -100,26 +100,55 @@ function produkt_category_icon($slug)
         <div class="dashboard-card">
             <h2>SEO-Einstellungen</h2>
             <p class="card-subline">Meta-Angaben</p>
-            <div class="form-grid">
-                <div class="produkt-form-group">
-                    <label>SEO-Titel</label>
-                    <input type="text" name="meta_title" value="<?php echo esc_attr($edit_item->meta_title ?? ''); ?>" maxlength="60">
-                    <small>Max. 60 Zeichen für Google <span id="meta_title_counter" class="produkt-char-counter"></span></small>
-                </div>
-                <div class="produkt-form-group">
-                    <label>Layout-Stil</label>
-                    <select name="layout_style">
-                        <option value="default" <?php selected($edit_item->layout_style ?? 'default', 'default'); ?>>Standard (Horizontal)</option>
-                        <option value="grid" <?php selected($edit_item->layout_style ?? 'default', 'grid'); ?>>Grid (Karten-Layout)</option>
-                        <option value="list" <?php selected($edit_item->layout_style ?? 'default', 'list'); ?>>Liste (Vertikal)</option>
-                    </select>
-                </div>
+            <div class="produkt-form-group">
+                <label>SEO-Titel</label>
+                <input type="text" name="meta_title" value="<?php echo esc_attr($edit_item->meta_title ?? ''); ?>" maxlength="60">
+                <small>Max. 60 Zeichen für Google <span id="meta_title_counter" class="produkt-char-counter"></span></small>
             </div>
-            
+
             <div class="produkt-form-group full-width">
                 <label>SEO-Beschreibung</label>
                 <textarea name="meta_description" rows="3" maxlength="160"><?php echo esc_textarea($edit_item->meta_description ?? ''); ?></textarea>
                 <div id="meta_description_counter" class="produkt-char-counter"></div>
+            </div>
+        </div>
+
+        <div class="dashboard-card">
+            <h2>Layout</h2>
+            <p class="card-subline">Darstellung im Frontend</p>
+            <input type="hidden" name="layout_style" value="<?php echo esc_attr($edit_item->layout_style ?? 'default'); ?>">
+            <div class="layout-option-grid">
+                <div class="layout-option-card" data-value="default">
+                    <div class="layout-option-name">Standard (Horizontal)</div>
+                    <div class="layout-option-preview">
+                        <svg viewBox="0 0 100 60" xmlns="http://www.w3.org/2000/svg">
+                            <rect x="5" y="5" width="27" height="50" fill="#e5e7eb"/>
+                            <rect x="36" y="5" width="27" height="50" fill="#e5e7eb"/>
+                            <rect x="67" y="5" width="27" height="50" fill="#e5e7eb"/>
+                        </svg>
+                    </div>
+                </div>
+                <div class="layout-option-card" data-value="grid">
+                    <div class="layout-option-name">Grid (Karten-Layout)</div>
+                    <div class="layout-option-preview">
+                        <svg viewBox="0 0 100 60" xmlns="http://www.w3.org/2000/svg">
+                            <rect x="5" y="5" width="40" height="25" fill="#e5e7eb"/>
+                            <rect x="55" y="5" width="40" height="25" fill="#e5e7eb"/>
+                            <rect x="5" y="30" width="40" height="25" fill="#e5e7eb"/>
+                            <rect x="55" y="30" width="40" height="25" fill="#e5e7eb"/>
+                        </svg>
+                    </div>
+                </div>
+                <div class="layout-option-card" data-value="list">
+                    <div class="layout-option-name">Liste (Vertikal)</div>
+                    <div class="layout-option-preview">
+                        <svg viewBox="0 0 100 60" xmlns="http://www.w3.org/2000/svg">
+                            <rect x="5" y="5" width="90" height="15" fill="#e5e7eb"/>
+                            <rect x="5" y="25" width="90" height="15" fill="#e5e7eb"/>
+                            <rect x="5" y="45" width="90" height="15" fill="#e5e7eb"/>
+                        </svg>
+                    </div>
+                </div>
             </div>
         </div>
 

--- a/admin/tabs/extras-add-tab.php
+++ b/admin/tabs/extras-add-tab.php
@@ -1,5 +1,6 @@
 <?php
 // Extras Add Tab Content
+$modus = get_option('produkt_betriebsmodus', 'miete');
 ?>
 
 <div class="produkt-add-extra">
@@ -16,24 +17,42 @@
         <div class="produkt-form-sections">
             <div class="dashboard-card">
                 <h2>Grunddaten</h2>
-                <p class="card-subline">Name und Preis</p>
-                <?php $modus = get_option('produkt_betriebsmodus', 'miete'); ?>
+                <p class="card-subline">Name</p>
                 <div class="form-grid">
                     <div class="produkt-form-group">
                         <label>Name *</label>
                         <input type="text" name="name" required placeholder="z.B. Himmel, Zubehör-Set">
                     </div>
-                    <?php if ($modus === 'kauf'): ?>
-                    <div class="produkt-form-group">
-                        <label>Preis / Tag (EUR) *</label>
-                        <input type="number" step="0.01" name="sale_price" placeholder="0.00" required>
+                </div>
+            </div>
+
+            <div class="dashboard-card">
+                <h2>Preis</h2>
+                <p class="card-subline">Tarif</p>
+                <div class="price-cards">
+                  <div class="price-card" data-field="<?php echo $modus === 'kauf' ? 'sale_price' : 'price'; ?>">
+                    <div class="price-card-head">
+                      <div class="price-title">Standardpreis</div>
+                      <span class="price-badge">EUR</span>
                     </div>
-                    <?php else: ?>
-                    <div class="produkt-form-group">
-                        <label>Preis (EUR) *</label>
-                        <input type="number" step="0.01" name="price" placeholder="0.00" required>
+                    <div class="price-display">
+                      <input type="text" class="price-input" placeholder="0,00" aria-label="Preis in Euro" />
+                      <span class="price-suffix">€</span>
+                      <input type="hidden" name="<?php echo $modus === 'kauf' ? 'sale_price' : 'price'; ?>" class="price-hidden" value="">
                     </div>
-                    <?php endif; ?>
+                    <div class="price-buttons">
+                      <button type="button" class="price-btn" data-step="-5">−5</button>
+                      <button type="button" class="price-btn" data-step="-1">−1</button>
+                      <button type="button" class="price-btn" data-step="1">+1</button>
+                      <button type="button" class="price-btn" data-step="5">+5</button>
+                    </div>
+                    <div class="price-chips">
+                      <button type="button" class="price-chip" data-value="1990">19,90 €</button>
+                      <button type="button" class="price-chip" data-value="2990">29,90 €</button>
+                      <button type="button" class="price-chip" data-value="4990">49,90 €</button>
+                      <button type="button" class="price-chip" data-value="6990">69,90 €</button>
+                    </div>
+                  </div>
                 </div>
             </div>
 
@@ -64,13 +83,32 @@
             <div class="dashboard-card">
                 <h2>Verfügbarkeit je Ausführung</h2>
                 <p class="card-subline">Extras pro Variante aktivieren</p>
-                <div class="produkt-form-row" style="flex-wrap:wrap;gap:15px;">
+                <div class="variant-availability-grid">
                     <?php foreach ($variants as $v): ?>
-                    <label class="produkt-toggle-label" style="min-width:160px;">
-                        <input type="checkbox" name="variant_available[<?php echo $v->id; ?>]" value="1" checked>
-                        <span class="produkt-toggle-slider"></span>
-                        <span><?php echo esc_html($v->name); ?></span>
-                    </label>
+                    <div class="variant-availability-card">
+                        <div class="availability-card-head">
+                            <div class="availability-card-title"><?php echo esc_html($v->name); ?></div>
+                            <label class="produkt-toggle-label">
+                                <input type="checkbox" name="variant_available[<?php echo $v->id; ?>]" value="1" checked>
+                                <span class="produkt-toggle-slider"></span>
+                            </label>
+                        </div>
+                        <?php if (!empty($v->image_url_1)): ?>
+                        <div class="availability-image"><img src="<?php echo esc_url($v->image_url_1); ?>" alt=""></div>
+                        <?php endif; ?>
+                        <?php if (!empty($v->description)): ?>
+                        <div class="availability-desc"><?php echo esc_html($v->description); ?></div>
+                        <?php endif; ?>
+                        <div class="availability-prices">
+                            <?php $std_price = ($modus === 'kauf') ? $v->verkaufspreis_einmalig : $v->mietpreis_monatlich; ?>
+                            <?php if ($std_price > 0): ?>
+                            <div>Standardpreis: <?php echo number_format($std_price, 2, ',', '.'); ?>€</div>
+                            <?php endif; ?>
+                            <?php if ($modus === 'kauf' && !empty($v->weekend_price)): ?>
+                            <div>Wochenendpreis: <?php echo number_format($v->weekend_price, 2, ',', '.'); ?>€</div>
+                            <?php endif; ?>
+                        </div>
+                    </div>
                     <?php endforeach; ?>
                 </div>
             </div>

--- a/admin/tabs/extras-edit-tab.php
+++ b/admin/tabs/extras-edit-tab.php
@@ -23,34 +23,53 @@
         </a>
 
         <div class="produkt-form-sections">
+            <?php $modus = get_option('produkt_betriebsmodus', 'miete');
+                  $sale_price = 0;
+                  if ($modus === 'kauf' && !empty($edit_item->stripe_price_id_sale)) {
+                      $p = \ProduktVerleih\StripeService::get_price_amount($edit_item->stripe_price_id_sale);
+                      if (!is_wp_error($p)) {
+                          $sale_price = $p;
+                      }
+                  }
+            ?>
             <div class="dashboard-card">
                 <h2>Grunddaten</h2>
-                <p class="card-subline">Name und Preis</p>
-                <?php $modus = get_option('produkt_betriebsmodus', 'miete');
-                      $sale_price = 0;
-                      if ($modus === 'kauf' && !empty($edit_item->stripe_price_id_sale)) {
-                          $p = \ProduktVerleih\StripeService::get_price_amount($edit_item->stripe_price_id_sale);
-                          if (!is_wp_error($p)) {
-                              $sale_price = $p;
-                          }
-                      }
-                ?>
+                <p class="card-subline">Name</p>
                 <div class="form-grid">
                     <div class="produkt-form-group">
                         <label>Name *</label>
                         <input type="text" name="name" value="<?php echo esc_attr($edit_item->name); ?>" required>
                     </div>
-                    <?php if ($modus === 'kauf'): ?>
-                    <div class="produkt-form-group">
-                        <label>Preis / Tag (EUR) *</label>
-                        <input type="number" step="0.01" name="sale_price" value="<?php echo esc_attr(number_format((float)$sale_price, 2, '.', '')); ?>" required>
+                </div>
+            </div>
+
+            <div class="dashboard-card">
+                <h2>Preis</h2>
+                <p class="card-subline">Tarif</p>
+                <div class="price-cards">
+                  <div class="price-card" data-field="<?php echo $modus === 'kauf' ? 'sale_price' : 'price'; ?>">
+                    <div class="price-card-head">
+                      <div class="price-title">Standardpreis</div>
+                      <span class="price-badge">EUR</span>
                     </div>
-                    <?php else: ?>
-                    <div class="produkt-form-group">
-                        <label>Preis (EUR) *</label>
-                        <input type="number" step="0.01" name="price" value="<?php echo esc_attr(number_format((float)$edit_item->price, 2, '.', '')); ?>" required>
+                    <div class="price-display">
+                      <input type="text" class="price-input" placeholder="0,00" aria-label="Preis in Euro" />
+                      <span class="price-suffix">€</span>
+                      <input type="hidden" name="<?php echo $modus === 'kauf' ? 'sale_price' : 'price'; ?>" class="price-hidden" value="<?php echo $modus === 'kauf' ? intval(round($sale_price * 100)) : intval(round($edit_item->price * 100)); ?>">
                     </div>
-                    <?php endif; ?>
+                    <div class="price-buttons">
+                      <button type="button" class="price-btn" data-step="-5">−5</button>
+                      <button type="button" class="price-btn" data-step="-1">−1</button>
+                      <button type="button" class="price-btn" data-step="1">+1</button>
+                      <button type="button" class="price-btn" data-step="5">+5</button>
+                    </div>
+                    <div class="price-chips">
+                      <button type="button" class="price-chip" data-value="1990">19,90 €</button>
+                      <button type="button" class="price-chip" data-value="2990">29,90 €</button>
+                      <button type="button" class="price-chip" data-value="4990">49,90 €</button>
+                      <button type="button" class="price-chip" data-value="6990">69,90 €</button>
+                    </div>
+                  </div>
                 </div>
             </div>
 
@@ -85,14 +104,33 @@
             <div class="dashboard-card">
                 <h2>Verfügbarkeit je Ausführung</h2>
                 <p class="card-subline">Extras pro Variante aktivieren</p>
-                <div class="produkt-form-row" style="flex-wrap:wrap;gap:15px;">
+                <div class="variant-availability-grid">
                     <?php foreach ($variants as $v): ?>
                     <?php $checked = isset($variant_availability[$v->id]) ? $variant_availability[$v->id] : 1; ?>
-                    <label class="produkt-toggle-label" style="min-width:160px;">
-                        <input type="checkbox" name="variant_available[<?php echo $v->id; ?>]" value="1" <?php echo $checked ? 'checked' : ''; ?>>
-                        <span class="produkt-toggle-slider"></span>
-                        <span><?php echo esc_html($v->name); ?></span>
-                    </label>
+                    <div class="variant-availability-card">
+                        <div class="availability-card-head">
+                            <div class="availability-card-title"><?php echo esc_html($v->name); ?></div>
+                            <label class="produkt-toggle-label">
+                                <input type="checkbox" name="variant_available[<?php echo $v->id; ?>]" value="1" <?php echo $checked ? 'checked' : ''; ?>>
+                                <span class="produkt-toggle-slider"></span>
+                            </label>
+                        </div>
+                        <?php if (!empty($v->image_url_1)): ?>
+                        <div class="availability-image"><img src="<?php echo esc_url($v->image_url_1); ?>" alt=""></div>
+                        <?php endif; ?>
+                        <?php if (!empty($v->description)): ?>
+                        <div class="availability-desc"><?php echo esc_html($v->description); ?></div>
+                        <?php endif; ?>
+                        <div class="availability-prices">
+                            <?php $std_price = ($modus === 'kauf') ? $v->verkaufspreis_einmalig : $v->mietpreis_monatlich; ?>
+                            <?php if ($std_price > 0): ?>
+                            <div>Standardpreis: <?php echo number_format($std_price, 2, ',', '.'); ?>€</div>
+                            <?php endif; ?>
+                            <?php if ($modus === 'kauf' && !empty($v->weekend_price)): ?>
+                            <div>Wochenendpreis: <?php echo number_format($v->weekend_price, 2, ',', '.'); ?>€</div>
+                            <?php endif; ?>
+                        </div>
+                    </div>
                     <?php endforeach; ?>
                 </div>
             </div>

--- a/admin/tabs/stripe-tab.php
+++ b/admin/tabs/stripe-tab.php
@@ -90,7 +90,7 @@ $modus               = get_option('produkt_betriebsmodus', 'miete');
                 <h2>AGB-Link</h2>
                 <p class="card-subline">Verweis auf Ihre AGB-Seite</p>
                 <div class="form-grid">
-                    <div class="form-field full">
+                    <div class="produkt-form-group full-width">
                         <label>URL zur AGB-Seite</label>
                         <input type="text" name="tos_url" value="<?php echo esc_attr($tos_url); ?>" placeholder="<?php echo esc_attr(home_url('/agb')); ?>">
                         <p class="description">Link, der im Checkout angezeigt wird.</p>
@@ -101,12 +101,12 @@ $modus               = get_option('produkt_betriebsmodus', 'miete');
                 <h2>Weiterleitungs-URLs</h2>
                 <p class="card-subline">Zielseiten nach dem Checkout</p>
                 <div class="form-grid">
-                    <div class="form-field">
+                    <div class="produkt-form-group">
                         <label>Success URL</label>
                         <input type="text" name="success_url" value="<?php echo esc_attr($success_url); ?>" placeholder="<?php echo esc_attr(home_url('/danke')); ?>">
                         <p class="description">Der Parameter <code>?session_id=CHECKOUT_SESSION_ID</code> wird automatisch angehängt.</p>
                     </div>
-                    <div class="form-field">
+                    <div class="produkt-form-group">
                         <label>Cancel URL</label>
                         <input type="text" name="cancel_url" value="<?php echo esc_attr($cancel_url); ?>" placeholder="<?php echo esc_attr(home_url('/abbrechen')); ?>">
                     </div>
@@ -116,21 +116,21 @@ $modus               = get_option('produkt_betriebsmodus', 'miete');
                 <h2>Custom Checkout Texte</h2>
                 <p class="card-subline">Individuelle Hinweise im Bezahlprozess</p>
                 <div class="form-grid">
-                    <div class="form-field full">
+                    <div class="produkt-form-group full-width">
                         <label>Nachricht unter Versandadresse</label>
-                        <textarea name="ct_shipping" rows="2" class="large-text"><?php echo esc_textarea($ct_shipping); ?></textarea>
+                        <textarea name="ct_shipping" rows="2"><?php echo esc_textarea($ct_shipping); ?></textarea>
                     </div>
-                    <div class="form-field full">
+                    <div class="produkt-form-group full-width">
                         <label>Text neben AGB-Checkbox</label>
-                        <textarea name="ct_agb" rows="2" class="large-text"><?php echo esc_textarea($ct_agb); ?></textarea>
+                        <textarea name="ct_agb" rows="2"><?php echo esc_textarea($ct_agb); ?></textarea>
                     </div>
-                    <div class="form-field full">
+                    <div class="produkt-form-group full-width">
                         <label>Nachricht auf dem Bezahl-Button</label>
-                        <textarea name="ct_submit" rows="2" class="large-text"><?php echo esc_textarea($ct_submit); ?></textarea>
+                        <textarea name="ct_submit" rows="2"><?php echo esc_textarea($ct_submit); ?></textarea>
                     </div>
-                    <div class="form-field full">
+                    <div class="produkt-form-group full-width">
                         <label>Text nach Absenden</label>
-                        <textarea name="ct_after_submit" rows="2" class="large-text"><?php echo esc_textarea($ct_after_submit); ?></textarea>
+                        <textarea name="ct_after_submit" rows="2"><?php echo esc_textarea($ct_after_submit); ?></textarea>
                     </div>
                 </div>
                 <p class="description">Bleibt ein Feld leer, wird kein Text angezeigt.</p>

--- a/admin/tabs/variants-add-tab.php
+++ b/admin/tabs/variants-add-tab.php
@@ -17,7 +17,7 @@ $modus = get_option('produkt_betriebsmodus', 'miete');
         <div class="produkt-form-sections">
             <div class="dashboard-card">
                 <h2>Grunddaten</h2>
-                <p class="card-subline">Name und Preis</p>
+                <p class="card-subline">Name und Beschreibung</p>
                 <div class="form-grid">
                     <div class="produkt-form-group">
                         <label>Name *</label>
@@ -28,13 +28,13 @@ $modus = get_option('produkt_betriebsmodus', 'miete');
                         <label>Monatlicher Mietpreis *</label>
                         <input type="number" step="0.01" name="mietpreis_monatlich" required placeholder="0.00">
                     </div>
+                    <div class="produkt-form-group">
+                        <label>Einmaliger Verkaufspreis</label>
+                        <input type="number" step="0.01" name="verkaufspreis_einmalig" placeholder="0.00">
+                    </div>
                     <?php else: ?>
                         <input type="hidden" name="mietpreis_monatlich" value="0">
                     <?php endif; ?>
-                    <div class="produkt-form-group">
-                        <label><?php echo ($modus === 'kauf') ? 'Preis / Tag (EUR) *' : 'Einmaliger Verkaufspreis'; ?></label>
-                        <input type="number" step="0.01" name="verkaufspreis_einmalig" placeholder="0.00">
-                    </div>
                 </div>
                 <div class="produkt-form-group full-width">
                     <label>Beschreibung</label>
@@ -42,17 +42,75 @@ $modus = get_option('produkt_betriebsmodus', 'miete');
                 </div>
             </div>
 
+            <?php if ($modus === 'kauf'): ?>
             <div class="dashboard-card">
-                <h2>Verfügbarkeit</h2>
-                <p class="card-subline">Buchbarkeit</p>
-                <div class="form-grid">
-                    <div class="produkt-form-group">
-                        <label class="produkt-toggle-label">
-                            <input type="checkbox" name="available" value="1" checked>
-                            <span class="produkt-toggle-slider"></span>
-                            <span>Verfügbar</span>
-                        </label>
+                <h2>Preise</h2>
+                <p class="card-subline">Tarife</p>
+                <div class="price-cards">
+                  <div class="price-card" data-field="verkaufspreis_einmalig">
+                    <div class="price-card-head">
+                      <div class="price-title">Standardpreis</div>
+                      <span class="price-badge">EUR</span>
                     </div>
+                    <div class="price-display">
+                      <input type="text" class="price-input" placeholder="0,00" aria-label="Standardpreis in Euro" />
+                      <span class="price-suffix">€</span>
+                      <input type="hidden" name="verkaufspreis_einmalig" class="price-hidden" value="">
+                    </div>
+                    <div class="price-buttons">
+                      <button type="button" class="price-btn" data-step="-5">−5</button>
+                      <button type="button" class="price-btn" data-step="-1">−1</button>
+                      <button type="button" class="price-btn" data-step="1">+1</button>
+                      <button type="button" class="price-btn" data-step="5">+5</button>
+                    </div>
+                    <div class="price-chips">
+                      <button type="button" class="price-chip" data-value="1990">19,90 €</button>
+                      <button type="button" class="price-chip" data-value="2990">29,90 €</button>
+                      <button type="button" class="price-chip" data-value="4990">49,90 €</button>
+                      <button type="button" class="price-chip" data-value="6990">69,90 €</button>
+                    </div>
+                  </div>
+
+                  <div class="price-card" data-field="weekend_price">
+                    <div class="price-card-head">
+                      <div class="price-title">Wochenendpreis <span class="price-sub">(Fr–So)</span></div>
+                      <span class="price-badge">EUR</span>
+                    </div>
+                    <div class="price-display">
+                      <input type="text" class="price-input" placeholder="0,00" aria-label="Wochenendpreis in Euro" />
+                      <span class="price-suffix">€</span>
+                      <input type="hidden" name="weekend_price" class="price-hidden" value="">
+                    </div>
+                    <div class="price-buttons">
+                      <button type="button" class="price-btn" data-step="-5">−5</button>
+                      <button type="button" class="price-btn" data-step="-1">−1</button>
+                      <button type="button" class="price-btn" data-step="1">+1</button>
+                      <button type="button" class="price-btn" data-step="5">+5</button>
+                    </div>
+                    <div class="price-chips">
+                      <button type="button" class="price-chip" data-value="1490">14,90 €</button>
+                      <button type="button" class="price-chip" data-value="1990">19,90 €</button>
+                      <button type="button" class="price-chip" data-value="2990">29,90 €</button>
+                      <button type="button" class="price-chip" data-value="3990">39,90 €</button>
+                    </div>
+                  </div>
+                </div>
+            </div>
+            <?php endif; ?>
+
+            <div class="dashboard-card">
+                <div class="card-header-flex">
+                    <div>
+                        <h2>Verfügbarkeit</h2>
+                        <p class="card-subline">Buchbarkeit</p>
+                    </div>
+                    <label class="produkt-toggle-label">
+                        <input type="checkbox" name="available" value="1" checked>
+                        <span class="produkt-toggle-slider"></span>
+                        <span>Verfügbar</span>
+                    </label>
+                </div>
+                <div class="form-grid">
                     <div class="produkt-form-group">
                         <label>Text wenn nicht verfügbar</label>
                         <input type="text" name="availability_note" placeholder="z.B. Wieder verfügbar ab 15.03.2024">

--- a/admin/tabs/variants-edit-tab.php
+++ b/admin/tabs/variants-edit-tab.php
@@ -4,6 +4,8 @@ $verkaufspreis_einmalig = floatval($edit_item->verkaufspreis_einmalig);
 $modus = get_option('produkt_betriebsmodus', 'miete');
 $mietpreis_monatlich = number_format((float)$edit_item->mietpreis_monatlich, 2, '.', '');
 $verkaufspreis_formatted = number_format((float)$verkaufspreis_einmalig, 2, '.', '');
+$weekend_price = floatval($edit_item->weekend_price);
+$weekend_price_formatted = number_format((float)$weekend_price, 2, '.', '');
 ?>
 
 <div class="produkt-edit-variant">
@@ -29,7 +31,7 @@ $verkaufspreis_formatted = number_format((float)$verkaufspreis_einmalig, 2, '.',
         <div class="produkt-form-sections">
             <div class="dashboard-card">
                 <h2>Grunddaten</h2>
-                <p class="card-subline">Name und Preis</p>
+                <p class="card-subline">Name und Beschreibung</p>
                 <div class="form-grid">
                     <div class="produkt-form-group">
                         <label>Name *</label>
@@ -40,13 +42,13 @@ $verkaufspreis_formatted = number_format((float)$verkaufspreis_einmalig, 2, '.',
                         <label>Monatlicher Mietpreis *</label>
                         <input type="number" step="0.01" name="mietpreis_monatlich" value="<?php echo esc_attr($mietpreis_monatlich); ?>" required>
                     </div>
+                    <div class="produkt-form-group">
+                        <label>Einmaliger Verkaufspreis</label>
+                        <input type="number" step="0.01" name="verkaufspreis_einmalig" value="<?php echo esc_attr($verkaufspreis_formatted); ?>">
+                    </div>
                     <?php else: ?>
                         <input type="hidden" name="mietpreis_monatlich" value="0">
                     <?php endif; ?>
-                    <div class="produkt-form-group">
-                        <label><?php echo ($modus === 'kauf') ? 'Preis / Tag (EUR) *' : 'Einmaliger Verkaufspreis'; ?></label>
-                        <input type="number" step="0.01" name="verkaufspreis_einmalig" value="<?php echo esc_attr($verkaufspreis_formatted); ?>">
-                    </div>
                 </div>
                 <div class="produkt-form-group full-width">
                     <label>Beschreibung</label>
@@ -54,17 +56,75 @@ $verkaufspreis_formatted = number_format((float)$verkaufspreis_einmalig, 2, '.',
                 </div>
             </div>
 
+            <?php if ($modus === 'kauf'): ?>
             <div class="dashboard-card">
-                <h2>Verfügbarkeit</h2>
-                <p class="card-subline">Buchbarkeit</p>
-                <div class="form-grid">
-                    <div class="produkt-form-group">
-                        <label class="produkt-toggle-label">
-                            <input type="checkbox" name="available" value="1" <?php echo ($edit_item->available ?? 1) ? 'checked' : ''; ?>>
-                            <span class="produkt-toggle-slider"></span>
-                            <span>Verfügbar</span>
-                        </label>
+                <h2>Preise</h2>
+                <p class="card-subline">Tarife</p>
+                <div class="price-cards">
+                  <div class="price-card" data-field="verkaufspreis_einmalig">
+                    <div class="price-card-head">
+                      <div class="price-title">Standardpreis</div>
+                      <span class="price-badge">EUR</span>
                     </div>
+                    <div class="price-display">
+                      <input type="text" class="price-input" placeholder="0,00" aria-label="Standardpreis in Euro" />
+                      <span class="price-suffix">€</span>
+                      <input type="hidden" name="verkaufspreis_einmalig" class="price-hidden" value="<?php echo intval(round($verkaufspreis_einmalig * 100)); ?>">
+                    </div>
+                    <div class="price-buttons">
+                      <button type="button" class="price-btn" data-step="-5">−5</button>
+                      <button type="button" class="price-btn" data-step="-1">−1</button>
+                      <button type="button" class="price-btn" data-step="1">+1</button>
+                      <button type="button" class="price-btn" data-step="5">+5</button>
+                    </div>
+                    <div class="price-chips">
+                      <button type="button" class="price-chip" data-value="1990">19,90 €</button>
+                      <button type="button" class="price-chip" data-value="2990">29,90 €</button>
+                      <button type="button" class="price-chip" data-value="4990">49,90 €</button>
+                      <button type="button" class="price-chip" data-value="6990">69,90 €</button>
+                    </div>
+                  </div>
+
+                  <div class="price-card" data-field="weekend_price">
+                    <div class="price-card-head">
+                      <div class="price-title">Wochenendpreis <span class="price-sub">(Fr–So)</span></div>
+                      <span class="price-badge">EUR</span>
+                    </div>
+                    <div class="price-display">
+                      <input type="text" class="price-input" placeholder="0,00" aria-label="Wochenendpreis in Euro" />
+                      <span class="price-suffix">€</span>
+                      <input type="hidden" name="weekend_price" class="price-hidden" value="<?php echo intval(round($weekend_price * 100)); ?>">
+                    </div>
+                    <div class="price-buttons">
+                      <button type="button" class="price-btn" data-step="-5">−5</button>
+                      <button type="button" class="price-btn" data-step="-1">−1</button>
+                      <button type="button" class="price-btn" data-step="1">+1</button>
+                      <button type="button" class="price-btn" data-step="5">+5</button>
+                    </div>
+                    <div class="price-chips">
+                      <button type="button" class="price-chip" data-value="1490">14,90 €</button>
+                      <button type="button" class="price-chip" data-value="1990">19,90 €</button>
+                      <button type="button" class="price-chip" data-value="2990">29,90 €</button>
+                      <button type="button" class="price-chip" data-value="3990">39,90 €</button>
+                    </div>
+                  </div>
+                </div>
+            </div>
+            <?php endif; ?>
+
+            <div class="dashboard-card">
+                <div class="card-header-flex">
+                    <div>
+                        <h2>Verfügbarkeit</h2>
+                        <p class="card-subline">Buchbarkeit</p>
+                    </div>
+                    <label class="produkt-toggle-label">
+                        <input type="checkbox" name="available" value="1" <?php echo ($edit_item->available ?? 1) ? 'checked' : ''; ?>>
+                        <span class="produkt-toggle-slider"></span>
+                        <span>Verfügbar</span>
+                    </label>
+                </div>
+                <div class="form-grid">
                     <div class="produkt-form-group">
                         <label>Text wenn nicht verfügbar</label>
                         <input type="text" name="availability_note" value="<?php echo esc_attr($edit_item->availability_note ?? ''); ?>">

--- a/assets/admin-script.js
+++ b/assets/admin-script.js
@@ -664,5 +664,24 @@ document.addEventListener('DOMContentLoaded', function() {
             });
         });
     });
+
+    document.querySelectorAll('.layout-option-grid').forEach(grid => {
+        const hidden = grid.closest('.dashboard-card').querySelector('input[name="layout_style"]');
+        function setActive(val) {
+            grid.querySelectorAll('.layout-option-card').forEach(card => {
+                card.classList.toggle('active', card.dataset.value === val);
+            });
+        }
+        grid.querySelectorAll('.layout-option-card').forEach(card => {
+            card.addEventListener('click', () => {
+                const val = card.dataset.value;
+                if (hidden) hidden.value = val;
+                setActive(val);
+            });
+        });
+        if (hidden) {
+            setActive(hidden.value || 'default');
+        }
+    });
 });
 

--- a/assets/admin-script.js
+++ b/assets/admin-script.js
@@ -614,3 +614,55 @@ document.addEventListener('click', function(e) {
     }
 });
 
+// Price card interactions
+document.addEventListener('DOMContentLoaded', function() {
+    const locale = 'de-DE';
+    function centsToDisplay(cents) {
+        if (isNaN(cents)) return '';
+        return (cents / 100).toLocaleString(locale, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+    }
+    function displayToCents(str) {
+        if (!str) return null;
+        const cleaned = String(str).replace(/[^\d,.-]/g, '').trim().replace(/\./g, '').replace(',', '.');
+        const value = parseFloat(cleaned);
+        if (isNaN(value)) return null;
+        return Math.round(value * 100);
+    }
+    document.querySelectorAll('.price-card').forEach(card => {
+        const input = card.querySelector('.price-input');
+        const hidden = card.querySelector('.price-hidden');
+        const steps = card.querySelectorAll('.price-btn');
+        const chips = card.querySelectorAll('.price-chip');
+        if (hidden.value) {
+            const init = parseInt(hidden.value, 10);
+            if (!isNaN(init)) input.value = centsToDisplay(init);
+        }
+        input.addEventListener('blur', () => {
+            const cents = displayToCents(input.value);
+            if (cents === null) { input.value = ''; hidden.value = ''; return; }
+            input.value = centsToDisplay(cents);
+            hidden.value = String(cents);
+        });
+        input.addEventListener('input', () => {
+            const cents = displayToCents(input.value);
+            hidden.value = cents === null ? '' : String(cents);
+        });
+        steps.forEach(btn => {
+            btn.addEventListener('click', () => {
+                const step = parseInt(btn.dataset.step, 10) || 0;
+                const currentCents = displayToCents(input.value) ?? 0;
+                const newCents = Math.max(0, currentCents + (step * 100));
+                input.value = centsToDisplay(newCents);
+                hidden.value = String(newCents);
+            });
+        });
+        chips.forEach(chip => {
+            chip.addEventListener('click', () => {
+                const cents = parseInt(chip.dataset.value, 10);
+                input.value = centsToDisplay(cents);
+                hidden.value = String(cents);
+            });
+        });
+    });
+});
+

--- a/assets/admin-script.js
+++ b/assets/admin-script.js
@@ -589,10 +589,12 @@ document.addEventListener('click', function(e) {
         var offset = parseInt(btn.getAttribute('data-offset')) || 0;
         var total = parseInt(btn.getAttribute('data-total')) || 0;
         var orderIds = btn.getAttribute('data-order-ids').split(',');
+        var initials = btn.getAttribute('data-initials') || '';
         var data = new URLSearchParams();
         data.append('action', 'pv_load_customer_logs');
         data.append('nonce', produkt_admin.nonce);
         data.append('offset', offset);
+        data.append('initials', initials);
         orderIds.forEach(function(id){ data.append('order_ids[]', id); });
         fetch(produkt_admin.ajax_url, {method:'POST', body:data})
             .then(r => r.json())

--- a/assets/admin-script.js
+++ b/assets/admin-script.js
@@ -683,5 +683,45 @@ document.addEventListener('DOMContentLoaded', function() {
             setActive(hidden.value || 'default');
         }
     });
+
+    // Load orders incrementally
+    const orderRows = document.querySelectorAll('.activity-table tbody tr');
+    const loadMoreBtn = document.getElementById('orders-load-more');
+    if (orderRows.length > 10 && loadMoreBtn) {
+        let visible = 10;
+        loadMoreBtn.style.display = '';
+        const updateOrders = () => {
+            orderRows.forEach((row, idx) => {
+                row.style.display = idx < visible ? '' : 'none';
+            });
+            if (visible >= orderRows.length) {
+                loadMoreBtn.style.display = 'none';
+            }
+        };
+        loadMoreBtn.addEventListener('click', () => {
+            visible += 10;
+            updateOrders();
+        });
+        updateOrders();
+    }
+
+    // Auto-generate slug from category name
+    const catForm = document.getElementById('produkt-category-form');
+    if (catForm) {
+        const nameInput = catForm.querySelector('input[name="name"]');
+        const slugInput = catForm.querySelector('input[name="slug"]');
+        if (nameInput && slugInput) {
+            let slugEdited = false;
+            slugInput.addEventListener('input', () => { slugEdited = true; });
+            nameInput.addEventListener('input', () => {
+                if (slugEdited) return;
+                slugInput.value = nameInput.value
+                    .toLowerCase()
+                    .trim()
+                    .replace(/[^a-z0-9]+/g, '-')
+                    .replace(/^-+|-+$/g, '');
+            });
+        }
+    }
 });
 

--- a/assets/admin-style.css
+++ b/assets/admin-style.css
@@ -288,9 +288,10 @@
 
 /* Variant availability cards */
 .variant-availability-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    display: flex;
+    flex-wrap: wrap;
     gap: 20px;
+    max-width: 1020px;
 }
 .variant-availability-card {
     background: #fff;
@@ -300,6 +301,7 @@
     box-shadow: 0 2px 8px rgba(0,0,0,0.04);
     display: flex;
     flex-direction: column;
+    flex: 0 0 240px;
 }
 .availability-card-head {
     display: flex;
@@ -311,10 +313,16 @@
     font-size: 14px;
     font-weight: 600;
 }
-.availability-image img {
-    width: 100%;
-    border-radius: 8px;
+.availability-image {
+    display: flex;
+    justify-content: center;
     margin-bottom: 10px;
+}
+.availability-image img {
+    width: 120px;
+    height: 120px;
+    object-fit: cover;
+    border-radius: 8px;
 }
 .availability-desc {
     font-size: 13px;

--- a/assets/admin-style.css
+++ b/assets/admin-style.css
@@ -286,6 +286,37 @@
 }
 .price-chip:hover { background: #f7f8fa; }
 
+/* Layout option cards */
+.layout-option-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 20px;
+}
+.layout-option-card {
+    border: 2px solid #e5e7eb;
+    border-radius: 12px;
+    padding: 16px;
+    background: #fff;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    text-align: center;
+}
+.layout-option-card.active {
+    border-color: #1d4ed8;
+    box-shadow: 0 0 0 4px rgba(29,78,216,0.1);
+}
+.layout-option-name {
+    font-weight: 600;
+    margin-bottom: 12px;
+}
+.layout-option-preview svg {
+    width: 100%;
+    height: auto;
+}
+
 .produkt-nav-item:hover {
     transform: translateY(-2px);
     box-shadow: 0 4px 12px rgba(0,0,0,0.1);

--- a/assets/admin-style.css
+++ b/assets/admin-style.css
@@ -9,7 +9,7 @@
 }
 
 #wpwrap {
-    background-image: url('main-page-bg.svg');
+    background-image: url('bg.jpg');
     background-position: center;
     background-repeat: no-repeat;
     background-size: cover;
@@ -26,6 +26,10 @@
     --pv-blue: #007cba;
     --pv-green: #28a745;
     --pv-red: #dc3545;
+    --pv-ink: #0f172a;
+    --pv-muted: #6b7280;
+    --pv-line: #e5e7eb;
+    --pv-focus: #1d4ed8;
 }
 
 @charset "UTF-8";
@@ -186,6 +190,102 @@
     transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
+/* Price cards */
+.price-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 20px;
+}
+.price-card {
+    background: #fff;
+    border: 1px solid #e5e7eb;
+    border-radius: 12px;
+    padding: 20px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+.price-card-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    margin-bottom: 12px;
+}
+.price-title { font-weight: 600; font-size: 14px; }
+.price-sub { font-weight: 400; color: #64748b; font-size: 12px; }
+.price-badge {
+    font-size: 10px;
+    font-weight: 700;
+    background: #eef2ff;
+    color: #1d4ed8;
+    border: 1px solid #dbe4ff;
+    padding: 3px 6px;
+    border-radius: 999px;
+}
+.price-display {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    flex-wrap: nowrap;
+    font-size: clamp(2rem, 8vw, 4rem);
+    font-weight: 800;
+    margin: 20px 0;
+    border-bottom: 2px solid #e5e7eb;
+    padding-bottom: 10px;
+    width: 100%;
+}
+.price-display:focus-within { border-color: #1d4ed8; }
+.price-input {
+    border: none !important;
+    box-shadow: none !important;
+    outline: none;
+    text-align: center;
+    width: 8ch;
+    max-width: 100%;
+    background: transparent;
+    font-size: inherit;
+    font-weight: inherit;
+}
+.price-suffix {
+    margin-left: 4px;
+    font-weight: 600;
+    color: #64748b;
+    flex-shrink: 0;
+}
+.price-buttons {
+    display: flex;
+    justify-content: center;
+    gap: 6px;
+    margin-bottom: 12px;
+}
+.price-btn {
+    border: 1px solid #e5e7eb;
+    background: #f9fafb;
+    padding: 6px 10px;
+    border-radius: 8px;
+    font-weight: 600;
+    cursor: pointer;
+}
+.price-btn:hover { background: #f1f5f9; }
+.price-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    justify-content: center;
+}
+.price-chip {
+    border: 1px solid #e5e7eb;
+    background: #fff;
+    border-radius: 999px;
+    padding: 4px 10px;
+    font-size: 13px;
+    cursor: pointer;
+}
+.price-chip:hover { background: #f7f8fa; }
+
 .produkt-nav-item:hover {
     transform: translateY(-2px);
     box-shadow: 0 4px 12px rgba(0,0,0,0.1);
@@ -328,7 +428,6 @@
 .produkt-form-group {
     display: flex;
     flex-direction: column;
-    gap: 2px;
     margin-bottom: 20px;
 }
 
@@ -338,16 +437,28 @@
 
 .produkt-form-group label {
     font-weight: 600;
-    margin-bottom: 5px;
-    color: #3c434a;
+    font-size: 14px;
+    color: var(--pv-muted);
+    margin-bottom: 4px;
 }
 
-.produkt-form-group input,
+.produkt-form-group input:not([type="checkbox"]),
 .produkt-form-group textarea,
 .produkt-form-group select {
-    padding: 8px 12px;
-    border: 1px solid #ddd;
-    border-radius: 4px;
+    background: transparent;
+    border: none;
+    border-bottom: 2px solid var(--pv-line);
+    padding: 10px 0;
+    font-size: 16px;
+    font-weight: 600;
+    outline: none;
+}
+
+.produkt-form-group input:not([type="checkbox"]):focus,
+.produkt-form-group textarea:focus,
+.produkt-form-group select:focus {
+    border-bottom-color: var(--pv-focus);
+    box-shadow: 0 4px 0 -3px var(--pv-focus);
 }
 
 .produkt-form-group input[type="checkbox"] {
@@ -1581,7 +1692,6 @@ body.shipping-modal-open {
 .produkt-form-group {
     display: flex;
     flex-direction: column;
-    gap: 2px;
     margin-bottom: 20px;
 }
 
@@ -1595,15 +1705,28 @@ body.shipping-modal-open {
 
 .produkt-form-group label {
     font-weight: 600;
-    margin-bottom: 5px;
-    color: #3c434a;
+    font-size: 14px;
+    color: var(--pv-muted);
+    margin-bottom: 4px;
 }
 
-.produkt-form-group input,
-.produkt-form-group textarea {
-    padding: 8px 12px;
-    border: 1px solid #ddd;
-    border-radius: 4px;
+.produkt-form-group input:not([type="checkbox"]),
+.produkt-form-group textarea,
+.produkt-form-group select {
+    background: transparent;
+    border: none;
+    border-bottom: 2px solid var(--pv-line);
+    padding: 10px 0;
+    font-size: 16px;
+    font-weight: 600;
+    outline: none;
+}
+
+.produkt-form-group input:not([type="checkbox"]):focus,
+.produkt-form-group textarea:focus,
+.produkt-form-group select:focus {
+    border-bottom-color: var(--pv-focus);
+    box-shadow: 0 4px 0 -3px var(--pv-focus);
 }
 
 .produkt-form-group input[type="checkbox"] {

--- a/assets/admin-style.css
+++ b/assets/admin-style.css
@@ -315,7 +315,7 @@
 }
 .availability-image {
     display: flex;
-    justify-content: center;
+    justify-content: flex-start;
     margin-bottom: 10px;
 }
 .availability-image img {
@@ -3160,7 +3160,7 @@ body.day-modal-open{overflow:hidden;}
 .dashboard-card {
     background: #fff;
     border-radius: 20px;
-    padding: 1.5rem;
+    padding: 2rem;
     margin-right: 20px;
 }
 
@@ -3191,7 +3191,7 @@ body.day-modal-open{overflow:hidden;}
 .card-subline {
     font-size: 0.9rem;
     color: #333d48;
-    margin-bottom: 1rem !important;
+    margin-bottom: 3rem !important;
     margin-top: 0rem !important;
     font-family: 'Manrope', sans-serif;
 }

--- a/assets/admin-style.css
+++ b/assets/admin-style.css
@@ -3107,8 +3107,8 @@ body.day-modal-open{overflow:hidden;}
 #produkt-admin-customers .customer-actions .icon-btn svg{width:20px;height:20px;}
 
 /* Customer detail layout */
-.customer-detail-grid{display:flex;gap:2rem;align-items:flex-start;margin-top:2rem;}
-.customer-left{flex:1;display:flex;flex-direction:column;gap:2rem;}
+.customer-detail-grid{display:flex;gap:0rem;align-items:flex-start;margin-top:2rem;}
+.customer-left{flex:1;display:flex;flex-direction:column;gap:1rem;}
 .customer-right{flex:1;display:flex;flex-direction:column;gap:2rem;padding-right:20px;box-sizing:border-box;}
 .customer-row{display:flex;gap:2rem;align-items:flex-start;}
 .customer-row > .dashboard-card{flex:1;}

--- a/assets/admin-style.css
+++ b/assets/admin-style.css
@@ -286,6 +286,48 @@
 }
 .price-chip:hover { background: #f7f8fa; }
 
+/* Variant availability cards */
+.variant-availability-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 20px;
+}
+.variant-availability-card {
+    background: #fff;
+    border: 1px solid #e5e7eb;
+    border-radius: 12px;
+    padding: 16px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+    display: flex;
+    flex-direction: column;
+}
+.availability-card-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+}
+.availability-card-title {
+    font-size: 14px;
+    font-weight: 600;
+}
+.availability-image img {
+    width: 100%;
+    border-radius: 8px;
+    margin-bottom: 10px;
+}
+.availability-desc {
+    font-size: 13px;
+    color: #64748b;
+    margin-bottom: 10px;
+}
+.availability-prices {
+    font-size: 13px;
+}
+.availability-prices div {
+    margin-top: 4px;
+}
+
 /* Layout option cards */
 .layout-option-grid {
     display: grid;

--- a/assets/admin-style.css
+++ b/assets/admin-style.css
@@ -4144,13 +4144,38 @@ MCA0MjEuOUwwIDBaIiBmaWxsPSIjNjkxM2U5Ij48L3BhdGg+PC9nPjwvc3ZnPg==\
 /* Sidebar order details extras */
 
 .order-log-list {
-    list-style: disc;
-    margin: 0 0 0 1.2rem;
+    margin: 0;
     padding: 0;
+}
+.order-log-entry {
+    display: flex;
+    gap: 12px;
+    margin-bottom: 0.75rem;
     font-size: 0.85rem;
 }
-.order-log-list li {
-    margin: 0.25rem 0;
+.log-avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: #1d2327;
+    color: #fff;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.75rem;
+}
+.log-body {
+    flex: 1;
+}
+.log-date {
+    font-size: 0.8rem;
+    color: #666;
+    line-height: 1.2;
+}
+.log-message {
+    margin-top: 2px;
+    line-height: 1.3;
 }
 
 .order-note-form {

--- a/assets/admin-style.css
+++ b/assets/admin-style.css
@@ -3110,7 +3110,7 @@ body.day-modal-open{overflow:hidden;}
 .customer-detail-grid{display:flex;gap:0rem;align-items:flex-start;margin-top:2rem;}
 .customer-left{flex:1;display:flex;flex-direction:column;gap:1rem;}
 .customer-right{flex:1;display:flex;flex-direction:column;gap:2rem;box-sizing:border-box;}
-.customer-row{display:flex;gap:2rem;align-items:flex-start;}
+.customer-row{display:flex;gap:0rem;align-items:flex-start;}
 .customer-row > .dashboard-card{flex:1;}
 .produkt-customer-details p{margin:6px 0;}
 .produkt-customer-orders{background:#f8f9fb;padding:20px;border-radius:12px;border:1px solid #e1e1e1;}

--- a/assets/admin-style.css
+++ b/assets/admin-style.css
@@ -3109,7 +3109,7 @@ body.day-modal-open{overflow:hidden;}
 /* Customer detail layout */
 .customer-detail-grid{display:flex;gap:0rem;align-items:flex-start;margin-top:2rem;}
 .customer-left{flex:1;display:flex;flex-direction:column;gap:1rem;}
-.customer-right{flex:1;display:flex;flex-direction:column;gap:2rem;padding-right:20px;box-sizing:border-box;}
+.customer-right{flex:1;display:flex;flex-direction:column;gap:2rem;box-sizing:border-box;}
 .customer-row{display:flex;gap:2rem;align-items:flex-start;}
 .customer-row > .dashboard-card{flex:1;}
 .produkt-customer-details p{margin:6px 0;}

--- a/assets/script.js
+++ b/assets/script.js
@@ -23,6 +23,7 @@ jQuery(document).ready(function($) {
     let selectedDays = 0;
     let variantWeekendOnly = false;
     let variantMinDays = 0;
+    let weekendTariff = false;
     let calendarMonth = new Date();
     let colorNotificationTimeout = null;
     let cart = JSON.parse(localStorage.getItem('produkt_cart') || '[]');
@@ -96,6 +97,9 @@ jQuery(document).ready(function($) {
             }
             if (period) {
                 details.append($('<div>', {class: 'cart-item-period'}).text(period));
+            }
+            if (item.weekend_tarif) {
+                details.append($('<div>', {class: 'cart-item-weekend'}).text('Wochenendtarif'));
             }
             const price = $('<div>', {class: 'cart-item-price'}).text(formatPrice(item.final_price) + '€');
             const rem = $('<span>', {class: 'cart-item-remove', 'data-index': idx}).text('×');
@@ -367,6 +371,7 @@ jQuery(document).ready(function($) {
                 product_color_id: selectedProductColor,
                 frame_color_id: selectedFrameColor,
                 final_price: currentPrice,
+                weekend_tarif: weekendTariff ? 1 : 0,
                 image: (function(){
                     let img = '';
                     const variantOption = $('.produkt-option[data-type="variant"].selected');
@@ -419,6 +424,7 @@ jQuery(document).ready(function($) {
             if (selectedCondition) params.set('condition_id', selectedCondition);
             if (selectedProductColor) params.set('product_color_id', selectedProductColor);
             if (selectedFrameColor) params.set('frame_color_id', selectedFrameColor);
+            if (weekendTariff) params.set('weekend_tarif', 1);
             if (currentPrice) params.set('final_price', currentPrice);
 
             const produktName = $('.produkt-option[data-type="variant"].selected h4').text().trim();
@@ -955,6 +961,8 @@ jQuery(document).ready(function($) {
                     product_color_id: selectedProductColor,
                     frame_color_id: selectedFrameColor,
                     days: selectedDays,
+                    start_date: startDate,
+                    end_date: endDate,
                     nonce: produkt_ajax.nonce
                 },
                 success: function(response) {
@@ -972,6 +980,13 @@ jQuery(document).ready(function($) {
                             $('#produkt-original-price').hide();
                         }
                         $('#produkt-savings').hide();
+                        if (data.weekend_applied) {
+                            weekendTariff = true;
+                            $('#produkt-weekend-note').text('Wochenendtarif').show();
+                        } else {
+                            weekendTariff = false;
+                            $('#produkt-weekend-note').hide();
+                        }
 
                         // Update button based on availability
                         currentPriceId = data.price_id || '';
@@ -1016,7 +1031,7 @@ jQuery(document).ready(function($) {
                         // Update mobile sticky price
                         updateMobileStickyPrice(data.final_price, data.original_price, data.discount, isAvailable);
 
-                        const label = produkt_ajax.button_text || (produkt_ajax.betriebsmodus === 'kauf' ? 'Jetzt kaufen' : 'Jetzt mieten');
+                        const label = (produkt_ajax.button_text && produkt_ajax.button_text.trim() !== '') ? produkt_ajax.button_text : (produkt_ajax.betriebsmodus === 'kauf' ? 'Jetzt kaufen' : 'Jetzt mieten');
                         if (produkt_ajax.betriebsmodus === 'kauf') {
                             $('.produkt-price-period').hide();
                             $('.produkt-mobile-price-period').hide();
@@ -1049,7 +1064,7 @@ jQuery(document).ready(function($) {
             // Hide mobile sticky price
             hideMobileStickyPrice();
 
-            const label = produkt_ajax.button_text || (produkt_ajax.betriebsmodus === 'kauf' ? 'Jetzt kaufen' : 'Jetzt mieten');
+            const label = (produkt_ajax.button_text && produkt_ajax.button_text.trim() !== '') ? produkt_ajax.button_text : (produkt_ajax.betriebsmodus === 'kauf' ? 'Jetzt kaufen' : 'Jetzt mieten');
             if (produkt_ajax.betriebsmodus === 'kauf') {
                 $('.produkt-price-period').hide();
                 $('.produkt-mobile-price-period').hide();
@@ -1066,7 +1081,7 @@ jQuery(document).ready(function($) {
         if (window.innerWidth <= 768) {
             // Determine button label and icon from main button
             const mainButton = $('#produkt-rent-button');
-            let mainLabel = produkt_ajax.button_text || mainButton.find('span').text().trim() || (produkt_ajax.betriebsmodus === 'kauf' ? 'Jetzt kaufen' : 'Jetzt mieten');
+            let mainLabel = (produkt_ajax.button_text && produkt_ajax.button_text.trim() !== '') ? produkt_ajax.button_text : (mainButton.find('span').text().trim() || (produkt_ajax.betriebsmodus === 'kauf' ? 'Jetzt kaufen' : 'Jetzt mieten'));
             const mainIcon = mainButton.data('icon') ? `<img src="${mainButton.data('icon')}" class="produkt-button-icon-img" alt="Button Icon">` : '';
 
             // Create mobile sticky price bar

--- a/assets/style.css
+++ b/assets/style.css
@@ -2335,4 +2335,12 @@ body.shop-filter-open {
     color: #dc3232;
 }
 
+.produkt-weekend-info {
+    margin-bottom: 0.5rem;
+    line-height: 1.3;
+    color: var(--produkt-text-color) !important;
+    font-weight: 500 !important;
+    font-size: 0.85rem !important;
+}
+
 

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -946,7 +946,8 @@ class Admin {
         }
         if ($search_term !== '') {
             $like = '%' . $wpdb->esc_like(ltrim($search_term, '#')) . '%';
-            $where_conditions[] = "(o.order_number LIKE %s OR CAST(o.id AS CHAR) LIKE %s)";
+            $where_conditions[] = "(o.order_number LIKE %s OR CAST(o.id AS CHAR) LIKE %s OR o.customer_name LIKE %s)";
+            $where_values[] = $like;
             $where_values[] = $like;
             $where_values[] = $like;
         }

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -337,7 +337,7 @@ class Admin {
                 'price_label' => $category->price_label ?? ($modus === 'kauf' ? 'Einmaliger Kaufpreis' : 'Monatlicher Mietpreis'),
                 'vat_included' => isset($category->vat_included) ? intval($category->vat_included) : 0,
                 'betriebsmodus' => $modus,
-                'button_text' => $category->button_text ?? ($ui['button_text'] ?? ''),
+                'button_text' => !empty($category->button_text) ? $category->button_text : ($ui['button_text'] ?? ''),
                 'blocked_days' => $blocked_days,
                 'variant_blocked_days' => [],
                 'popup_settings' => [

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -2006,7 +2006,7 @@ function pv_load_customer_logs() {
     $placeholders = implode(',', array_fill(0, count($order_ids), '%d'));
     $params = $order_ids;
     $params[] = $offset;
-    $sql = "SELECT id, order_id, event, message, created_at FROM {$wpdb->prefix}produkt_order_logs WHERE order_id IN ($placeholders) ORDER BY created_at DESC LIMIT 5 OFFSET %d";
+    $sql = "SELECT l.id, l.order_id, o.order_number, l.event, l.message, l.created_at FROM {$wpdb->prefix}produkt_order_logs l JOIN {$wpdb->prefix}produkt_orders o ON l.order_id = o.id WHERE l.order_id IN ($placeholders) ORDER BY l.created_at DESC LIMIT 5 OFFSET %d";
     $logs = $wpdb->get_results($wpdb->prepare($sql, $params));
 
     ob_start();
@@ -2033,7 +2033,8 @@ function pv_load_customer_logs() {
             default:
                 $text = $log->message ?: $log->event;
         }
-        $date_id = date_i18n('d.m.Y H:i', strtotime($log->created_at)) . ' / #' . $log->order_id;
+        $order_no = !empty($log->order_number) ? $log->order_number : $log->order_id;
+        $date_id = date_i18n('d.m.Y H:i', strtotime($log->created_at)) . ' / #' . $order_no;
         echo '<div class="order-log-entry"><div class="log-avatar">' . esc_html($avatar) . '</div><div class="log-body"><div class="log-date">' . esc_html($date_id) . '</div><div class="log-message">' . esc_html($text) . '</div></div></div>';
     }
     $html = ob_get_clean();

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -2006,7 +2006,7 @@ function pv_load_customer_logs() {
     $placeholders = implode(',', array_fill(0, count($order_ids), '%d'));
     $params = $order_ids;
     $params[] = $offset;
-    $sql = "SELECT id, event, message, created_at FROM {$wpdb->prefix}produkt_order_logs WHERE order_id IN ($placeholders) ORDER BY created_at DESC LIMIT 5 OFFSET %d";
+    $sql = "SELECT id, order_id, event, message, created_at FROM {$wpdb->prefix}produkt_order_logs WHERE order_id IN ($placeholders) ORDER BY created_at DESC LIMIT 5 OFFSET %d";
     $logs = $wpdb->get_results($wpdb->prepare($sql, $params));
 
     ob_start();
@@ -2033,7 +2033,8 @@ function pv_load_customer_logs() {
             default:
                 $text = $log->message ?: $log->event;
         }
-        echo '<div class="order-log-entry"><div class="log-avatar">' . esc_html($avatar) . '</div><div class="log-body"><div class="log-date">' . esc_html(date_i18n('d.m.Y H:i', strtotime($log->created_at))) . '</div><div class="log-message">' . esc_html($text) . '</div></div></div>';
+        $date_id = date_i18n('d.m.Y H:i', strtotime($log->created_at)) . ' / #' . $log->order_id;
+        echo '<div class="order-log-entry"><div class="log-avatar">' . esc_html($avatar) . '</div><div class="log-body"><div class="log-date">' . esc_html($date_id) . '</div><div class="log-message">' . esc_html($text) . '</div></div></div>';
     }
     $html = ob_get_clean();
 

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -6,6 +6,7 @@ class Ajax {
     public function ajax_get_product_price() {
         check_ajax_referer('produkt_nonce', 'nonce');
         
+        date_default_timezone_set('Europe/Berlin');
         $variant_id = intval($_POST['variant_id']);
         $extra_ids_raw = isset($_POST['extra_ids']) ? sanitize_text_field($_POST['extra_ids']) : '';
         $extra_ids = array_filter(array_map('intval', explode(',', $extra_ids_raw)));
@@ -15,6 +16,8 @@ class Ajax {
         $product_color_id = isset($_POST['product_color_id']) ? intval($_POST['product_color_id']) : null;
         $frame_color_id = isset($_POST['frame_color_id']) ? intval($_POST['frame_color_id']) : null;
         $days = isset($_POST['days']) ? max(1, intval($_POST['days'])) : 1;
+        $start_date = isset($_POST['start_date']) ? sanitize_text_field($_POST['start_date']) : '';
+        $end_date   = isset($_POST['end_date']) ? sanitize_text_field($_POST['end_date']) : '';
         
         global $wpdb;
         
@@ -53,10 +56,32 @@ class Ajax {
         if ($variant && ($duration || $modus === 'kauf')) {
             $variant_price = 0;
             $used_price_id  = '';
+            $weekend_applied = false;
 
             if ($modus === 'kauf') {
                 $variant_price = floatval($variant->verkaufspreis_einmalig);
                 $used_price_id = $variant->stripe_price_id;
+                $weekend_price = floatval($variant->weekend_price);
+                if ($weekend_price > 0 && $start_date && $end_date) {
+                    try {
+                        $tz = new \DateTimeZone('Europe/Berlin');
+                        $s = new \DateTime($start_date, $tz);
+                        $e = new \DateTime($end_date, $tz);
+                        $period = new \DatePeriod($s, new \DateInterval('P1D'), (clone $e)->modify('+1 day'));
+                        $weekend_only = true;
+                        foreach ($period as $dt) {
+                            $dw = (int)$dt->format('w');
+                            if (!in_array($dw, [5,6,0], true)) { $weekend_only = false; break; }
+                        }
+                        if ($weekend_only) {
+                            $variant_price = $weekend_price;
+                            $used_price_id = $variant->stripe_weekend_price_id ?: $variant->stripe_price_id;
+                            $weekend_applied = true;
+                        }
+                    } catch (\Exception $ex) {
+                        // ignore date errors
+                    }
+                }
             } else {
                 // Determine the Stripe price ID to send to checkout
                 $price_id_to_use = $wpdb->get_var($wpdb->prepare(
@@ -158,7 +183,9 @@ class Ajax {
                 'price_id'      => $used_price_id,
                 'available'     => $variant->available ? true : false,
                 'availability_note' => $variant->availability_note ?: '',
-                'delivery_time' => $variant->delivery_time ?: ''
+                'delivery_time' => $variant->delivery_time ?: '',
+                'weekend_applied' => $weekend_applied,
+                'weekend_price_set' => $variant->weekend_price > 0
             ));
         } else {
             wp_send_json_error('Invalid selection');
@@ -1135,6 +1162,7 @@ function produkt_create_subscription() {
 }
 
 function produkt_create_checkout_session() {
+    require_once PRODUKT_PLUGIN_PATH . 'includes/account-helpers.php';
     try {
         $init = StripeService::init();
         if (is_wp_error($init)) {
@@ -1169,6 +1197,7 @@ function produkt_create_checkout_session() {
         $product_color_id  = intval($body['product_color_id'] ?? 0);
         $frame_color_id    = intval($body['frame_color_id'] ?? 0);
         $final_price       = floatval($body['final_price'] ?? 0);
+        $weekend_tarif     = !empty($body['weekend_tarif']) ? 1 : 0;
         $customer_email    = sanitize_email($body['email'] ?? '');
         $current_user = wp_get_current_user();
         if ($current_user && $current_user->exists()) {
@@ -1191,6 +1220,7 @@ function produkt_create_checkout_session() {
             'start_date'    => $start_date,
             'end_date'      => $end_date,
             'days'          => $days,
+            'weekend_tarif' => $weekend_tarif,
         ];
         if ($shipping_price_id) {
             $metadata['shipping_price_id'] = $shipping_price_id;
@@ -1369,43 +1399,50 @@ function produkt_create_checkout_session() {
         // store preliminary order with status "offen"
         global $wpdb;
         $extra_id = !empty($extra_ids) ? $extra_ids[0] : 0;
+        // Assign custom order number if numbering is enabled
+        $order_number = \pv_generate_order_number();
+        $insert_data = [
+            'category_id'       => $category_id,
+            'variant_id'        => $variant_id,
+            'extra_id'          => $extra_id,
+            'extra_ids'         => $extra_ids_raw,
+            'duration_id'       => $duration_id,
+            'condition_id'      => $condition_id ?: null,
+            'product_color_id'  => $product_color_id ?: null,
+            'frame_color_id'    => $frame_color_id ?: null,
+            'final_price'       => $final_price,
+            'shipping_cost'     => $shipping_cost,
+            'shipping_price_id' => $shipping_price_id,
+            'mode'              => $modus,
+            'start_date'        => $start_date ?: null,
+            'end_date'          => $end_date ?: null,
+            'inventory_reverted'=> 0,
+            'stripe_session_id' => $session->id,
+            'amount_total'      => 0,
+            'produkt_name'      => $metadata['produkt'],
+            'zustand_text'      => $metadata['zustand'],
+            'produktfarbe_text' => $metadata['produktfarbe'],
+            'gestellfarbe_text' => $metadata['gestellfarbe'],
+            'extra_text'        => $metadata['extra'],
+            'dauer_text'        => $modus === 'kauf' && empty($metadata['dauer_name'])
+                ? ($days . ' Tag' . ($days > 1 ? 'e' : '')
+                    . ($start_date && $end_date ? ' (' . $start_date . ' - ' . $end_date . ')' : ''))
+                : $metadata['dauer_name'],
+            'customer_name'     => '',
+            'customer_email'    => $customer_email,
+            'user_ip'           => $_SERVER['REMOTE_ADDR'] ?? '',
+            'user_agent'        => substr($_SERVER['HTTP_USER_AGENT'] ?? '', 0, 255),
+            'discount_amount'   => 0,
+            'weekend_tariff'    => $weekend_tarif,
+            'status'            => 'offen',
+            'created_at'        => current_time('mysql', 1),
+        ];
+        if ($order_number !== '') {
+            $insert_data['order_number'] = $order_number;
+        }
         $wpdb->insert(
             $wpdb->prefix . 'produkt_orders',
-            [
-                'category_id'      => $category_id,
-                'variant_id'       => $variant_id,
-                'extra_id'         => $extra_id,
-                'extra_ids'        => $extra_ids_raw,
-                'duration_id'      => $duration_id,
-                'condition_id'     => $condition_id ?: null,
-                'product_color_id' => $product_color_id ?: null,
-                'frame_color_id'   => $frame_color_id ?: null,
-                'final_price'      => $final_price,
-                'shipping_cost'    => $shipping_cost,
-                'shipping_price_id'=> $shipping_price_id,
-                'mode'             => $modus,
-                'start_date'       => $start_date ?: null,
-                'end_date'         => $end_date ?: null,
-                'inventory_reverted' => 0,
-                'stripe_session_id'=> $session->id,
-                'amount_total'     => 0,
-                'produkt_name'     => $metadata['produkt'],
-                'zustand_text'     => $metadata['zustand'],
-                'produktfarbe_text'=> $metadata['produktfarbe'],
-                'gestellfarbe_text'=> $metadata['gestellfarbe'],
-                'extra_text'       => $metadata['extra'],
-                'dauer_text'       => $modus === 'kauf' && empty($metadata['dauer_name'])
-                    ? ($days . ' Tag' . ($days > 1 ? 'e' : '')
-                        . ($start_date && $end_date ? ' (' . $start_date . ' - ' . $end_date . ')' : ''))
-                    : $metadata['dauer_name'],
-                'customer_name'    => '',
-                'customer_email'   => $customer_email,
-                'user_ip'          => $_SERVER['REMOTE_ADDR'] ?? '',
-                'user_agent'       => substr($_SERVER['HTTP_USER_AGENT'] ?? '', 0, 255),
-                'discount_amount'  => 0,
-                'status'           => 'offen',
-                'created_at'       => current_time('mysql', 1)
-            ]
+            $insert_data
         );
 
         wp_send_json(['url' => $session->url]);
@@ -1509,13 +1546,15 @@ function produkt_create_embedded_checkout_session() {
                 'start_date'       => $it_start ?: null,
                 'end_date'         => $it_end ?: null,
                 'days'             => $it_days,
+                'weekend_tariff'   => !empty($it['weekend_tarif']) ? 1 : 0,
                 'metadata' => [
                     'produkt'       => sanitize_text_field($it['produkt'] ?? ''),
                     'extra'         => sanitize_text_field($it['extra'] ?? ''),
                     'dauer_name'    => sanitize_text_field($it['dauer_name'] ?? ''),
                     'zustand'       => sanitize_text_field($it['zustand'] ?? ''),
                     'produktfarbe'  => sanitize_text_field($it['produktfarbe'] ?? ''),
-                    'gestellfarbe'  => sanitize_text_field($it['gestellfarbe'] ?? '')
+                    'gestellfarbe'  => sanitize_text_field($it['gestellfarbe'] ?? ''),
+                    'weekend_tarif' => !empty($it['weekend_tarif']) ? 1 : 0
                 ]
             ];
         }
@@ -1644,6 +1683,7 @@ function produkt_create_embedded_checkout_session() {
                     'start_date'       => $o['start_date'],
                     'end_date'         => $o['end_date'],
                     'inventory_reverted' => 0,
+                    'weekend_tariff'   => $o['weekend_tariff'],
                     'stripe_session_id'=> $session->id,
                     'amount_total'     => 0,
                     'produkt_name'     => $o['metadata']['produkt'],

--- a/includes/Database.php
+++ b/includes/Database.php
@@ -588,6 +588,7 @@ class Database {
                 order_number varchar(50) DEFAULT '',
                 user_ip varchar(45) DEFAULT NULL,
                 user_agent text DEFAULT NULL,
+                client_info text DEFAULT NULL,
                 created_at timestamp DEFAULT CURRENT_TIMESTAMP,
                 PRIMARY KEY (id),
                 KEY category_id (category_id),
@@ -623,7 +624,8 @@ class Database {
                 'inventory_reverted'=> 'tinyint(1) DEFAULT 0',
                 'weekend_tariff'    => 'tinyint(1) DEFAULT 0',
                 'status'            => "varchar(20) DEFAULT 'offen'",
-                'invoice_url'       => "varchar(255) DEFAULT ''"
+                'invoice_url'       => "varchar(255) DEFAULT ''",
+                'client_info'       => 'text'
             );
 
             foreach ($new_order_columns as $column => $type) {

--- a/includes/Database.php
+++ b/includes/Database.php
@@ -37,6 +37,8 @@ class Database {
             'stripe_product_id'      => 'VARCHAR(255) DEFAULT NULL',
             'mietpreis_monatlich'    => 'DECIMAL(10,2) DEFAULT 0',
             'verkaufspreis_einmalig' => 'DECIMAL(10,2) DEFAULT 0',
+            'weekend_price'         => 'DECIMAL(10,2) DEFAULT 0',
+            'stripe_weekend_price_id'=> 'VARCHAR(255) DEFAULT NULL',
             'price_from'             => 'DECIMAL(10,2) DEFAULT 0',
             'mode'                   => "VARCHAR(10) DEFAULT 'miete'",
             'image_url_1' => 'TEXT',
@@ -69,6 +71,10 @@ class Database {
                     $after = 'stripe_product_id';
                 } elseif ($column === 'verkaufspreis_einmalig') {
                     $after = 'mietpreis_monatlich';
+                } elseif ($column === 'weekend_price') {
+                    $after = 'verkaufspreis_einmalig';
+                } elseif ($column === 'stripe_weekend_price_id') {
+                    $after = 'weekend_price';
                 } elseif ($column === 'mode') {
                     $after = 'price_from';
                 } elseif ($column === 'sku') {
@@ -566,6 +572,7 @@ class Database {
                 start_date date DEFAULT NULL,
                 end_date date DEFAULT NULL,
                 inventory_reverted tinyint(1) DEFAULT 0,
+                weekend_tariff tinyint(1) DEFAULT 0,
                 stripe_session_id varchar(255) DEFAULT '',
                 stripe_subscription_id varchar(255) DEFAULT '',
                 amount_total int DEFAULT 0,
@@ -614,6 +621,7 @@ class Database {
                 'start_date'        => 'date DEFAULT NULL',
                 'end_date'          => 'date DEFAULT NULL',
                 'inventory_reverted'=> 'tinyint(1) DEFAULT 0',
+                'weekend_tariff'    => 'tinyint(1) DEFAULT 0',
                 'status'            => "varchar(20) DEFAULT 'offen'",
                 'invoice_url'       => "varchar(255) DEFAULT ''"
             );
@@ -1036,6 +1044,8 @@ class Database {
             stripe_archived tinyint(1) DEFAULT 0,
             mietpreis_monatlich decimal(10,2) DEFAULT 0,
             verkaufspreis_einmalig decimal(10,2) DEFAULT 0,
+            weekend_price decimal(10,2) DEFAULT 0,
+            stripe_weekend_price_id varchar(255) DEFAULT NULL,
             base_price decimal(10,2) NOT NULL,
             price_from decimal(10,2) DEFAULT 0,
             mode varchar(10) DEFAULT 'miete',

--- a/includes/StripeService.php
+++ b/includes/StripeService.php
@@ -902,6 +902,7 @@ class StripeService {
             $start_date    = $start_date_raw !== '' ? $start_date_raw : null;
             $end_date      = $end_date_raw !== '' ? $end_date_raw : null;
             $days          = intval($metadata['days'] ?? 0);
+            $weekend_tarif  = intval($metadata['weekend_tarif'] ?? ($existing_orders[0]->weekend_tariff ?? 0));
             $user_ip       = sanitize_text_field($metadata['user_ip'] ?? '');
             $user_agent    = sanitize_text_field($metadata['user_agent'] ?? '');
 
@@ -1008,6 +1009,7 @@ class StripeService {
                 'mode'              => ($mode === 'payment' ? 'kauf' : 'miete'),
                 'start_date'        => $start_date,
                 'end_date'          => $end_date,
+                'weekend_tariff'    => $weekend_tarif,
                 'inventory_reverted'=> 0,
                 'user_ip'           => $user_ip,
                 'user_agent'        => $user_agent,

--- a/includes/render-order.php
+++ b/includes/render-order.php
@@ -41,6 +41,9 @@ if (!defined('ABSPATH')) { exit; }
             <p><strong>Miettage:</strong> <?php echo esc_html($order->dauer_text); ?></p>
         <?php endif; ?>
         <p><strong>Preis:</strong> <?php echo esc_html(number_format((float) $order->final_price, 2, ',', '.')); ?>€</p>
+        <?php if (!empty($order->weekend_tariff)) : ?>
+            <p><strong>Hinweis:</strong> Wochenendtarif</p>
+        <?php endif; ?>
         <?php if ($order->shipping_cost > 0 || !empty($order->shipping_name)) : ?>
             <p><strong>Versand:</strong> <?php echo esc_html($order->shipping_name ?: 'Versand'); ?> <?php if ($order->shipping_cost > 0) : ?>- <?php echo esc_html(number_format((float) $order->shipping_cost, 2, ',', '.')); ?>€<?php endif; ?></p>
         <?php endif; ?>

--- a/includes/stripe-sync.php
+++ b/includes/stripe-sync.php
@@ -128,6 +128,29 @@ function produkt_sync_sale_price($variant_id, $verkaufspreis_einmalig, $stripe_p
     }
 }
 
+function produkt_sync_weekend_price($variant_id, $weekend_price, $stripe_product_id) {
+    if ($weekend_price > 0 && $stripe_product_id) {
+        try {
+            $stripe_price = \Stripe\Price::create([
+                'unit_amount' => intval($weekend_price * 100),
+                'currency'    => 'eur',
+                'product'     => $stripe_product_id,
+                'nickname'    => 'Wochenendtarif',
+                'metadata'    => ['type' => 'weekend']
+            ]);
+
+            global $wpdb;
+            $wpdb->update(
+                $wpdb->prefix . 'produkt_variants',
+                ['stripe_weekend_price_id' => $stripe_price->id],
+                ['id' => $variant_id]
+            );
+        } catch (\Exception $e) {
+            // ignore Stripe weekend price error
+        }
+    }
+}
+
 function produkt_hard_delete($produkt_id) {
     if (!$produkt_id) {
         return;

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -131,7 +131,7 @@ $show_features = isset($category) ? ($category->show_features ?? 1) : 1;
 $default_feature_svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 81.5 81.9"><path d="M56.5,26.8l-21.7,21.7-9.7-9.7c-1.2-1.2-3.3-1.2-4.5,0s-1.2,3.3,0,4.5l12,12c.6.6,1.5.9,2.3.9s1.6-.3,2.3-.9l24-23.9c1.2-1.2,1.2-3.3,0-4.5-1.3-1.3-3.3-1.3-4.5,0Z"/><path d="M40.8,1C18.7,1,.8,18.9.8,41s17.9,40,40,40,40-17.9,40-40S62.8,1,40.8,1ZM40.8,74.6c-18.5,0-33.6-15.1-33.6-33.6S22.3,7.4,40.8,7.4s33.6,15.1,33.6,33.6-15.1,33.6-33.6,33.6Z"/></svg>';
 // Button
 $ui = get_option('produkt_ui_settings', []);
-$custom_label = $ui['button_text'] ?? '';
+$custom_label = !empty($category->button_text) ? $category->button_text : ($ui['button_text'] ?? '');
 $button_text = $custom_label; // default, final label determined later
 $button_icon = $ui['button_icon'] ?? '';
 $payment_icons = is_array($ui['payment_icons'] ?? null) ? $ui['payment_icons'] : [];
@@ -160,7 +160,7 @@ $shipping_price_id = $shipping->stripe_price_id ?? '';
 $shipping_cost = $shipping->price ?? 0;
 $shipping_provider = $shipping->service_provider ?? '';
 $modus = get_option('produkt_betriebsmodus', 'miete');
-$button_text = $button_text !== '' ? $button_text : ($modus === 'kauf' ? 'Jetzt kaufen' : 'Jetzt mieten');
+$button_text = !empty($button_text) ? $button_text : ($modus === 'kauf' ? 'Jetzt kaufen' : 'Jetzt mieten');
 $price_label = $ui['price_label'] ?? ($modus === 'kauf' ? 'Einmaliger Kaufpreis' : 'Monatlicher Mietpreis');
 $shipping_label = $ui['shipping_label'] ?? 'Einmalige Versandkosten:';
 $price_period = $ui['price_period'] ?? 'month';
@@ -268,6 +268,7 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
                             <?php endif; ?>
                         </div>
                         <p class="produkt-savings" id="produkt-savings" style="display: none;"></p>
+                        <p class="produkt-weekend-note" id="produkt-weekend-note" style="display:none;"></p>
                         <p class="produkt-vat-note"><?php echo $vat_included ? 'inkl. MwSt.' : 'Kein Ausweis der Umsatzsteuer gemäß § 19 UStG.'; ?></p>
                     </div>
                 </div>
@@ -343,6 +344,7 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
                              data-delivery="<?php echo esc_attr($variant->delivery_time ?? ''); ?>"
                              data-weekend="<?php echo intval($variant->weekend_only ?? 0); ?>"
                              data-min-days="<?php echo intval($variant->min_rental_days ?? 0); ?>"
+                             data-weekend-price="<?php echo esc_attr($variant->weekend_price ?? 0); ?>"
                              data-images="<?php echo esc_attr(json_encode(array(
                                  $variant->image_url_1 ?? '',
                                  $variant->image_url_2 ?? '',
@@ -367,6 +369,9 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
                                     }
                                 ?>
                                 <p class="produkt-option-price"><?php echo number_format($display_price, 2, ',', '.'); ?>€<?php echo $modus === 'kauf' ? '' : ($price_period === 'month' ? '/Monat' : ''); ?></p>
+                                <?php if ($modus === 'kauf' && floatval($variant->weekend_price) > 0): ?>
+                                    <div class="produkt-weekend-info">Wochenendpreis: <?php echo number_format((float)$variant->weekend_price, 2, ',', '.'); ?>€</div>
+                                <?php endif; ?>
                                 <?php if (!($variant->available ?? 1)): ?>
                                     <div class="produkt-availability-notice">
                                         <span class="produkt-unavailable-badge"><span class="produkt-emoji">❌</span> Nicht verfügbar</span>


### PR DESCRIPTION
## Summary
- allow variants to define a weekend-specific daily rate and sync a dedicated Stripe price
- apply weekend tariff automatically for Friday–Sunday bookings and surface the note in cart and orders
- persist weekend tariff flag in orders and enforce Europe/Berlin timezone for price checks
- fix button settings so custom labels stay visible when booking is available and style weekend price note
- ensure provisional orders receive custom numbering by loading order helpers
- redesign variant price inputs with interactive cards for standard and weekend rates
- remove default borders from price inputs and make the price cards responsive
- modernize admin dashboard forms with underlined input styling

## Testing
- `php -l admin/tabs/variants-add-tab.php`
- `php -l admin/tabs/variants-edit-tab.php`
- `php -l admin/variants-page.php`
- `php -l includes/Ajax.php`
- `php -l includes/Database.php`
- `php -l includes/stripe-sync.php`
- `php -l includes/StripeService.php`
- `php -l templates/product-page.php`
- `php -l includes/render-order.php`
- `php -l admin/dashboard/sidebar-order-details.php`
- `php -l admin/tabs/buttons-tab.php`


------
https://chatgpt.com/codex/tasks/task_b_689a501dfcec83309df2a0bee6a91108