### PR TITLE
Improve order handling and date formatting

### DIFF
--- a/admin/calendar-page.php
+++ b/admin/calendar-page.php
@@ -31,7 +31,7 @@ $start_index   = (int)date('N', $first_day_ts) - 1;
 $open_by_day = [];
 $return_by_day = [];
 $orders_detail = [];
-$where = ["o.mode = 'kauf'"];
+$where = ["o.mode = 'kauf'", "o.status = 'abgeschlossen'"];
 
 $sql = "SELECT o.*, c.name as category_name,
                COALESCE(v.name, o.produkt_name) as variant_name,

--- a/admin/customers-page.php
+++ b/admin/customers-page.php
@@ -517,12 +517,35 @@ if (!$customer_id) {
                         </tr>
                     </thead>
                     <tbody>
-                        <?php foreach ($orders as $o) : ?>
+                        <?php foreach ($orders as $o) :
+                            $product_display = $o->category_name;
+                            $variant_display = $o->variant_name ?: '–';
+                            $extras_display  = $o->extra_names ?: '–';
+                            $more = 0;
+                            if (!empty($o->client_info)) {
+                                $ci = json_decode($o->client_info, true);
+                                if (!empty($ci['cart_items']) && is_array($ci['cart_items'])) {
+                                    $more = count($ci['cart_items']) - 1;
+                                    $first = $ci['cart_items'][0]['metadata'] ?? [];
+                                    if (!empty($first['produkt'])) {
+                                        $product_display = $first['produkt'];
+                                    }
+                                    if (!empty($first['extra'])) {
+                                        $extras_display = $first['extra'];
+                                    }
+                                }
+                            }
+                            if ($more > 0) {
+                                $product_display .= ' (' . $more . ' weitere)';
+                                $variant_display .= ' (' . $more . ' weitere)';
+                                $extras_display  .= ' (' . $more . ' weitere)';
+                            }
+                        ?>
                             <tr>
                                 <td>#<?php echo esc_html($o->order_number ?: $o->id); ?></td>
-                                <td><?php echo esc_html($o->category_name); ?></td>
-                                <td><?php echo esc_html($o->variant_name ?: '–'); ?></td>
-                                <td><?php echo esc_html($o->extra_names ?: '–'); ?></td>
+                                <td><?php echo esc_html($product_display); ?></td>
+                                <td><?php echo esc_html($variant_display); ?></td>
+                                <td><?php echo esc_html($extras_display); ?></td>
                                 <?php
                                 $start = $o->start_date ? date_i18n('d.m.Y', strtotime($o->start_date)) : '–';
                                 $end   = $o->end_date ? date_i18n('d.m.Y', strtotime($o->end_date)) : '–';

--- a/admin/customers-page.php
+++ b/admin/customers-page.php
@@ -520,25 +520,44 @@ if (!$customer_id) {
                         <?php foreach ($orders as $o) :
                             $product_display = $o->category_name;
                             $variant_display = $o->variant_name ?: '–';
-                            $extras_display  = $o->extra_names ?: '–';
-                            $more = 0;
+                            $extras_display  = '–';
+                            $product_count   = 0;
+                            $extra_count     = 0;
+
                             if (!empty($o->client_info)) {
                                 $ci = json_decode($o->client_info, true);
                                 if (!empty($ci['cart_items']) && is_array($ci['cart_items'])) {
-                                    $more = count($ci['cart_items']) - 1;
-                                    $first = $ci['cart_items'][0]['metadata'] ?? [];
-                                    if (!empty($first['produkt'])) {
-                                        $product_display = $first['produkt'];
-                                    }
-                                    if (!empty($first['extra'])) {
-                                        $extras_display = $first['extra'];
+                                    foreach ($ci['cart_items'] as $ci_item) {
+                                        $meta = $ci_item['metadata'] ?? [];
+                                        if (!empty($meta['produkt'])) {
+                                            $product_count++;
+                                            if ($product_count === 1) {
+                                                $product_display = $meta['produkt'];
+                                            }
+                                            if (!empty($meta['extra'])) {
+                                                $extra_count++;
+                                                if ($extra_count === 1) {
+                                                    $extras_display = $meta['extra'];
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             }
-                            if ($more > 0) {
-                                $product_display .= ' (' . $more . ' weitere)';
-                                $variant_display .= ' (' . $more . ' weitere)';
-                                $extras_display  .= ' (' . $more . ' weitere)';
+
+                            if ($extra_count === 0 && !empty($o->extra_names)) {
+                                $extras_display = $o->extra_names;
+                            }
+
+                            if ($product_count > 1) {
+                                $product_display .= ' (' . ($product_count - 1) . ' weitere)';
+                                if ($variant_display !== '–') {
+                                    $variant_display .= ' (' . ($product_count - 1) . ' weitere)';
+                                }
+                            }
+
+                            if ($extra_count > 1) {
+                                $extras_display .= ' (' . ($extra_count - 1) . ' weitere)';
                             }
                         ?>
                             <tr>

--- a/admin/dashboard/sidebar-order-details.php
+++ b/admin/dashboard/sidebar-order-details.php
@@ -71,6 +71,11 @@ $produkte = $order->produkte ?? [$order]; // fallback
             <button type="button" class="icon-btn icon-btn-no-stroke note-icon" title="Notiz hinzufügen">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 81.2 80.7"><path d="M80.5,19.1c0-2.2-.9-4.2-2.4-5.8l-10.3-10.3c-1.5-1.5-3.6-2.4-5.8-2.4s-4.2.8-5.8,2.4l-3.9,3.9c-1.2-.6-2.6-.9-4-.9-2.5,0-4.9,1-6.7,2.8-2.9,2.9-3.5,7.1-1.9,10.6L7.4,51.9s0,0-.1.1c0,0-.1.1-.1.2,0,0,0,.1-.1.2,0,0,0,.1-.1.2,0,0,0,.2,0,.2,0,0,0,.1,0,.2L1,77.4c-.2.8,0,1.6.6,2.2.4.4,1,.7,1.7.7s.4,0,.5,0l24.3-5.8c0,0,.1,0,.2,0,0,0,.2,0,.2,0,0,0,.1,0,.2-.1,0,0,.1,0,.2-.1,0,0,.1-.1.2-.2,0,0,0,0,.1-.1l32.5-32.5c1.2.6,2.6.9,4,.9,2.5,0,4.9-1,6.7-2.8,2.9-2.9,3.5-7.1,1.9-10.6l3.9-3.9c1.5-1.5,2.4-3.6,2.4-5.8h0ZM25.5,66.7l-11.2-11.2c.1,0,.2,0,.4-.1l17.4-6.4-6.7,17.7ZM34.8,43l-18.8,6.9,26.8-26.8,5.9,5.9-13.9,13.9ZM10.4,58.2l12.6,12.6-16.6,4,4-16.6ZM31,65.4l7.2-19.1,13.9-13.9,5.9,5.9-27.1,27.1ZM69.1,36.1s0,0,0,0c-.9.9-2.1,1.4-3.3,1.4s-2.5-.5-3.3-1.4l-17.3-17.3c-1.8-1.8-1.8-4.8,0-6.7.9-.9,2.1-1.4,3.3-1.4s2.5.5,3.3,1.4l17.3,17.3c1.9,1.8,1.9,4.8,0,6.7h0ZM74.9,21.5l-3.5,3.5-15.2-15.2,3.5-3.5c.7-.7,1.5-1,2.5-1s1.8.4,2.5,1l10.3,10.3c.6.6,1,1.5,1,2.5s-.4,1.8-1,2.5h0Z"/></svg>
             </button>
+            <?php if ($order->status === 'offen') : ?>
+            <button type="button" class="icon-btn icon-btn-no-stroke delete-order-btn" title="Auftrag löschen">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M18 6.4 17.6 5 12 10.6 6.4 5 5 6.4 10.6 12 5 17.6 6.4 19 12 13.4 17.6 19 19 17.6 13.4 12z"/></svg>
+            </button>
+            <?php endif; ?>
         </div>
     </div>
 
@@ -178,12 +183,6 @@ $produkte = $order->produkte ?? [$order]; // fallback
             </p>
         <?php endif; ?>
     </div>
-
-    <?php if ($order->status === 'offen') : ?>
-        <div class="delete-order-section">
-            <button type="button" class="button delete-order-btn">Auftrag löschen</button>
-        </div>
-    <?php endif; ?>
 
     <div class="orders-accordion">
         <div class="produkt-accordion-item">

--- a/admin/dashboard/sidebar-order-details.php
+++ b/admin/dashboard/sidebar-order-details.php
@@ -15,9 +15,9 @@ if (!empty($order->customer_name)) {
     $initials = strtoupper(substr($names[0], 0, 1) . (isset($names[1]) ? substr($names[1], 0, 1) : ''));
 }
 
-// Prozent Mietdauer berechnen
+// Prozent Mietdauer nur berechnen, wenn Auftrag nicht offen ist
 $percent = 0;
-if (!empty($sd) && !empty($ed)) {
+if ($order->status !== 'offen' && !empty($sd) && !empty($ed)) {
     $start = strtotime($sd);
     $end = strtotime($ed);
     $today = time();
@@ -28,10 +28,17 @@ if (!empty($sd) && !empty($ed)) {
 
 // Status-Text für den Badge ermitteln
 $badge_status = 'In Vermietung';
-if ($percent >= 100) {
+if ($order->status === 'offen') {
+    $badge_status = 'Offen';
+} elseif ($percent >= 100) {
     $badge_status = 'Abgeschlossen';
 } elseif ($percent <= 0) {
     $badge_status = 'Ausstehend';
+}
+
+// Miettage nicht anzeigen, wenn Auftrag offen ist
+if ($order->status === 'offen') {
+    $days = null;
 }
 
 // Produkte ermitteln
@@ -97,12 +104,14 @@ $produkte = $order->produkte ?? [$order]; // fallback
     <div class="rental-period-box">
         <div class="badge-status"><?php echo esc_html($badge_status); ?></div>
         <h3>Mietzeitraum</h3>
-        <div class="rental-progress-number"><?php echo $percent; ?>%</div>
-        <div class="rental-progress">
-            <div class="bar">
-                <div class="fill" style="width: <?php echo $percent; ?>%;"></div>
+        <?php if ($order->status !== 'offen') : ?>
+            <div class="rental-progress-number"><?php echo $percent; ?>%</div>
+            <div class="rental-progress">
+                <div class="bar">
+                    <div class="fill" style="width: <?php echo $percent; ?>%;"></div>
+                </div>
             </div>
-        </div>
+        <?php endif; ?>
         <div class="rental-dates">
             <span>Abgeholt: <?php echo date_i18n('d. M', strtotime($sd)); ?></span>
             <span>Rückgabe: <?php echo date_i18n('d. M', strtotime($ed)); ?></span>
@@ -169,6 +178,12 @@ $produkte = $order->produkte ?? [$order]; // fallback
             </p>
         <?php endif; ?>
     </div>
+
+    <?php if ($order->status === 'offen') : ?>
+        <div class="delete-order-section">
+            <button type="button" class="button delete-order-btn">Auftrag löschen</button>
+        </div>
+    <?php endif; ?>
 
     <div class="orders-accordion">
         <div class="produkt-accordion-item">

--- a/admin/main-page.php
+++ b/admin/main-page.php
@@ -250,11 +250,17 @@ $plugin_name = $branding_result ? esc_html($branding_result->setting_value) : 'H
                 if (!empty($order->client_info)) {
                     $ci = json_decode($order->client_info, true);
                     if (!empty($ci['cart_items']) && is_array($ci['cart_items'])) {
-                        $more = count($ci['cart_items']) - 1;
-                        $first = $ci['cart_items'][0]['metadata']['produkt'] ?? '';
-                        if ($first) {
-                            $product_display = $first;
+                        $product_items = [];
+                        foreach ($ci['cart_items'] as $ci_item) {
+                            $meta = $ci_item['metadata'] ?? [];
+                            if (!empty($meta['produkt'])) {
+                                $product_items[] = $meta['produkt'];
+                            }
                         }
+                        if (!empty($product_items)) {
+                            $product_display = $product_items[0];
+                        }
+                        $more = count($product_items) - 1;
                     }
                 }
                 if ($more > 0) {

--- a/admin/main-page.php
+++ b/admin/main-page.php
@@ -244,11 +244,27 @@ $plugin_name = $branding_result ? esc_html($branding_result->setting_value) : 'H
             </tr>
         </thead>
         <tbody>
-            <?php foreach ($orders as $order): ?>
+            <?php foreach ($orders as $order):
+                $product_display = $order->produkt_name;
+                $more = 0;
+                if (!empty($order->client_info)) {
+                    $ci = json_decode($order->client_info, true);
+                    if (!empty($ci['cart_items']) && is_array($ci['cart_items'])) {
+                        $more = count($ci['cart_items']) - 1;
+                        $first = $ci['cart_items'][0]['metadata']['produkt'] ?? '';
+                        if ($first) {
+                            $product_display = $first;
+                        }
+                    }
+                }
+                if ($more > 0) {
+                    $product_display .= ' (' . $more . ' weitere)';
+                }
+            ?>
                 <tr>
                     <td><?php echo esc_html($order->order_number ?: $order->id); ?></td>
                     <td><?php echo esc_html($order->customer_name); ?></td>
-                    <td><?php echo esc_html($order->produkt_name); ?></td>
+                    <td><?php echo esc_html($product_display); ?></td>
                     <td><?php echo date_i18n('d.m.Y', strtotime($order->created_at)); ?></td>
                     <td><span class="badge status-<?php echo esc_attr($order->status); ?>"><?php echo ucfirst($order->status); ?></span></td>
                     <td><a href="#" class="view-details-link" data-order-id="<?php echo esc_attr($order->id); ?>">Details ansehen</a></td>

--- a/assets/admin-script.js
+++ b/assets/admin-script.js
@@ -38,6 +38,27 @@ jQuery(document).ready(function($) {
         $('#order-details-overlay').removeClass('visible');
     });
 
+    // Auftrag löschen
+    $(document).on('click', '.delete-order-btn', function(e) {
+        e.preventDefault();
+        if (!confirm('Auftrag wirklich löschen?')) {
+            return;
+        }
+        var wrapper = $(this).closest('.sidebar-wrapper');
+        var orderId = wrapper.data('order-id');
+        $.post(ajaxurl, {
+            action: 'pv_delete_order',
+            nonce: produkt_admin.nonce,
+            order_id: orderId
+        }, function(res) {
+            if (res.success) {
+                location.reload();
+            } else {
+                alert('Fehler beim Löschen');
+            }
+        });
+    });
+
     // Confirm delete actions
     $('.wp-list-table a[href*="delete"]').on('click', function(e) {
         if (!confirm('Sind Sie sicher, dass Sie diesen Eintrag löschen möchten?')) {

--- a/assets/admin-style.css
+++ b/assets/admin-style.css
@@ -3098,7 +3098,7 @@ body.color-modal-open {
 .col-type{width:80px;}
 .col-price{width:100px;}
 .col-discount{width:80px;}
-.col-status{width:100px;}
+.col-status{width:200px;}
 .col-actions{width:120px;}
 
 

--- a/assets/script.js
+++ b/assets/script.js
@@ -106,7 +106,9 @@ jQuery(document).ready(function($) {
             }
             let period = '';
             if (item.start_date && item.end_date) {
-                period = item.start_date + ' - ' + item.end_date + ' (' + item.days + ' Tage)';
+                const startFmt = formatDate(item.start_date);
+                const endFmt = formatDate(item.end_date);
+                period = startFmt + ' - ' + endFmt + ' (' + item.days + ' Tage)';
             } else if (item.dauer_name) {
                 period = item.dauer_name;
             }
@@ -1417,6 +1419,11 @@ function updateSelectedDays() {
 
     function formatPrice(price) {
         return parseFloat(price).toFixed(2).replace('.', ',');
+    }
+
+    function formatDate(dateStr) {
+        const parts = dateStr.split('-');
+        return parts[2] + '.' + parts[1] + '.' + parts[0];
     }
 
     function scrollToNotify() {

--- a/assets/script.js
+++ b/assets/script.js
@@ -287,16 +287,19 @@ jQuery(document).ready(function($) {
             produkt_ajax.variant_weekend_only = variantWeekendOnly;
             produkt_ajax.variant_min_days = variantMinDays;
 
-            // Reset selections when switching variants so the rent button
-            // becomes inactive immediately
+            // Reset other selections when switching variants so the rent button
+            // becomes inactive immediately. Preserve rental dates if a period
+            // is already locked by existing cart items.
             selectedCondition = null;
             selectedProductColor = null;
             selectedFrameColor = null;
             selectedExtras = [];
             selectedDuration = null;
-            startDate = null;
-            endDate = null;
-            selectedDays = 0;
+            if (cart.length === 0) {
+                startDate = null;
+                endDate = null;
+                selectedDays = 0;
+            }
             renderCalendar(calendarMonth);
             updateSelectedDays();
 

--- a/assets/script.js
+++ b/assets/script.js
@@ -36,6 +36,8 @@ jQuery(document).ready(function($) {
         $('.h2-cart-badge').text(cart.length); // alle Instanzen (Desktop/Mobil/Sticky)
     }
     updateCartBadge();
+    updateSelectedDays();
+    updatePriceAndButton();
 
     window.addEventListener('storage', function(e){
         if (e.key === 'produkt_cart') {
@@ -179,9 +181,7 @@ jQuery(document).ready(function($) {
         $('#produkt-field-shipping').val(shippingPriceId);
     }
 
-    if (produkt_ajax.betriebsmodus === 'kauf') {
-        renderCalendar(calendarMonth);
-    }
+    renderCalendar(calendarMonth);
     if (!Array.isArray(produkt_ajax.variant_blocked_days)) {
         produkt_ajax.variant_blocked_days = [];
     }

--- a/assets/script.js
+++ b/assets/script.js
@@ -768,6 +768,7 @@ jQuery(document).ready(function($) {
                 if (response.success) {
                     produkt_ajax.variant_blocked_days = response.data.days || [];
                     renderCalendar(calendarMonth);
+                    updatePriceAndButton();
                 }
             }
         });
@@ -969,8 +970,9 @@ jQuery(document).ready(function($) {
         
         const allSelected = requiredSelections.every(selection => selection !== null && selection !== false);
         const minOk = !(variantMinDays > 0 && selectedDays > 0 && selectedDays < variantMinDays);
+        const rangeOk = isSelectedRangeAvailable();
 
-        if (allSelected && minOk) {
+        if (allSelected && minOk && rangeOk) {
             // Show loading state
             $('#produkt-price-display').show();
             $('#produkt-final-price').text('Lädt...');
@@ -1076,15 +1078,8 @@ jQuery(document).ready(function($) {
             $('#produkt-price-display').hide();
             $('#produkt-rent-button').prop('disabled', true);
             $('.produkt-mobile-button').prop('disabled', true);
-            $('#produkt-button-help').show();
-            $('#produkt-unavailable-help').hide();
-            $('#produkt-notify').hide();
-            $('#produkt-notify-success').hide();
-            $('.produkt-notify-form').show();
             currentPrice = 0;
 
-            $('#produkt-availability-wrapper').hide();
-            
             // Hide mobile sticky price
             hideMobileStickyPrice();
 
@@ -1098,6 +1093,25 @@ jQuery(document).ready(function($) {
             }
             $('#produkt-rent-button span').text(label);
             $('.produkt-mobile-button span').text(label);
+
+            if (allSelected && minOk && !rangeOk) {
+                $('#produkt-button-help').hide();
+                $('#produkt-unavailable-help').text('Produkt im Mietzeitraum nicht verfügbar').show();
+                $('#produkt-notify').show();
+                $('.produkt-notify-form').show();
+                $('#produkt-notify-success').hide();
+                $('#produkt-availability-wrapper').show();
+                $('#produkt-availability-status').addClass('unavailable').removeClass('available');
+                $('#produkt-availability-status .status-text').text('Nicht auf Lager');
+                $('#produkt-delivery-box').hide();
+            } else {
+                $('#produkt-button-help').show();
+                $('#produkt-unavailable-help').hide();
+                $('#produkt-notify').hide();
+                $('#produkt-notify-success').hide();
+                $('.produkt-notify-form').show();
+                $('#produkt-availability-wrapper').hide();
+            }
         }
     }
 
@@ -1331,6 +1345,21 @@ function updateSelectedDays() {
             }
         });
         return ids;
+    }
+
+    function isSelectedRangeAvailable() {
+        if (!startDate || !endDate) return true;
+        let blocked = [];
+        if (Array.isArray(produkt_ajax.blocked_days)) blocked = blocked.concat(produkt_ajax.blocked_days);
+        if (Array.isArray(produkt_ajax.variant_blocked_days)) blocked = blocked.concat(produkt_ajax.variant_blocked_days);
+        if (Array.isArray(produkt_ajax.extra_blocked_days)) blocked = blocked.concat(produkt_ajax.extra_blocked_days);
+        const s = new Date(startDate);
+        const e = new Date(endDate);
+        for (let d = new Date(s.getTime()); d <= e; d.setDate(d.getDate() + 1)) {
+            const ds = d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0');
+            if (blocked.includes(ds)) return false;
+        }
+        return true;
     }
 
     function checkExtraAvailability() {

--- a/assets/script.js
+++ b/assets/script.js
@@ -27,6 +27,10 @@ jQuery(document).ready(function($) {
     let calendarMonth = new Date();
     let colorNotificationTimeout = null;
     let cart = JSON.parse(localStorage.getItem('produkt_cart') || '[]');
+    if (cart.length > 0) {
+        startDate = cart[0].start_date || null;
+        endDate = cart[0].end_date || null;
+    }
 
     function updateCartBadge() {
         $('.h2-cart-badge').text(cart.length); // alle Instanzen (Desktop/Mobil/Sticky)
@@ -245,7 +249,7 @@ jQuery(document).ready(function($) {
             $('#produkt-rent-button').prop('disabled', true);
             $('.produkt-mobile-button').prop('disabled', true);
             $('#produkt-button-help').hide();
-            $('#produkt-unavailable-help').show();
+            $('#produkt-unavailable-help').text('Produkt im Mietzeitraum nicht verfügbar').show();
             $('#produkt-notify').show();
             $('.produkt-notify-form').show();
             $('#produkt-notify-success').hide();
@@ -886,7 +890,7 @@ jQuery(document).ready(function($) {
                 $('#produkt-rent-button').prop('disabled', true);
                 $('.produkt-mobile-button').prop('disabled', true);
                 $('#produkt-button-help').hide();
-                $('#produkt-unavailable-help').show();
+                $('#produkt-unavailable-help').text('Produkt im Mietzeitraum nicht verfügbar').show();
                 $('#produkt-notify').show();
                 $('.produkt-notify-form').show();
                 $('#produkt-notify-success').hide();
@@ -1038,13 +1042,10 @@ jQuery(document).ready(function($) {
                             $('#produkt-notify-success').hide();
                         } else {
                             $('#produkt-button-help').hide();
-                            $('#produkt-unavailable-help').show();
+                            $('#produkt-unavailable-help').text(data.availability_note || 'Produkt im Mietzeitraum nicht verfügbar').show();
                             $('#produkt-notify').show();
                             $('.produkt-notify-form').show();
                             $('#produkt-notify-success').hide();
-                            if (data.availability_note) {
-                                $('#produkt-unavailable-help').text(data.availability_note);
-                            }
                             scrollToNotify();
                         }
                         
@@ -1243,6 +1244,9 @@ jQuery(document).ready(function($) {
     });
     $(document).on('click', '#booking-calendar .calendar-day:not(.disabled)', function(){
         const dateStr = $(this).data('date');
+        if (cart.length > 0 && cart[0].start_date && cart[0].end_date) {
+            return;
+        }
 
         if (!startDate || (startDate && endDate)) {
             startDate = dateStr;
@@ -1371,6 +1375,14 @@ function updateSelectedDays() {
                 updatePriceAndButton();
             }
         });
+    }
+
+    if (startDate && endDate) {
+        updateSelectedDays();
+        updateExtraBookings(getZeroStockExtraIds());
+        checkExtraAvailability();
+        renderCalendar(calendarMonth);
+        updatePriceAndButton();
     }
 
     function showGalleryNotification() {

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -1554,6 +1554,7 @@ function produkt_create_embedded_checkout_session() {
                 'frame_color_id'   => intval($it['frame_color_id'] ?? 0) ?: null,
                 'price_id'         => $pid,
                 'final_price'      => floatval($it['final_price'] ?? 0),
+                'image_url'        => esc_url_raw($it['image'] ?? ''),
                 'start_date'       => $it_start ?: null,
                 'end_date'         => $it_end ?: null,
                 'days'             => $it_days,

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -1423,8 +1423,6 @@ function produkt_create_checkout_session() {
         // store preliminary order with status "offen"
         global $wpdb;
         $extra_id = !empty($extra_ids) ? $extra_ids[0] : 0;
-        // Assign custom order number if numbering is enabled
-        $order_number = \pv_generate_order_number();
         $insert_data = [
             'category_id'       => $category_id,
             'variant_id'        => $variant_id,
@@ -1462,9 +1460,6 @@ function produkt_create_checkout_session() {
             'status'            => 'offen',
             'created_at'        => current_time('mysql', 1),
         ];
-        if ($order_number !== '') {
-            $insert_data['order_number'] = $order_number;
-        }
         $wpdb->insert(
             $wpdb->prefix . 'produkt_orders',
             $insert_data
@@ -1713,7 +1708,6 @@ function produkt_create_embedded_checkout_session() {
         $first = $orders[0] ?? [];
 
         global $wpdb;
-        $order_number = pv_generate_order_number();
         $wpdb->insert(
             $wpdb->prefix . 'produkt_orders',
             [
@@ -1748,7 +1742,6 @@ function produkt_create_embedded_checkout_session() {
                 'client_info'      => $client_info_json,
                 'discount_amount'  => 0,
                 'status'           => 'offen',
-                'order_number'     => $order_number,
                 'created_at'       => current_time('mysql', 1)
             ]
         );

--- a/includes/Webhook.php
+++ b/includes/Webhook.php
@@ -166,7 +166,7 @@ function send_produkt_welcome_email(array $order, int $order_id) {
                 $unit = round(floatval($ci_item['final_price']) / $tage, 2);
             }
             $unit_fmt = number_format($unit, 2, ',', '.') . '€';
-            $message .= '<tr><td>' . $name . '</td><td style="text-align:right;">' . esc_html($unit_fmt) . '</td></tr>';
+            $message .= '<tr><td>' . $name . '</td><td style="text-align:right;">Preis/Tag ' . esc_html($unit_fmt) . '</td></tr>';
         }
         if ($order['shipping_cost'] > 0) {
             $message .= '<tr><td><strong>Versand</strong></td><td style="text-align:right;">' . esc_html($shipping) . '</td></tr>';
@@ -355,7 +355,7 @@ function send_admin_order_email(array $order, int $order_id, string $session_id)
                 $unit = round(floatval($ci_item['final_price']) / $tage, 2);
             }
             $unit_fmt = number_format($unit, 2, ',', '.') . '€';
-            $message .= '<tr><td>' . $name . '</td><td style="text-align:right;">' . esc_html($unit_fmt) . '</td></tr>';
+            $message .= '<tr><td>' . $name . '</td><td style="text-align:right;">Preis/Tag ' . esc_html($unit_fmt) . '</td></tr>';
         }
         if ($order['shipping_cost'] > 0) {
             $message .= '<tr><td><strong>Versand</strong></td><td style="text-align:right;">' . esc_html($shipping) . '</td></tr>';

--- a/includes/account-helpers.php
+++ b/includes/account-helpers.php
@@ -253,7 +253,11 @@ function pv_get_order_by_id($order_id) {
         if (!empty($ci['cart_items']) && is_array($ci['cart_items'])) {
             $row['produkte'] = [];
             foreach ($ci['cart_items'] as $item) {
-                $meta = $item['metadata'] ?? [];
+                $meta        = $item['metadata'] ?? [];
+                $variant_id  = intval($item['variant_id'] ?? 0);
+                $category_id = intval($item['category_id'] ?? 0);
+                $img         = $item['image_url'] ?? pv_get_image_url_by_variant_or_category($variant_id, $category_id);
+
                 $row['produkte'][] = (object) [
                     'produkt_name'      => $meta['produkt'] ?? '',
                     'extra_names'       => $meta['extra'] ?? '',
@@ -267,6 +271,9 @@ function pv_get_order_by_id($order_id) {
                     'end_date'          => $item['end_date'] ?? null,
                     'days'              => $item['days'] ?? 0,
                     'price_id'          => $item['price_id'] ?? '',
+                    'variant_id'        => $variant_id,
+                    'category_id'       => $category_id,
+                    'image_url'         => $img,
                 ];
             }
             if (empty($row['produkt_name']) && !empty($row['produkte'][0]->produkt_name)) {

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -579,7 +579,7 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
                         Bitte treffen Sie alle Auswahlen um fortzufahren
                     </p>
                     <p class="produkt-unavailable-help" id="produkt-unavailable-help" style="display: none;">
-                        Das gewählte Produkt ist aktuell nicht verfügbar
+                        Produkt im Mietzeitraum nicht verfügbar
                     </p>
                     <div class="produkt-notify" id="produkt-notify" style="display: none;">
                         <p>Benachrichtigen Sie mich sobald das Produkt wieder erhältlich ist.</p>


### PR DESCRIPTION
## Summary
- label unit prices in emails as "Preis/Tag"
- hide rental progress for open orders and allow deleting them
- show only completed orders in calendar and fix cart date format

## Testing
- `php -l includes/Webhook.php`
- `php -l admin/dashboard/sidebar-order-details.php`
- `php -l admin/calendar-page.php`
- `php -l includes/Ajax.php`
- `node --check assets/script.js`
- `node --check assets/admin-script.js`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a25a08d14c83309501fc5845d53f0f