### PR TITLE
Handle variant availability in multi-item orders

### DIFF
--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -66,6 +66,8 @@ class Plugin {
         add_action('wp_ajax_nopriv_get_variant_options', [$this->ajax, 'ajax_get_variant_options']);
         add_action('wp_ajax_get_variant_booked_days', [$this->ajax, 'ajax_get_variant_booked_days']);
         add_action('wp_ajax_nopriv_get_variant_booked_days', [$this->ajax, 'ajax_get_variant_booked_days']);
+        add_action('wp_ajax_check_variant_availability', [$this->ajax, 'ajax_check_variant_availability']);
+        add_action('wp_ajax_nopriv_check_variant_availability', [$this->ajax, 'ajax_check_variant_availability']);
         add_action('wp_ajax_get_extra_booked_days', [$this->ajax, 'ajax_get_extra_booked_days']);
         add_action('wp_ajax_nopriv_get_extra_booked_days', [$this->ajax, 'ajax_get_extra_booked_days']);
         add_action('wp_ajax_check_extra_availability', [$this->ajax, 'ajax_check_extra_availability']);


### PR DESCRIPTION
## Summary
- include cart_items from client_info when determining variant booked days
- add server-side variant availability check that inspects client_info cart_items
- register AJAX endpoint for variant availability checks

## Testing
- `php -l includes/Ajax.php`
- `php -l includes/Plugin.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a2ef97ab0883308866561bd9677ad3